### PR TITLE
Expand on cli `init` capabilities

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @subql/cli
 $ subql COMMAND
 running command...
 $ subql (-v|--version|version)
-@subql/cli/0.12.1-0 linux-x64 node-v14.17.6
+@subql/cli/0.12.1-0 darwin-x64 node-v14.15.1
 $ subql --help [COMMAND]
 USAGE
   $ subql COMMAND
@@ -63,6 +63,7 @@ USAGE
 
 OPTIONS
   -f, --force
+  -l, --location=location  local folder to run codegen in
   --file=file
 ```
 
@@ -98,6 +99,9 @@ ARGUMENTS
 
 OPTIONS
   -f, --force
+  -l, --location=location  local folder to create the project in
+  --install-dependencies   Install dependencies as well
+  --npm                    Force using NPM instead of yarn, only works with `install-dependencies` flag
   --starter
 ```
 

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import path from 'path';
 import {Command, flags} from '@oclif/command';
 import {codegen} from '../controller/codegen-controller';
 
@@ -10,14 +11,18 @@ export default class Codegen extends Command {
   static flags = {
     force: flags.boolean({char: 'f'}),
     file: flags.string(),
+    location: flags.string({char: 'l', description: 'local folder to run codegen in'}),
   };
 
   async run(): Promise<void> {
+    const {flags} = this.parse(Codegen);
     this.log('===============================');
     this.log('---------Subql Codegen---------');
     this.log('===============================');
+
+    const location = flags.location ? path.resolve(flags.location) : process.cwd();
     try {
-      await codegen(process.cwd());
+      await codegen(location);
     } catch (err) {
       console.error(err.message);
       process.exit(1);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -17,8 +17,8 @@ export default class Init extends Command {
       default: true,
     }),
     location: flags.string({char: 'l', description: 'local folder to create the project in'}),
-    'skip-install': flags.boolean({description: 'Skip installing dependencies'}),
-    npm: flags.boolean({description: 'Force using NPM instead of yarn'}),
+    'install-dependencies': flags.boolean({description: 'Install dependencies as well', default: false}),
+    npm: flags.boolean({description: 'Force using NPM instead of yarn, only works with `install-dependencies` flag'}),
   };
 
   static args = [
@@ -56,7 +56,7 @@ export default class Init extends Command {
         const projectPath = await createProject(location, project);
         cli.action.stop();
 
-        if (!flags['skip-install']) {
+        if (flags['install-dependencies']) {
           cli.action.start('Installing dependencies');
           installDependencies(projectPath, flags.npm);
           cli.action.stop();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -7,7 +7,6 @@ import {Command, flags} from '@oclif/command';
 import cli from 'cli-ux';
 import {createProject, installDependencies} from '../controller/init-controller';
 import {ProjectSpec} from '../types';
-import Codegen from './codegen';
 
 export default class Init extends Command {
   static description = 'Init a scaffold subquery project';
@@ -19,7 +18,6 @@ export default class Init extends Command {
     }),
     location: flags.string({char: 'l', description: 'local folder to create the project in'}),
     'skip-install': flags.boolean({description: 'Skip installing dependencies'}),
-    'skip-codegen': flags.boolean({description: 'Skip graphql codegen'}),
     npm: flags.boolean({description: 'Force using NPM instead of yarn'}),
   };
 
@@ -61,12 +59,6 @@ export default class Init extends Command {
         if (!flags['skip-install']) {
           cli.action.start('Installing dependencies');
           installDependencies(projectPath, flags.npm);
-          cli.action.stop();
-        }
-
-        if (!flags['skip-codegen']) {
-          cli.action.start('Generating graphql code');
-          await Codegen.run(['-l', projectPath]);
           cli.action.stop();
         }
 


### PR DESCRIPTION
Changes:

- Install dependencies by default when init a project, can be skipped through `--skip-install`
- ~~Run `codegen` when init a project, can be skipped through `--skip-codegen`~~
- Add the ability to specify a directory to init project in, same applies to `codegen` command