### PR TITLE
[release] node 0.16.1

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.16.1] - 2021-06-22
 ### Added
 - add arg for enable/disable timestamp created_at and updated_at though `--timestamp-field`
 

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.16.1] - 2021-06-22
 ### Added
-- add arg for enable/disable timestamp created_at and updated_at though `--timestamp-field`
+- add arg for enable/disable timestamp created_at and updated_at though `--timestamp-field` (#352)
 
 ## [0.16.0] - 2021-06-22
 ### Changed

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/node",
-  "version": "0.16.1-0",
+  "version": "0.16.1",
   "description": "",
   "author": "Ian He",
   "license": "Apache-2.0",


### PR DESCRIPTION
Patch:

add arg for enable/disable timestamp created_at and updated_at though `--timestamp-field`