### PR TITLE
Fix gaping problem in dictionary returned blocks

### DIFF
--- a/packages/node/src/indexer/dictionary.service.test.ts
+++ b/packages/node/src/indexer/dictionary.service.test.ts
@@ -114,4 +114,32 @@ describe('DictionaryService', () => {
     );
     expect(dic.batchBlocks).toEqual(range(startBlock, startBlock + batchSize));
   }, 500000);
+
+  it('use minimum value of event/extrinsic returned block as batch end block', async () => {
+    const project = testSubqueryProject();
+    const dictionaryService = new DictionaryService(project);
+    const batchSize = 50;
+    const startBlock = 333300;
+    const endBlock = 340000;
+    const indexFilters = {
+      //last event at block 333524
+      eventFilters: [
+        { module: 'session', method: 'NewSession' },
+        { module: 'staking', method: 'EraPayout' },
+        { module: 'staking', method: 'Reward' },
+      ],
+      //last extrinsic at block 339186
+      extrinsicFilters: [
+        { module: 'staking', method: 'payoutStakers' },
+        { module: 'utility', method: 'batch' },
+      ],
+    };
+    const dic = await dictionaryService.getDictionary(
+      startBlock,
+      endBlock,
+      batchSize,
+      indexFilters,
+    );
+    expect(dic.batchBlocks[dic.batchBlocks.length - 1]).toBe(333524);
+  }, 500000);
 });

--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -76,15 +76,19 @@ export class DictionaryService implements OnApplicationShutdown {
       });
       const blockHeightSet = new Set<number>();
       const specVersionBlockHeightSet = new Set<number>();
+      let eventEndBlock: number;
+      let extrinsicEndBlock: number;
 
       if (resp.data.events && resp.data.events.nodes.length >= 0) {
         for (const node of resp.data.events.nodes) {
           blockHeightSet.add(Number(node.blockHeight));
+          eventEndBlock = Number(node.blockHeight); //last added event blockHeight
         }
       }
       if (resp.data.extrinsics && resp.data.extrinsics.nodes.length >= 0) {
         for (const node of resp.data.extrinsics.nodes) {
           blockHeightSet.add(Number(node.blockHeight));
+          extrinsicEndBlock = Number(node.blockHeight); //last added extrinsic blockHeight
         }
       }
       if (resp.data.specVersions && resp.data.specVersions.nodes.length >= 0) {
@@ -93,7 +97,13 @@ export class DictionaryService implements OnApplicationShutdown {
         }
       }
       const _metadata = resp.data._metadata;
-      const batchBlocks = Array.from(blockHeightSet);
+      const endBlock = Math.min(
+        isNaN(eventEndBlock) ? Infinity : eventEndBlock,
+        isNaN(extrinsicEndBlock) ? Infinity : extrinsicEndBlock,
+      );
+      const batchBlocks = Array.from(blockHeightSet)
+        .filter((block) => block <= endBlock)
+        .sort((n1, n2) => n1 - n2);
       //TODO
       // const specVersions = Array.from(specVersionBlockHeightSet);
       return {


### PR DESCRIPTION
Closes #451 

We get the min value of event/extrinsic returned block heights, and filter out rest of blocks. This will make sure all events/extrinsic will be query from the dictionary.
