### PR TITLE
Fix block gaps by saving subqueryState in the entity transaction.

### DIFF
--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -99,14 +99,15 @@ export class IndexerManager {
       }
       this.subqueryState.nextBlockHeight =
         block.block.header.number.toNumber() + 1;
-      await this.subqueryState.save();
-      this.fetchService.latestProcessed(block.block.header.number.toNumber());
-      this.prevSpecVersion = block.specVersion;
+      await this.subqueryState.save({ transaction: tx });
     } catch (e) {
       await tx.rollback();
       throw e;
     }
     await tx.commit();
+    this.fetchService.latestProcessed(block.block.header.number.toNumber());
+    this.prevSpecVersion = block.specVersion;
+
     this.eventEmitter.emit(IndexerEvent.BlockLastProcessed, {
       height: block.block.header.number.toNumber(),
       timestamp: Date.now(),


### PR DESCRIPTION
During testing of our subquery project, we noticed that sometimes there were block gaps that correlated in the logs with transient network errors between the subquery node and our RPC node. Meaning that the error restarted the node between subquery advancing the `nextBlockHeight` and changes to our entities being saved to the database.

I'm pretty sure this patch fixes the problem by ensuring that saving the next block happens in the same transaction as saving the entities.

I've tested it with our chain and haven't ran into the block gaps again even in the presence of transient network errors.