### PR TITLE
Allow pass error stack limit

### DIFF
--- a/packages/common/src/logger/logger.ts
+++ b/packages/common/src/logger/logger.ts
@@ -23,7 +23,7 @@ export class Logger {
   private pino: Pino.Logger;
   private childLoggers: {[category: string]: Pino.Logger} = {};
 
-  constructor({level: logLevel = 'info', nestedKey, outputFormat, stackSize = 5}: LoggerOption) {
+  constructor({level: logLevel = 'info', nestedKey, outputFormat, stackSize}: LoggerOption) {
     this.pino = Pino({
       messageKey: 'message',
       timestamp: () => `,"timestamp":"${new Date().toISOString()}"`,
@@ -43,7 +43,7 @@ export class Logger {
                     type: 'error',
                     name: value.name,
                     message: value.message,
-                    stack: limitStack(value.stack, stackSize),
+                    stack: stackSize ? limitStack(value.stack, stackSize) : value.stack,
                   };
                 } else {
                   return stringify(value);

--- a/packages/common/src/logger/logger.ts
+++ b/packages/common/src/logger/logger.ts
@@ -14,7 +14,7 @@ export interface LoggerOption {
 
 function limitStack(stack: string, configSize: number): string {
   const stackArray = stack.split(/\r\n|\r|\n/);
-  const reduceSize = Math.min(stackArray.length, configSize) + 1; //one additional line for error message
+  const reduceSize = Math.min(stackArray.length, configSize);
   stackArray.splice(reduceSize);
   return stackArray.join('\n');
 }

--- a/packages/node/src/utils/logger.ts
+++ b/packages/node/src/utils/logger.ts
@@ -9,7 +9,7 @@ import { argv } from '../yargs';
 const outputFmt = argv('output-fmt') as 'json' | 'colored';
 const debug = argv('debug');
 const logLevel = argv('log-level') as string | undefined;
-const errorStackSize = argv('error-stack-size') as number | undefined;
+const errorStackSize = argv('error-stack-size') as number;
 
 const logger = new Logger({
   level: debug ? 'debug' : logLevel,

--- a/packages/node/src/utils/logger.ts
+++ b/packages/node/src/utils/logger.ts
@@ -9,11 +9,13 @@ import { argv } from '../yargs';
 const outputFmt = argv('output-fmt') as 'json' | 'colored';
 const debug = argv('debug');
 const logLevel = argv('log-level') as string | undefined;
+const errorStackSize = argv('error-stack-size') as number | undefined;
 
 const logger = new Logger({
   level: debug ? 'debug' : logLevel,
   outputFormat: outputFmt,
   nestedKey: 'payload',
+  stackSize: errorStackSize,
 });
 
 export function getLogger(category: string): Pino.Logger {

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -74,6 +74,7 @@ export function getYargsOption() {
       demandOption: false,
       describe: 'Specify error stack size to be printed',
       type: 'number',
+      default: 10,
     },
     migrate: {
       demandOption: false,

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -70,6 +70,11 @@ export function getYargsOption() {
       type: 'string',
       choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
     },
+    'error-stack-size': {
+      demandOption: false,
+      describe: 'Specify error stack size to be printed',
+      type: 'number',
+    },
     migrate: {
       demandOption: false,
       describe: 'Migrate db schema (for management tables only)',


### PR DESCRIPTION
Closes #491 

When logger output-fmt is json, default error stack size now is 5, can be specify by `error-stack-size`.
