### PR TITLE
reduce injectMetadata call

### DIFF
--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -79,7 +79,7 @@ describe('ApiService', () => {
     } else {
       blockhash = await api.rpc.chain.getBlockHash(4401242);
     }
-    await apiService.setBlockhash(blockhash);
+    await apiService.setBlockhash(blockhash, true);
 
     expect(
       patchedApi.consts.staking.maxNominatorRewardedPerValidator.toNumber(),

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -123,8 +123,8 @@ export class ApiService implements OnApplicationShutdown {
     if (inject) {
       const { metadata, registry } = await this.api.getBlockRegistry(blockHash);
       this.patchedApi.injectMetadata(metadata, true, registry);
+      this.patchApi();
     }
-    this.patchApi();
   }
 
   private replaceToAtVersion(

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -115,13 +115,15 @@ export class ApiService implements OnApplicationShutdown {
     (this.patchedApi as any).isPatched = true;
   }
 
-  async setBlockhash(blockHash: BlockHash): Promise<void> {
+  async setBlockhash(blockHash: BlockHash, inject = false): Promise<void> {
     if (!this.patchedApi) {
       await this.getPatchedApi();
     }
     this.currentBlockHash = blockHash;
-    const { metadata, registry } = await this.api.getBlockRegistry(blockHash);
-    this.patchedApi.injectMetadata(metadata, true, registry);
+    if (inject) {
+      const { metadata, registry } = await this.api.getBlockRegistry(blockHash);
+      this.patchedApi.injectMetadata(metadata, true, registry);
+    }
     this.patchApi();
   }
 

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -88,7 +88,6 @@ export class FetchService implements OnApplicationShutdown {
   }
 
   async startLoop(initBlockHeight: number): Promise<void> {
-    const preloadBlocks = this.nodeConfig.batchSize * 2;
     if (isUndefined(this.latestProcessedHeight)) {
       this.latestProcessedHeight = initBlockHeight - 1;
     }

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -30,6 +30,7 @@ export class IndexerManager {
   private vm: IndexerSandbox;
   private api: ApiPromise;
   private subqueryState: SubqueryModel;
+  private prevSpecVersion?: number;
 
   constructor(
     protected apiService: ApiService,
@@ -49,8 +50,13 @@ export class IndexerManager {
     });
     const tx = await this.sequelize.transaction();
     this.storeService.setTransaction(tx);
+
+    const inject = block.specVersion !== this.prevSpecVersion;
+    this.prevSpecVersion = block.specVersion;
+
     try {
-      await timeout(this.apiService.setBlockhash(block.block.hash), 10); //TODO remove this when polkadot/api issue #3197 solved
+      const hash = block.block.hash;
+      await timeout(this.apiService.setBlockhash(hash, inject), 10); //TODO remove this when polkadot/api issue #3197 solved
       for (const ds of this.project.dataSources) {
         if (ds.startBlock > block.block.header.number.toNumber()) {
           continue;


### PR DESCRIPTION
`injectMetadata` method is heavy, this PR try to improve the performance, we only call this method when the spec version is changed.
this could improve the BPS from 3 to 20.


before the PR is merged, we need to solve the memory leak issue， this is enlarged by the BPS increases