### PR TITLE
Manifest spec version

### DIFF
--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -148,7 +148,7 @@ export async function codegen(projectPath: string): Promise<void> {
   const interfacesPath = path.join(projectPath, TYPE_ROOT_DIR, `interfaces.ts`);
   await prepareDirPath(modelDir, true);
   await prepareDirPath(interfacesPath, false);
-  const manifest = loadProjectManifest(projectPath);
+  const manifest = loadProjectManifest(projectPath, ['0.0.1']);
   await generateJsonInterfaces(projectPath, path.join(projectPath, manifest.schema));
   await generateModels(projectPath, path.join(projectPath, manifest.schema));
   if (exportTypes.interfaces || exportTypes.models) {

--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -4,13 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import {promisify} from 'util';
-import {
-  getAllEntitiesRelations,
-  buildSchema,
-  loadProjectManifest,
-  getAllJsonObjects,
-  setJsonObjectType,
-} from '@subql/common';
+import {getAllEntitiesRelations, loadProjectManifest, getAllJsonObjects, setJsonObjectType} from '@subql/common';
 import {GraphQLEntityField, GraphQLJsonFieldType, GraphQLEntityIndex} from '@subql/common/graphql/types';
 import ejs from 'ejs';
 import {upperFirst} from 'lodash';
@@ -148,7 +142,7 @@ export async function codegen(projectPath: string): Promise<void> {
   const interfacesPath = path.join(projectPath, TYPE_ROOT_DIR, `interfaces.ts`);
   await prepareDirPath(modelDir, true);
   await prepareDirPath(interfacesPath, false);
-  const manifest = loadProjectManifest(projectPath, ['0.0.1']);
+  const manifest = loadProjectManifest(projectPath);
   await generateJsonInterfaces(projectPath, path.join(projectPath, manifest.schema));
   await generateModels(projectPath, path.join(projectPath, manifest.schema));
   if (exportTypes.interfaces || exportTypes.models) {

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import * as path from 'path';
 import {promisify} from 'util';
-import {ProjectManifest} from '@subql/common';
+import {ProjectManifestV0_0_1 as ProjectManifest} from '@subql/common';
 import yaml from 'js-yaml';
 import rimraf from 'rimraf';
 import simpleGit from 'simple-git';

--- a/packages/common/src/project/load.ts
+++ b/packages/common/src/project/load.ts
@@ -3,24 +3,8 @@
 
 import fs from 'fs';
 import path from 'path';
-import {plainToClass} from 'class-transformer';
-import {validateSync} from 'class-validator';
 import yaml from 'js-yaml';
-import {ProjectManifestV0_0_1Impl, ProjectManifestV0_0_2Impl} from './models';
-import {SpecVersion, ProjectManifestBase, ProjectManifestV0_0_1, ProjectManifestV0_0_2} from './types';
-
-type ProjectManifest<V extends SpecVersion> = V extends '0.0.1'
-  ? ProjectManifestV0_0_1
-  : V extends '0.0.2'
-  ? ProjectManifestV0_0_2
-  : ProjectManifestBase;
-
-type VersionImpl<V extends SpecVersion> = Record<V, (doc: unknown) => ProjectManifest<V>>;
-
-const plainToProjectManifestImpl: VersionImpl<SpecVersion> = {
-  '0.0.1': (doc: unknown) => plainToClass(ProjectManifestV0_0_1Impl, doc),
-  '0.0.2': (doc: unknown) => plainToClass(ProjectManifestV0_0_2Impl, doc),
-};
+import {ProjectManifestVersioned, VersionedProjectManifest} from './versioned';
 
 function loadFromFile(file: string): unknown {
   let filePath = file;
@@ -31,32 +15,9 @@ function loadFromFile(file: string): unknown {
   return yaml.load(fs.readFileSync(filePath, 'utf-8'));
 }
 
-export function validateProjectManifest<SV extends Array<SpecVersion>>(
-  doc: unknown,
-  supportedVersions: SV
-): ProjectManifest<SV[number]> {
-  const specVersion = (doc as ProjectManifestBase).specVersion;
-
-  if (!supportedVersions.includes(specVersion as SpecVersion) && !!plainToProjectManifestImpl[specVersion]) {
-    throw new Error(`Unsupported specVersion: ${specVersion}`);
-  }
-
-  const manifest = plainToProjectManifestImpl[specVersion](doc);
-
-  const errors = validateSync(manifest, {whitelist: true, forbidNonWhitelisted: true});
-  if (errors?.length) {
-    // TODO: print error details
-    const errorMsgs = errors.map((e) => e.toString()).join('\n');
-    throw new Error(`failed to parse project.yaml.\n${errorMsgs}`);
-  }
-  return manifest;
-}
-
-export function loadProjectManifest<SV extends Array<SpecVersion>>(
-  file: string,
-  supportedVersions: SV
-): ProjectManifest<SV[number]> {
+export function loadProjectManifest(file: string): ProjectManifestVersioned {
   const doc = loadFromFile(file);
-
-  return validateProjectManifest(doc, supportedVersions);
+  const projectManifest = new ProjectManifestVersioned(doc as VersionedProjectManifest);
+  projectManifest.validate();
+  return projectManifest;
 }

--- a/packages/common/src/project/load.ts
+++ b/packages/common/src/project/load.ts
@@ -4,35 +4,59 @@
 import fs from 'fs';
 import path from 'path';
 import {plainToClass} from 'class-transformer';
-import {validateSync, ValidationError} from 'class-validator';
+import {validateSync} from 'class-validator';
 import yaml from 'js-yaml';
-import {ProjectManifestImpl} from './models';
-import {ProjectManifest} from './types';
+import {ProjectManifestV0_0_1Impl, ProjectManifestV0_0_2Impl} from './models';
+import {SpecVersion, ProjectManifestBase, ProjectManifestV0_0_1, ProjectManifestV0_0_2} from './types';
 
-export function plainToProjectManifest(doc: unknown): ProjectManifestImpl {
-  return plainToClass(ProjectManifestImpl, doc);
-}
+type ProjectManifest<V extends SpecVersion> = V extends '0.0.1'
+  ? ProjectManifestV0_0_1
+  : V extends '0.0.2'
+  ? ProjectManifestV0_0_2
+  : ProjectManifestBase;
 
-export function validateProjectManifest(manifest: ProjectManifestImpl): ValidationError[] {
-  const errors = validateSync(manifest, {whitelist: true, forbidNonWhitelisted: true});
+type VersionImpl<V extends SpecVersion> = Record<V, (doc: unknown) => ProjectManifest<V>>;
 
-  return errors;
-}
+const plainToProjectManifestImpl: VersionImpl<SpecVersion> = {
+  '0.0.1': (doc: unknown) => plainToClass(ProjectManifestV0_0_1Impl, doc),
+  '0.0.2': (doc: unknown) => plainToClass(ProjectManifestV0_0_2Impl, doc),
+};
 
-export function loadProjectManifest(file: string): ProjectManifest {
+function loadFromFile(file: string): unknown {
   let filePath = file;
   if (fs.existsSync(file) && fs.lstatSync(file).isDirectory()) {
     filePath = path.join(file, 'project.yaml');
   }
 
-  const doc = yaml.load(fs.readFileSync(filePath, 'utf-8'));
+  return yaml.load(fs.readFileSync(filePath, 'utf-8'));
+}
 
-  const manifest = plainToProjectManifest(doc);
-  const errors = validateProjectManifest(manifest);
+export function validateProjectManifest<SV extends Array<SpecVersion>>(
+  doc: unknown,
+  supportedVersions: SV
+): ProjectManifest<SV[number]> {
+  const specVersion = (doc as ProjectManifestBase).specVersion;
+
+  if (!supportedVersions.includes(specVersion as SpecVersion) && !!plainToProjectManifestImpl[specVersion]) {
+    throw new Error(`Unsupported specVersion: ${specVersion}`);
+  }
+
+  const manifest = plainToProjectManifestImpl[specVersion](doc);
+
+  const errors = validateSync(manifest, {whitelist: true, forbidNonWhitelisted: true});
   if (errors?.length) {
     // TODO: print error details
     const errorMsgs = errors.map((e) => e.toString()).join('\n');
     throw new Error(`failed to parse project.yaml.\n${errorMsgs}`);
   }
   return manifest;
+}
+
+export function loadProjectManifest<SV extends Array<SpecVersion>>(
+  file: string,
+  supportedVersions: SV
+): ProjectManifest<SV[number]> {
+  const doc = loadFromFile(file);
+
+  return validateProjectManifest(doc, supportedVersions);
 }

--- a/packages/common/src/project/models.ts
+++ b/packages/common/src/project/models.ts
@@ -6,6 +6,7 @@ import {plainToClass, Transform, Type} from 'class-transformer';
 import {
   Allow,
   ArrayMaxSize,
+  Equals,
   IsArray,
   IsBoolean,
   IsEnum,
@@ -17,7 +18,8 @@ import {
 } from 'class-validator';
 import {SubqlKind} from './constants';
 import {
-  ProjectManifest,
+  ProjectManifestV0_0_1,
+  ProjectManifestV0_0_2,
   SubqlBlockFilter,
   SubqlCallFilter,
   SubqlEventFilter,
@@ -25,9 +27,10 @@ import {
   SubqlHandler,
   SubqlMapping,
   SubqlRuntimeDatasource,
+  ProjectManifestBase,
 } from './types';
 
-export class ProjectNetwork implements RegisteredTypes {
+export class ProjectNetworkV0_0_1 implements RegisteredTypes {
   @IsString()
   endpoint: string;
   @IsString()
@@ -50,25 +53,58 @@ export class ProjectNetwork implements RegisteredTypes {
   typesSpec?: Record<string, RegistryTypes>;
 }
 
-export class ProjectManifestImpl implements ProjectManifest {
+export class FileType {
+  @IsString()
+  file: string;
+}
+
+export class ProjectNetworkV0_0_2 {
+  @IsString()
+  genesisHash: string;
+
+  @IsObject()
+  @ValidateNested()
+  @Type(() => FileType)
+  chaintypes: FileType;
+}
+
+export class ProjectManifestBaseImpl implements ProjectManifestBase {
   @Allow()
   definitions: object;
   @IsString()
   description: string;
-  @ValidateNested()
-  @Type(() => ProjectNetwork)
-  @IsObject()
-  network: ProjectNetwork;
   @IsString()
   repository: string;
-  @IsString()
-  schema: string;
   @IsString()
   specVersion: string;
   @IsArray()
   @ValidateNested()
   @Type(() => RuntimeDataSource)
   dataSources: RuntimeDataSource[];
+}
+
+export class ProjectManifestV0_0_1Impl extends ProjectManifestBaseImpl implements ProjectManifestV0_0_1 {
+  @Equals('0.0.1')
+  specVersion: string;
+  @ValidateNested()
+  @Type(() => ProjectNetworkV0_0_1)
+  @IsObject()
+  network: ProjectNetworkV0_0_1;
+  @IsString()
+  schema: string;
+}
+
+export class ProjectManifestV0_0_2Impl extends ProjectManifestBaseImpl implements ProjectManifestV0_0_2 {
+  @Equals('0.2.0')
+  specVersion: string;
+  @IsObject()
+  @ValidateNested()
+  @Type(() => ProjectNetworkV0_0_2)
+  network: ProjectNetworkV0_0_2;
+  @IsObject()
+  @ValidateNested()
+  @Type(() => FileType)
+  schema: FileType;
 }
 
 export class BlockFilter implements SubqlBlockFilter {

--- a/packages/common/src/project/models.ts
+++ b/packages/common/src/project/models.ts
@@ -1,25 +1,10 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {RegistryTypes, RegisteredTypes, OverrideModuleType, OverrideBundleType} from '@polkadot/types/types';
 import {plainToClass, Transform, Type} from 'class-transformer';
-import {
-  Allow,
-  ArrayMaxSize,
-  Equals,
-  IsArray,
-  IsBoolean,
-  IsEnum,
-  IsInt,
-  IsObject,
-  IsOptional,
-  IsString,
-  ValidateNested,
-} from 'class-validator';
+import {ArrayMaxSize, IsArray, IsBoolean, IsEnum, IsInt, IsOptional, IsString, ValidateNested} from 'class-validator';
 import {SubqlKind} from './constants';
 import {
-  ProjectManifestV0_0_1,
-  ProjectManifestV0_0_2,
   SubqlBlockFilter,
   SubqlCallFilter,
   SubqlEventFilter,
@@ -27,85 +12,7 @@ import {
   SubqlHandler,
   SubqlMapping,
   SubqlRuntimeDatasource,
-  ProjectManifestBase,
 } from './types';
-
-export class ProjectNetworkV0_0_1 implements RegisteredTypes {
-  @IsString()
-  endpoint: string;
-  @IsString()
-  @IsOptional()
-  dictionary?: string;
-  @IsObject()
-  @IsOptional()
-  types?: RegistryTypes;
-  @IsObject()
-  @IsOptional()
-  typesAlias?: Record<string, OverrideModuleType>;
-  @IsObject()
-  @IsOptional()
-  typesBundle?: OverrideBundleType;
-  @IsObject()
-  @IsOptional()
-  typesChain?: Record<string, RegistryTypes>;
-  @IsObject()
-  @IsOptional()
-  typesSpec?: Record<string, RegistryTypes>;
-}
-
-export class FileType {
-  @IsString()
-  file: string;
-}
-
-export class ProjectNetworkV0_0_2 {
-  @IsString()
-  genesisHash: string;
-
-  @IsObject()
-  @ValidateNested()
-  @Type(() => FileType)
-  chaintypes: FileType;
-}
-
-export class ProjectManifestBaseImpl implements ProjectManifestBase {
-  @Allow()
-  definitions: object;
-  @IsString()
-  description: string;
-  @IsString()
-  repository: string;
-  @IsString()
-  specVersion: string;
-  @IsArray()
-  @ValidateNested()
-  @Type(() => RuntimeDataSource)
-  dataSources: RuntimeDataSource[];
-}
-
-export class ProjectManifestV0_0_1Impl extends ProjectManifestBaseImpl implements ProjectManifestV0_0_1 {
-  @Equals('0.0.1')
-  specVersion: string;
-  @ValidateNested()
-  @Type(() => ProjectNetworkV0_0_1)
-  @IsObject()
-  network: ProjectNetworkV0_0_1;
-  @IsString()
-  schema: string;
-}
-
-export class ProjectManifestV0_0_2Impl extends ProjectManifestBaseImpl implements ProjectManifestV0_0_2 {
-  @Equals('0.2.0')
-  specVersion: string;
-  @IsObject()
-  @ValidateNested()
-  @Type(() => ProjectNetworkV0_0_2)
-  network: ProjectNetworkV0_0_2;
-  @IsObject()
-  @ValidateNested()
-  @Type(() => FileType)
-  schema: FileType;
-}
 
 export class BlockFilter implements SubqlBlockFilter {
   @IsOptional()

--- a/packages/common/src/project/project.spec.ts
+++ b/packages/common/src/project/project.spec.ts
@@ -4,16 +4,24 @@
 import path from 'path';
 import {loadProjectManifest} from './load';
 
+const projectsDir = path.join(__dirname, '../../test');
+
 describe('project.yaml', () => {
   it('can parse project.yaml to ProjectManifestImpl', () => {
-    const project = loadProjectManifest(path.join(__dirname, '../../test/project.yaml'));
+    const project = loadProjectManifest(path.join(projectsDir, 'project.yaml'), ['0.0.1']);
     expect(project).toBeTruthy();
   });
 
   it('can validate project.yaml', () => {
-    expect(() => loadProjectManifest(path.join(__dirname, '../../test/project_falsy.yaml'))).toThrow();
-    expect(() => loadProjectManifest(path.join(__dirname, '../../test/project_falsy_array.yaml'))).toThrow(
-      /failed to parse project.yaml/
-    );
+    expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy.yaml'), ['0.0.1'])).toThrow();
+    expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy_array.yaml'), ['0.0.1'])).toThrow();
+  });
+
+  it('can validate a v0.0.2 project.yaml', () => {
+    expect(() => loadProjectManifest(path.join(projectsDir, 'project_0.0.2.yaml'), ['0.0.1', '0.0.2'])).toBeTruthy();
+  });
+
+  it('can fail validation if version not supported', () => {
+    expect(() => loadProjectManifest(path.join(projectsDir, 'project_0.0.2.yaml'), ['0.0.1'])).toThrow();
   });
 });

--- a/packages/common/src/project/project.spec.ts
+++ b/packages/common/src/project/project.spec.ts
@@ -7,21 +7,21 @@ import {loadProjectManifest} from './load';
 const projectsDir = path.join(__dirname, '../../test');
 
 describe('project.yaml', () => {
-  // it('can parse project.yaml to ProjectManifestImpl', () => {
-  //   const project = loadProjectManifest(path.join(projectsDir, 'project.yaml'), ['0.0.1']);
-  //   expect(project).toBeTruthy();
-  // });
-  //
-  // it('can validate project.yaml', () => {
-  //   expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy.yaml'), ['0.0.1'])).toThrow();
-  //   expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy_array.yaml'), ['0.0.1'])).toThrow();
-  // });
-  //
-  // it('can validate a v0.0.2 project.yaml', () => {
-  //   expect(() => loadProjectManifest(path.join(projectsDir, 'project_0.0.2.yaml'), ['0.0.1', '0.0.2'])).toBeTruthy();
-  // });
-  //
-  // it('can fail validation if version not supported', () => {
-  //   expect(() => loadProjectManifest(path.join(projectsDir, 'project_0.0.2.yaml'), ['0.0.1'])).toThrow();
-  // });
+  it('can parse project.yaml to ProjectManifestImpl', () => {
+    const project = loadProjectManifest(path.join(projectsDir, 'project.yaml'));
+    expect(project).toBeTruthy();
+  });
+
+  it('can validate project.yaml', () => {
+    expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy.yaml'))).toThrow();
+    expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy_array.yaml'))).toThrow();
+  });
+
+  it('can validate a v0.0.2 project.yaml', () => {
+    expect(() => loadProjectManifest(path.join(projectsDir, 'project_0.0.2.yaml'))).toBeTruthy();
+  });
+
+  it('can fail validation if version not supported', () => {
+    expect(() => loadProjectManifest(path.join(projectsDir, 'project_invalid_version.yaml'))).toThrow();
+  });
 });

--- a/packages/common/src/project/project.spec.ts
+++ b/packages/common/src/project/project.spec.ts
@@ -7,21 +7,21 @@ import {loadProjectManifest} from './load';
 const projectsDir = path.join(__dirname, '../../test');
 
 describe('project.yaml', () => {
-  it('can parse project.yaml to ProjectManifestImpl', () => {
-    const project = loadProjectManifest(path.join(projectsDir, 'project.yaml'), ['0.0.1']);
-    expect(project).toBeTruthy();
-  });
-
-  it('can validate project.yaml', () => {
-    expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy.yaml'), ['0.0.1'])).toThrow();
-    expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy_array.yaml'), ['0.0.1'])).toThrow();
-  });
-
-  it('can validate a v0.0.2 project.yaml', () => {
-    expect(() => loadProjectManifest(path.join(projectsDir, 'project_0.0.2.yaml'), ['0.0.1', '0.0.2'])).toBeTruthy();
-  });
-
-  it('can fail validation if version not supported', () => {
-    expect(() => loadProjectManifest(path.join(projectsDir, 'project_0.0.2.yaml'), ['0.0.1'])).toThrow();
-  });
+  // it('can parse project.yaml to ProjectManifestImpl', () => {
+  //   const project = loadProjectManifest(path.join(projectsDir, 'project.yaml'), ['0.0.1']);
+  //   expect(project).toBeTruthy();
+  // });
+  //
+  // it('can validate project.yaml', () => {
+  //   expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy.yaml'), ['0.0.1'])).toThrow();
+  //   expect(() => loadProjectManifest(path.join(projectsDir, 'project_falsy_array.yaml'), ['0.0.1'])).toThrow();
+  // });
+  //
+  // it('can validate a v0.0.2 project.yaml', () => {
+  //   expect(() => loadProjectManifest(path.join(projectsDir, 'project_0.0.2.yaml'), ['0.0.1', '0.0.2'])).toBeTruthy();
+  // });
+  //
+  // it('can fail validation if version not supported', () => {
+  //   expect(() => loadProjectManifest(path.join(projectsDir, 'project_0.0.2.yaml'), ['0.0.1'])).toThrow();
+  // });
 });

--- a/packages/common/src/project/types.ts
+++ b/packages/common/src/project/types.ts
@@ -1,39 +1,19 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {RegistryTypes} from '@polkadot/types/types';
 import {SubqlKind} from './constants';
 
-export type SpecVersion = '0.0.1' | '0.0.2';
-
-export interface ProjectManifestBase {
+export interface IProjectManifest {
   specVersion: string;
   description: string;
   repository: string;
-
   dataSources: SubqlDataSource[];
-}
-
-export interface ProjectManifestV0_0_1 extends ProjectManifestBase {
   schema: string;
-
-  network: {
-    endpoint: string;
-    customTypes?: RegistryTypes;
-  };
 }
 
-export interface ProjectManifestV0_0_2 extends ProjectManifestBase {
-  schema: {
-    file: string;
-  };
-
-  network: {
-    genesisHash: string;
-    chaintypes: {
-      file: string;
-    };
-  };
+export interface ProjectNetworkConfig {
+  endpoint: string;
+  dictionary?: string;
 }
 
 // [startSpecVersion?, endSpecVersion?] closed range
@@ -93,7 +73,7 @@ export interface SubqlRuntimeDatasource extends SubqlDatasource {
 }
 
 export interface SubqlNetworkFilter {
-  specName: String;
+  specName: string;
 }
 
 export type SubqlDataSource = SubqlRuntimeDatasource;

--- a/packages/common/src/project/types.ts
+++ b/packages/common/src/project/types.ts
@@ -4,19 +4,36 @@
 import {RegistryTypes} from '@polkadot/types/types';
 import {SubqlKind} from './constants';
 
-export interface ProjectManifest {
+export type SpecVersion = '0.0.1' | '0.0.2';
+
+export interface ProjectManifestBase {
   specVersion: string;
   description: string;
   repository: string;
 
+  dataSources: SubqlDataSource[];
+}
+
+export interface ProjectManifestV0_0_1 extends ProjectManifestBase {
   schema: string;
 
   network: {
     endpoint: string;
     customTypes?: RegistryTypes;
   };
+}
 
-  dataSources: SubqlDataSource[];
+export interface ProjectManifestV0_0_2 extends ProjectManifestBase {
+  schema: {
+    file: string;
+  };
+
+  network: {
+    genesisHash: string;
+    chaintypes: {
+      file: string;
+    };
+  };
 }
 
 // [startSpecVersion?, endSpecVersion?] closed range

--- a/packages/common/src/project/versioned/ProjectManifestVersioned.ts
+++ b/packages/common/src/project/versioned/ProjectManifestVersioned.ts
@@ -1,0 +1,78 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {plainToClass} from 'class-transformer';
+import {validateSync} from 'class-validator';
+import {IProjectManifest, SubqlDataSource} from '../types';
+import {ProjectManifestV0_0_1Impl} from './v0_0_1';
+import {ProjectManifestV0_0_2Impl} from './v0_0_2';
+
+export type VersionedProjectManifest = {specVersion: string};
+
+const SUPPORTED_VERSIONS = {
+  v0_0_1: ProjectManifestV0_0_1Impl,
+  v0_0_2: ProjectManifestV0_0_2Impl,
+};
+
+type ProjectManifestImpls = InstanceType<typeof SUPPORTED_VERSIONS[keyof typeof SUPPORTED_VERSIONS]>;
+
+export class ProjectManifestVersioned implements IProjectManifest {
+  private _impl: ProjectManifestImpls;
+
+  constructor(projectManifest: VersionedProjectManifest) {
+    const klass = SUPPORTED_VERSIONS[projectManifest.specVersion];
+    if (!klass) {
+      throw new Error('specVersion not supported for project manifest file');
+    }
+    this._impl = plainToClass(klass, projectManifest);
+  }
+
+  get asImpl(): IProjectManifest {
+    return this._impl;
+  }
+
+  get isV0_0_1(): boolean {
+    return this.specVersion === '0.0.1';
+  }
+
+  get asV0_0_1(): ProjectManifestV0_0_1Impl {
+    return this._impl as ProjectManifestV0_0_1Impl;
+  }
+
+  get isV0_0_2(): boolean {
+    return this.specVersion === '0.0.2';
+  }
+
+  get asV0_0_2(): ProjectManifestV0_0_2Impl {
+    return this._impl as ProjectManifestV0_0_2Impl;
+  }
+
+  validate(): void {
+    const errors = validateSync(this._impl, {whitelist: true, forbidNonWhitelisted: true});
+    if (errors?.length) {
+      // TODO: print error details
+      const errorMsgs = errors.map((e) => e.toString()).join('\n');
+      throw new Error(`failed to parse project.yaml.\n${errorMsgs}`);
+    }
+  }
+
+  get dataSources(): SubqlDataSource[] {
+    return this._impl.dataSources;
+  }
+
+  get schema(): string {
+    return this._impl.schema;
+  }
+
+  get specVersion(): string {
+    return this._impl.specVersion;
+  }
+
+  get description(): string {
+    return this._impl.description;
+  }
+
+  get repository(): string {
+    return this._impl.repository;
+  }
+}

--- a/packages/common/src/project/versioned/ProjectManifestVersioned.ts
+++ b/packages/common/src/project/versioned/ProjectManifestVersioned.ts
@@ -10,8 +10,8 @@ import {ProjectManifestV0_0_2Impl} from './v0_0_2';
 export type VersionedProjectManifest = {specVersion: string};
 
 const SUPPORTED_VERSIONS = {
-  v0_0_1: ProjectManifestV0_0_1Impl,
-  v0_0_2: ProjectManifestV0_0_2Impl,
+  '0.0.1': ProjectManifestV0_0_1Impl,
+  '0.0.2': ProjectManifestV0_0_2Impl,
 };
 
 type ProjectManifestImpls = InstanceType<typeof SUPPORTED_VERSIONS[keyof typeof SUPPORTED_VERSIONS]>;

--- a/packages/common/src/project/versioned/base.ts
+++ b/packages/common/src/project/versioned/base.ts
@@ -1,0 +1,21 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {Type} from 'class-transformer';
+import {Allow, IsArray, IsString, ValidateNested} from 'class-validator';
+import {RuntimeDataSource} from '../models';
+
+export class ProjectManifestBaseImpl {
+  @Allow()
+  definitions: object;
+  @IsString()
+  description: string;
+  @IsString()
+  repository: string;
+  @IsString()
+  specVersion: string;
+  @IsArray()
+  @ValidateNested()
+  @Type(() => RuntimeDataSource)
+  dataSources: RuntimeDataSource[];
+}

--- a/packages/common/src/project/versioned/index.ts
+++ b/packages/common/src/project/versioned/index.ts
@@ -1,0 +1,6 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './ProjectManifestVersioned';
+export * from './v0_0_1';
+export * from './v0_0_2';

--- a/packages/common/src/project/versioned/v0_0_1/index.ts
+++ b/packages/common/src/project/versioned/v0_0_1/index.ts
@@ -1,7 +1,5 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+export * from './model';
 export * from './types';
-export * from './load';
-export * from './constants';
-export * from './versioned';

--- a/packages/common/src/project/versioned/v0_0_1/model.ts
+++ b/packages/common/src/project/versioned/v0_0_1/model.ts
@@ -1,0 +1,43 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {RegistryTypes, RegisteredTypes, OverrideModuleType, OverrideBundleType} from '@polkadot/types/types';
+import {Type} from 'class-transformer';
+import {Equals, IsObject, IsOptional, IsString, ValidateNested} from 'class-validator';
+import {ProjectNetworkConfig} from '../../types';
+import {ProjectManifestBaseImpl} from '../base';
+import {ProjectManifestV0_0_1} from './types';
+
+export class ProjectNetworkV0_0_1 implements RegisteredTypes, ProjectNetworkConfig {
+  @IsString()
+  endpoint: string;
+  @IsString()
+  @IsOptional()
+  dictionary?: string;
+  @IsObject()
+  @IsOptional()
+  types?: RegistryTypes;
+  @IsObject()
+  @IsOptional()
+  typesAlias?: Record<string, OverrideModuleType>;
+  @IsObject()
+  @IsOptional()
+  typesBundle?: OverrideBundleType;
+  @IsObject()
+  @IsOptional()
+  typesChain?: Record<string, RegistryTypes>;
+  @IsObject()
+  @IsOptional()
+  typesSpec?: Record<string, RegistryTypes>;
+}
+
+export class ProjectManifestV0_0_1Impl extends ProjectManifestBaseImpl implements ProjectManifestV0_0_1 {
+  @Equals('0.0.1')
+  specVersion: string;
+  @ValidateNested()
+  @Type(() => ProjectNetworkV0_0_1)
+  @IsObject()
+  network: ProjectNetworkV0_0_1;
+  @IsString()
+  schema: string;
+}

--- a/packages/common/src/project/versioned/v0_0_1/types.ts
+++ b/packages/common/src/project/versioned/v0_0_1/types.ts
@@ -1,0 +1,14 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {RegistryTypes} from '@polkadot/types/types';
+import {IProjectManifest} from '../../types';
+
+export interface ProjectManifestV0_0_1 extends IProjectManifest {
+  schema: string;
+
+  network: {
+    endpoint: string;
+    customTypes?: RegistryTypes;
+  };
+}

--- a/packages/common/src/project/versioned/v0_0_2/index.ts
+++ b/packages/common/src/project/versioned/v0_0_2/index.ts
@@ -1,7 +1,5 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+export * from './model';
 export * from './types';
-export * from './load';
-export * from './constants';
-export * from './versioned';

--- a/packages/common/src/project/versioned/v0_0_2/model.ts
+++ b/packages/common/src/project/versioned/v0_0_2/model.ts
@@ -1,0 +1,37 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {Type} from 'class-transformer';
+import {Equals, IsObject, IsString, ValidateNested} from 'class-validator';
+import {ProjectManifestBaseImpl} from '../base';
+import {ProjectManifestV0_0_2} from './types';
+
+export class FileType {
+  @IsString()
+  file: string;
+}
+
+export class ProjectNetworkV0_0_2 {
+  @IsString()
+  genesisHash: string;
+
+  @IsObject()
+  @ValidateNested()
+  @Type(() => FileType)
+  chaintypes: FileType;
+}
+
+export class ProjectManifestV0_0_2Impl extends ProjectManifestBaseImpl implements ProjectManifestV0_0_2 {
+  @Equals('0.2.0')
+  specVersion: string;
+  @IsObject()
+  @ValidateNested()
+  @Type(() => ProjectNetworkV0_0_2)
+  network: ProjectNetworkV0_0_2;
+  // TODO: when really implement v0_0_2
+  // @ValidateNested()
+  // @Type(() => FileType)
+  // schema: FileType;
+  @IsString()
+  schema: string;
+}

--- a/packages/common/src/project/versioned/v0_0_2/types.ts
+++ b/packages/common/src/project/versioned/v0_0_2/types.ts
@@ -1,0 +1,18 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {IProjectManifest} from '../../types';
+
+export interface ProjectManifestV0_0_2 extends IProjectManifest {
+  // schema: {
+  //   file: string;
+  // };
+  schema: string;
+
+  network: {
+    genesisHash: string;
+    chaintypes: {
+      file: string;
+    };
+  };
+}

--- a/packages/common/test/project_0.0.2.yaml
+++ b/packages/common/test/project_0.0.2.yaml
@@ -1,0 +1,31 @@
+# project.yaml
+specVersion: "0.0.2"
+description: ""
+repository: "https://github.com/subquery/subql-starter"
+
+schema:
+  file: ./schema.graphql
+
+network:
+  genesisHash: '0x'
+  chaintypes:
+    file: ./types.json
+
+dataSources:
+  - name: main
+    kind: substrate/Runtime
+    startBlock: 1
+    mapping:
+      file: dist/index.js
+      handlers:
+        - handler: handleBlock
+          kind: substrate/BlockHandler
+        - handler: handleEvent
+          kind: substrate/EventHandler
+          filter: #Filter is optional
+            module: balances
+            method: Deposit
+        - handler: handleCall
+          kind: substrate/CallHandler
+
+

--- a/packages/common/test/project_invalid_version.yaml
+++ b/packages/common/test/project_invalid_version.yaml
@@ -1,0 +1,31 @@
+# project.yaml
+specVersion: "0.0.0"
+description: ""
+repository: "https://github.com/subquery/subql-starter"
+
+schema:
+  file: ./schema.graphql
+
+network:
+  genesisHash: '0x'
+  chaintypes:
+    file: ./types.json
+
+dataSources:
+  - name: main
+    kind: substrate/Runtime
+    startBlock: 1
+    mapping:
+      file: dist/index.js
+      handlers:
+        - handler: handleBlock
+          kind: substrate/BlockHandler
+        - handler: handleEvent
+          kind: substrate/EventHandler
+          filter: #Filter is optional
+            module: balances
+            method: Deposit
+        - handler: handleCall
+          kind: substrate/CallHandler
+
+

--- a/packages/node/src/configure/project.model.ts
+++ b/packages/node/src/configure/project.model.ts
@@ -3,10 +3,10 @@
 
 import {
   loadProjectManifest,
-  ProjectManifest,
+  ProjectManifestV0_0_1 as ProjectManifest,
   SubqlDataSource,
 } from '@subql/common';
-import { ProjectNetwork } from '@subql/common/project/models';
+import { ProjectNetworkV0_0_1 as ProjectNetwork } from '@subql/common/project/models';
 import { getLogger } from '../utils/logger';
 import { prepareProjectDir } from '../utils/project';
 
@@ -16,7 +16,7 @@ export class SubqueryProject implements ProjectManifest {
   static async create(path: string): Promise<SubqueryProject> {
     const projectPath = await prepareProjectDir(path);
     const project = new SubqueryProject();
-    const source = loadProjectManifest(projectPath);
+    const source = loadProjectManifest(projectPath, ['0.0.1']);
     Object.assign(project, source);
     project.path = projectPath;
     project.dataSources.map(function (dataSource) {

--- a/packages/node/src/configure/project.model.ts
+++ b/packages/node/src/configure/project.model.ts
@@ -3,7 +3,6 @@
 
 import {
   loadProjectManifest,
-  IProjectManifest,
   SubqlDataSource,
   ProjectNetworkConfig,
   ProjectManifestVersioned,
@@ -35,7 +34,8 @@ export class SubqueryProject {
   constructor(manifest: ProjectManifestVersioned, path: string) {
     this._projectManifest = manifest;
     this._path = path;
-    manifest.asImpl.dataSources.forEach(function (dataSource) {
+
+    manifest.dataSources.forEach(function (dataSource) {
       if (!dataSource.startBlock || dataSource.startBlock < 1) {
         if (dataSource.startBlock < 1) logger.warn('start block changed to #1');
         dataSource.startBlock = 1;
@@ -48,10 +48,12 @@ export class SubqueryProject {
   }
 
   get network(): ProjectNetworkConfig {
-    if (this._projectManifest.specVersion === '0.0.1') {
+    if (this._projectManifest.isV0_0_1) {
       return this._projectManifest.asV0_0_1.network;
     }
-    throw new Error('not implemented');
+    throw new Error(
+      `unsupported specVersion: ${this._projectManifest.specVersion}`,
+    );
   }
 
   get path(): string {

--- a/packages/node/src/indexer/api.service.spec.ts
+++ b/packages/node/src/indexer/api.service.spec.ts
@@ -3,7 +3,7 @@
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { ProjectNetworkV0_0_1 } from '@subql/common';
+import { ProjectManifestVersioned, ProjectNetworkV0_0_1 } from '@subql/common';
 import { omit } from 'lodash';
 import { SubqueryProject } from '../configure/project.model';
 import { ApiService } from './api.service';
@@ -46,7 +46,11 @@ const testNetwork: ProjectNetworkV0_0_1 = {
 
 function testSubqueryProject(): SubqueryProject {
   const project = new SubqueryProject(
-    { specVersion: '0.0.1', network: testNetwork } as any,
+    new ProjectManifestVersioned({
+      specVersion: '0.0.1',
+      network: testNetwork,
+      dataSources: [],
+    } as any),
     '',
   );
   return project;

--- a/packages/node/src/indexer/api.service.spec.ts
+++ b/packages/node/src/indexer/api.service.spec.ts
@@ -3,7 +3,7 @@
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { ProjectNetworkV0_0_1 as ProjectNetwork } from '@subql/common/project/models';
+import { ProjectNetworkV0_0_1 } from '@subql/common';
 import { omit } from 'lodash';
 import { SubqueryProject } from '../configure/project.model';
 import { ApiService } from './api.service';
@@ -20,7 +20,7 @@ jest.mock('@polkadot/api', () => {
   return { ApiPromise, WsProvider: jest.fn() };
 });
 
-const testNetwork: ProjectNetwork = {
+const testNetwork: ProjectNetworkV0_0_1 = {
   endpoint: 'wss://kusama.api.onfinality.io/public-ws',
   types: {
     TestType: 'u32',
@@ -45,8 +45,10 @@ const testNetwork: ProjectNetwork = {
 };
 
 function testSubqueryProject(): SubqueryProject {
-  const project = new SubqueryProject();
-  project.network = testNetwork;
+  const project = new SubqueryProject(
+    { specVersion: '0.0.1', network: testNetwork } as any,
+    '',
+  );
   return project;
 }
 

--- a/packages/node/src/indexer/api.service.spec.ts
+++ b/packages/node/src/indexer/api.service.spec.ts
@@ -3,7 +3,7 @@
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { ProjectNetwork } from '@subql/common/project/models';
+import { ProjectNetworkV0_0_1 as ProjectNetwork } from '@subql/common/project/models';
 import { omit } from 'lodash';
 import { SubqueryProject } from '../configure/project.model';
 import { ApiService } from './api.service';

--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -5,6 +5,7 @@ import { INestApplication } from '@nestjs/common';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Test } from '@nestjs/testing';
 import { BlockHash } from '@polkadot/types/interfaces';
+import { ProjectManifestVersioned } from '@subql/common';
 import { take } from 'rxjs/operators';
 import { SubqueryProject } from '../configure/project.model';
 import { delay } from '../utils/promise';
@@ -15,7 +16,7 @@ const HTTP_ENDPOINT = 'https://kusama.api.onfinality.io/public';
 
 function testSubqueryProject(endpoint: string): SubqueryProject {
   const project = new SubqueryProject(
-    {
+    new ProjectManifestVersioned({
       specVersion: '0.0.1',
       network: {
         endpoint,
@@ -23,7 +24,8 @@ function testSubqueryProject(endpoint: string): SubqueryProject {
           TestType: 'u32',
         },
       },
-    } as any,
+      dataSources: [],
+    } as any),
     '',
   );
   return project;

--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -14,13 +14,18 @@ const WS_ENDPOINT = 'wss://kusama.api.onfinality.io/public-ws';
 const HTTP_ENDPOINT = 'https://kusama.api.onfinality.io/public';
 
 function testSubqueryProject(endpoint: string): SubqueryProject {
-  const project = new SubqueryProject();
-  project.network = {
-    endpoint,
-    types: {
-      TestType: 'u32',
-    },
-  };
+  const project = new SubqueryProject(
+    {
+      specVersion: '0.0.1',
+      network: {
+        endpoint,
+        types: {
+          TestType: 'u32',
+        },
+      },
+    } as any,
+    '',
+  );
   return project;
 }
 

--- a/packages/node/src/indexer/dictionary.service.test.ts
+++ b/packages/node/src/indexer/dictionary.service.test.ts
@@ -1,13 +1,14 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { ProjectManifestVersioned } from '@subql/common';
 import { range } from 'lodash';
 import { SubqueryProject } from '../configure/project.model';
 import { DictionaryService } from './dictionary.service';
 
 function testSubqueryProject(): SubqueryProject {
   const project = new SubqueryProject(
-    {
+    new ProjectManifestVersioned({
       specVersion: '0.0.1',
       network: {
         endpoint: 'wss://polkadot.api.onfinality.io/public-ws',
@@ -18,7 +19,7 @@ function testSubqueryProject(): SubqueryProject {
         },
       },
       dataSources: [],
-    } as any,
+    } as any),
     '',
   );
   return project;

--- a/packages/node/src/indexer/dictionary.service.test.ts
+++ b/packages/node/src/indexer/dictionary.service.test.ts
@@ -6,15 +6,21 @@ import { SubqueryProject } from '../configure/project.model';
 import { DictionaryService } from './dictionary.service';
 
 function testSubqueryProject(): SubqueryProject {
-  const project = new SubqueryProject();
-  project.network = {
-    endpoint: 'wss://polkadot.api.onfinality.io/public-ws',
-    dictionary: 'https://api.subquery.network/sq/subquery/dictionary-polkadot',
-    types: {
-      TestType: 'u32',
-    },
-  };
-  project.dataSources = [];
+  const project = new SubqueryProject(
+    {
+      specVersion: '0.0.1',
+      network: {
+        endpoint: 'wss://polkadot.api.onfinality.io/public-ws',
+        dictionary:
+          'https://api.subquery.network/sq/subquery/dictionary-polkadot',
+        types: {
+          TestType: 'u32',
+        },
+      },
+      dataSources: [],
+    } as any,
+    '',
+  );
   return project;
 }
 

--- a/packages/node/src/indexer/fetch.service.spec.ts
+++ b/packages/node/src/indexer/fetch.service.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { SubqlKind } from '@subql/common';
+import { ProjectManifestVersioned, SubqlKind } from '@subql/common';
 import { NodeConfig } from '../configure/NodeConfig';
 import { SubqueryProject } from '../configure/project.model';
 import { fetchBlocksBatches } from '../utils/substrate';
@@ -158,7 +158,7 @@ function mockDictionaryService3(): DictionaryService {
 
 function testSubqueryProject(): SubqueryProject {
   const project = new SubqueryProject(
-    {
+    new ProjectManifestVersioned({
       specVersion: '0.0.1',
       network: {
         endpoint: 'wss://polkadot.api.onfinality.io/public-ws',
@@ -167,7 +167,7 @@ function testSubqueryProject(): SubqueryProject {
         },
       },
       dataSources: [],
-    } as any,
+    } as any),
     '',
   );
   return project;

--- a/packages/node/src/indexer/fetch.service.spec.ts
+++ b/packages/node/src/indexer/fetch.service.spec.ts
@@ -157,14 +157,19 @@ function mockDictionaryService3(): DictionaryService {
 }
 
 function testSubqueryProject(): SubqueryProject {
-  const project = new SubqueryProject();
-  project.network = {
-    endpoint: 'wss://polkadot.api.onfinality.io/public-ws',
-    types: {
-      TestType: 'u32',
-    },
-  };
-  project.dataSources = [];
+  const project = new SubqueryProject(
+    {
+      specVersion: '0.0.1',
+      network: {
+        endpoint: 'wss://polkadot.api.onfinality.io/public-ws',
+        types: {
+          TestType: 'u32',
+        },
+      },
+      dataSources: [],
+    } as any,
+    '',
+  );
   return project;
 }
 
@@ -253,7 +258,7 @@ describe('FetchService', () => {
     const project = testSubqueryProject();
     project.network.dictionary =
       'https://api.subquery.network/sq/subquery/dictionary-polkadot';
-    project.dataSources = [
+    project.projectManifest.asV0_0_1.dataSources = [
       {
         name: 'runtime',
         kind: SubqlKind.Runtime,
@@ -315,7 +320,7 @@ describe('FetchService', () => {
     const project = testSubqueryProject();
     project.network.dictionary =
       'https://api.subquery.network/sq/subquery/dictionary-polkadot';
-    project.dataSources = [
+    project.projectManifest.asV0_0_1.dataSources = [
       {
         name: 'runtime',
         kind: SubqlKind.Runtime,
@@ -376,7 +381,7 @@ describe('FetchService', () => {
     const project = testSubqueryProject();
     project.network.dictionary =
       'https://api.subquery.network/sq/subquery/dictionary-polkadot';
-    project.dataSources = [
+    project.projectManifest.asV0_0_1.dataSources = [
       {
         name: 'runtime',
         kind: SubqlKind.Runtime,
@@ -431,7 +436,7 @@ describe('FetchService', () => {
     const project = testSubqueryProject();
     project.network.dictionary =
       'https://api.subquery.network/sq/subquery/dictionary-polkadot';
-    project.dataSources = [
+    project.projectManifest.asV0_0_1.dataSources = [
       {
         name: 'runtime',
         kind: SubqlKind.Runtime,

--- a/packages/node/src/indexer/fetch.service.test.ts
+++ b/packages/node/src/indexer/fetch.service.test.ts
@@ -10,23 +10,28 @@ import { DictionaryService } from './dictionary.service';
 import { FetchService } from './fetch.service';
 
 function testSubqueryProject(): SubqueryProject {
-  const project = new SubqueryProject();
-  project.network = {
-    endpoint: 'wss://polkadot.api.onfinality.io/public-ws',
-    types: {
-      TestType: 'u32',
-    },
-  };
-  project.dataSources = [
+  const project = new SubqueryProject(
     {
-      name: 'runtime',
-      kind: SubqlKind.Runtime,
-      startBlock: 1,
-      mapping: {
-        handlers: [{ handler: 'handleTest', kind: SubqlKind.EventHandler }],
+      specVersion: '0.0.1',
+      network: {
+        endpoint: 'wss://polkadot.api.onfinality.io/public-ws',
+        types: {
+          TestType: 'u32',
+        },
       },
-    },
-  ];
+      dataSources: [
+        {
+          name: 'runtime',
+          kind: SubqlKind.Runtime,
+          startBlock: 1,
+          mapping: {
+            handlers: [{ handler: 'handleTest', kind: SubqlKind.EventHandler }],
+          },
+        },
+      ],
+    } as any,
+    '',
+  );
   return project;
 }
 
@@ -103,7 +108,7 @@ describe('FetchService', () => {
     const apiService = new ApiService(project, new EventEmitter2());
     await apiService.init();
     //filter is defined
-    project.dataSources = [
+    project.projectManifest.asV0_0_1.dataSources = [
       {
         name: 'runtime',
         kind: SubqlKind.Runtime,
@@ -193,7 +198,7 @@ describe('FetchService', () => {
     //set dictionary to a different network
     project.network.dictionary =
       'https://api.subquery.network/sq/subquery/dictionary-polkadot';
-    project.dataSources = [
+    project.projectManifest.asV0_0_1.dataSources = [
       {
         name: 'runtime',
         kind: SubqlKind.Runtime,
@@ -246,7 +251,7 @@ describe('FetchService', () => {
     //set dictionary to a different network
     project.network.dictionary =
       'https://api.subquery.network/sq/subquery/dictionary-polkadot';
-    project.dataSources = [
+    project.projectManifest.asV0_0_1.dataSources = [
       {
         name: 'runtime',
         kind: SubqlKind.Runtime,
@@ -309,7 +314,7 @@ describe('FetchService', () => {
     project.network.endpoint = 'wss://kusama.api.onfinality.io/public-ws';
     project.network.dictionary =
       'https://api.subquery.network/sq/subquery/dictionary-polkadot';
-    project.dataSources = [
+    project.projectManifest.asV0_0_1.dataSources = [
       {
         name: 'runtime',
         kind: SubqlKind.Runtime,

--- a/packages/node/src/indexer/fetch.service.test.ts
+++ b/packages/node/src/indexer/fetch.service.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { SubqlKind } from '@subql/common';
+import { ProjectManifestVersioned, SubqlKind } from '@subql/common';
 import { NodeConfig } from '../configure/NodeConfig';
 import { SubqueryProject } from '../configure/project.model';
 import { ApiService } from './api.service';
@@ -11,7 +11,7 @@ import { FetchService } from './fetch.service';
 
 function testSubqueryProject(): SubqueryProject {
   const project = new SubqueryProject(
-    {
+    new ProjectManifestVersioned({
       specVersion: '0.0.1',
       network: {
         endpoint: 'wss://polkadot.api.onfinality.io/public-ws',
@@ -29,7 +29,7 @@ function testSubqueryProject(): SubqueryProject {
           },
         },
       ],
-    } as any,
+    } as any),
     '',
   );
   return project;

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -16,6 +16,7 @@
     "/dist"
   ],
   "dependencies": {
+    "@subql/common": "workspace:*",
     "axios": "^0.21.1",
     "js-yaml": "^4.1.0",
     "package-json-type": "^1.0.3"

--- a/packages/validator/src/rules/index.ts
+++ b/packages/validator/src/rules/index.ts
@@ -5,3 +5,4 @@ export * from './rule';
 export * from './require-build-script';
 export * from './require-codegen-script';
 export * from './require-cli-dep';
+export * from './require-valid-manifest';

--- a/packages/validator/src/rules/require-valid-manifest.ts
+++ b/packages/validator/src/rules/require-valid-manifest.ts
@@ -1,0 +1,21 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {plainToProjectManifest, validateProjectManifest} from '@subql/common/project';
+import {Context} from '../context';
+import {Rule, RuleType} from './rule';
+
+export class RequireValidManifest implements Rule {
+  type = RuleType.Schema;
+  name: 'require-valid-manifest';
+  description: '`project.yaml` must match the schema';
+
+  validate(ctx: Context): boolean {
+    const schema = ctx.data.schema;
+
+    const manifest = plainToProjectManifest(schema);
+    const errors = validateProjectManifest(manifest);
+
+    return !errors.length;
+  }
+}

--- a/packages/validator/src/rules/require-valid-manifest.ts
+++ b/packages/validator/src/rules/require-valid-manifest.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {validateProjectManifest} from '@subql/common/project';
+import {ProjectManifestVersioned, VersionedProjectManifest} from '@subql/common';
 import {Context} from '../context';
 import {Rule, RuleType} from './rule';
 
@@ -14,7 +14,8 @@ export class RequireValidManifest implements Rule {
     const schema = ctx.data.schema;
 
     try {
-      validateProjectManifest(schema, ['0.0.1']);
+      const project = new ProjectManifestVersioned(schema as VersionedProjectManifest);
+      project.validate();
       return true;
     } catch (e) {
       return false;

--- a/packages/validator/src/rules/require-valid-manifest.ts
+++ b/packages/validator/src/rules/require-valid-manifest.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {plainToProjectManifest, validateProjectManifest} from '@subql/common/project';
+import {validateProjectManifest} from '@subql/common/project';
 import {Context} from '../context';
 import {Rule, RuleType} from './rule';
 
@@ -13,9 +13,11 @@ export class RequireValidManifest implements Rule {
   validate(ctx: Context): boolean {
     const schema = ctx.data.schema;
 
-    const manifest = plainToProjectManifest(schema);
-    const errors = validateProjectManifest(manifest);
-
-    return !errors.length;
+    try {
+      validateProjectManifest(schema, ['0.0.1']);
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 }

--- a/packages/validator/src/rules/rule.ts
+++ b/packages/validator/src/rules/rule.ts
@@ -5,6 +5,7 @@ import {Context} from '../context';
 import {RequireBuildScript} from './require-build-script';
 import {RequireCliDep} from './require-cli-dep';
 import {RequireCodegenScript} from './require-codegen-script';
+import {RequireValidManifest} from './require-valid-manifest';
 
 export enum RuleType {
   PackageJSON = 'packageJSON',
@@ -19,4 +20,9 @@ export interface Rule {
   validate(ctx: Context): boolean;
 }
 
-export const commonRules: Rule[] = [new RequireBuildScript(), new RequireCodegenScript(), new RequireCliDep()];
+export const commonRules: Rule[] = [
+  new RequireBuildScript(),
+  new RequireCodegenScript(),
+  new RequireCliDep(),
+  new RequireValidManifest(),
+];

--- a/packages/validator/src/validator.spec.ts
+++ b/packages/validator/src/validator.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {commonRules, RequireBuildScript, RequireCliDep, RequireCodegenScript} from './rules';
+import {commonRules} from './rules';
 import {Validator} from './validator';
 
 describe('Validator', () => {
@@ -15,8 +15,8 @@ describe('Validator', () => {
 
   it('should validate get reports', async () => {
     const result = await v.getValidateReports();
-    expect(result.length).toBe(5);
-    expect(result.filter((r) => r.valid).length).toBe(5);
+    expect(result.length).toBe(6);
+    expect(result.filter((r) => r.valid).length).toBe(6);
   });
 
   it('should return validate result', async () => {

--- a/packages/validator/tsconfig.json
+++ b/packages/validator/tsconfig.json
@@ -5,5 +5,8 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    {"path": "../common"},
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4602,6 +4602,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subql/validator@workspace:packages/validator"
   dependencies:
+    "@subql/common": "workspace:*"
     "@types/js-yaml": ^4.0.1
     axios: ^0.21.1
     js-yaml: ^4.1.0


### PR DESCRIPTION
Addresses https://github.com/subquery/subql/issues/348

Also adds project manifest validation to cli `validate` command.

Version `0.0.1` of the project manifest is still the only supported version.