### PR TITLE
modify release workflow and add release action

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,0 +1,29 @@
+# Composite action needed to access github context
+
+name: 'Create Release'
+description: 'This will publish to NPM registry and create Github release'
+inputs:
+  package-path: # id of input
+    description: 'package path to run action e.g. package/common'
+    required: true
+  repo-token:
+    description: 'token to create github release'
+    required: true
+  npm-token:
+    description: 'token to push to npm registry'
+    required: true
+  
+runs:
+  using: "composite"
+  steps:
+    - working-directory: ${{ inputs.package-path }}
+      run: echo "Changes exist in cli" && npm publish --access public 
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      shell: bash
+
+    - working-directory: ${{ github.workspace }}
+      run: node ${{ github.action_path }}/gh-release-script.js ${{ github.workspace }}/${{ inputs.package-path }}
+      env: 
+        REPO_TOKEN: ${{ inputs.repo-token }}
+      shell: bash

--- a/.github/actions/create-release/gh-release-script.js
+++ b/.github/actions/create-release/gh-release-script.js
@@ -1,0 +1,80 @@
+const fs = require('fs');
+const { exit } = require('process');
+const core = require('@actions/core');
+const { request } = require('@octokit/request');
+
+const myArgs = process.argv.slice(2);
+
+const pJson = require(`${myArgs[0]}/package.json`)
+
+const version = pJson.version;
+const repoName = pJson.name; 
+
+function checkForBetaVersion(version) {
+    if (version.includes('-')){
+        exit(0); //skip this package but continue trying to release others
+    }
+}
+
+function gatherReleaseInfo(logPath) {
+    const changeLogs = fs.readFileSync(logPath, 'utf8');
+    const regex = /## \[([0-9]+(\.[0-9]+)+)] - [0-9]{4}-[0-9]{2}-[0-9]{2}/i;
+    
+    let lines = changeLogs.split(/\n/);
+    let releaseInfo = '';
+    let i = 0;
+
+    for(let j = 0; j < lines.length; j++){
+       if(lines[j].includes(`[${version}]`)){
+           i = j;
+           j = lines.length;
+       } 
+    }
+
+    lines = lines.slice(i);
+    
+    for(let j = 0; j < lines.length; j++){
+        if(j == 0){
+           releaseInfo += `${lines[j]}`+ '\n';
+           continue;
+        }        
+
+        if(!regex.test(lines[j])){
+            releaseInfo += `${lines[j]}`+ '\n';
+        } else {
+            j = lines.length;
+        }
+    }
+    
+    if(releaseInfo === ''){
+        core.setFailed("No release info found, either missing in changelog or changelog is formatted incorrectly")
+    }
+
+    console.log("Gathered release info...")  
+    return releaseInfo;
+}
+
+async function publishRelease(releaseInfo) {
+    const repoTagName = repoName.split('/');
+
+    await request('POST /repos/{owner}/{repo}/releases', {
+        headers: {
+            authorization: `token ${process.env.REPO_TOKEN}`,
+        },
+        owner: 'subquery',
+        name: `[${version}] ${repoName}`,
+        repo: 'subql',
+        tag_name: `${repoTagName[1]}/${version}`,
+        body: releaseInfo
+    }).catch( err => {
+        core.setFailed(err)
+    })
+
+    console.log("Release Created...")  
+}
+
+checkForBetaVersion(version);
+
+const releaseInfo = gatherReleaseInfo(`./packages/common/CHANGELOG.md`);
+
+publishRelease(releaseInfo);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,45 +71,43 @@ jobs:
       - name: build
         run: yarn workspaces foreach run build
 
-        #Publish to npm
-      - name: Publish Common
+      #Publish to npm and github releases
+      - name: Publish Common 
         if: steps.changed-common.outputs.changed == 'true'
-        working-directory: packages/common
-        run: echo "Changes exist in common" && yarn npm publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: ./.github/actions/create-release
+        with:
+          package-path: packages/common
+          repo-token: ${{ secrets.REPO_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN}}
 
       - name: Publish Cli
         if: steps.changed-cli.outputs.changed == 'true'
-        working-directory: packages/cli
-        run: echo "Changes exist in cli" && yarn npm publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+        uses: ./.github/actions/create-release
+        with:
+          package-path: packages/cli
+          repo-token: ${{ secrets.REPO_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN}}
+      
       - name: Publish Types
         if: steps.changed-types.outputs.changed == 'true'
-        working-directory: packages/types
-        run: echo "Changes exist in types" && yarn npm publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+        uses: ./.github/actions/create-release
+        with:
+          package-path: packages/types
+          repo-token: ${{ secrets.REPO_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN}}
+     
       - name: Publish Node
         if: steps.changed-node.outputs.changed == 'true'
-        working-directory: packages/node
-        run: echo "Changes exist in node" && yarn npm publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish Query
-        if: steps.changed-query.outputs.changed == 'true'
-        working-directory: packages/query
-        run: echo "Changes exist in query" && yarn npm publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: ./.github/actions/create-release
+        with:
+          package-path: packages/node
+          repo-token: ${{ secrets.REPO_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN}}
 
       - name: Publish Validator
         if: steps.changed-validator.outputs.changed == 'true'
-        working-directory: packages/validator
-        run: echo "Changes exist in validator" && yarn npm publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: ./.github/actions/create-release
+        with:
+          package-path: packages/validator
+          repo-token: ${{ secrets.REPO_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN}}


### PR DESCRIPTION
- I've created a seperate composite action, because otherwise I couldn't access certain variables I needed 
   e.g `${{ github.action_path }}` and it is actually quite readable.

- It could be possible to add `marceloprado/has-changed-path@v1` into the composite action but it is too difficult at
   the moment.