### PR TITLE
add information to changelogs, remove contract-processors from workflow

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -32,11 +32,6 @@ jobs:
 
       - uses: ./.github/actions/create-release
         with:
-          package-path: packages/contract-processors
-          repo-token: ${{ secrets.REPO_TOKEN }}
-
-      - uses: ./.github/actions/create-release
-        with:
           package-path: packages/node
           repo-token: ${{ secrets.REPO_TOKEN }}
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
+All notable changes to this project will be documented in this file.
 
-- All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
-  and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+All logs must start with the format: [x.y.z] - yyyy-mm-dd
 
 ## [Unreleased]
 
@@ -82,7 +83,7 @@
 - subql init doesn' need --starter by default (#86)
 - model template use bigint instead of BigInt (#82)
 
-## 0.2.0 - 2020-12-22
+## [0.2.0] - 2020-12-22
 ### Changed
 - support subcommand codegen
 - support subcommand init

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+All logs must start with the format: [x.y.z] - yyyy-mm-dd
+
 ## [Unreleased]
 
 ## [0.11.0] - 2021-10-12
@@ -60,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - bump dependencies (#148)
 
-## 0.6.0 - 2021-01-27
+## [0.6.0] - 2021-01-27
 ### Fixed
 - pin class-transfermer to 0.3.1 (#116)
 
@@ -77,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - support callHandler and eventHandler (#47)
 
-## 0.2.0 - 2020-12-22
+## [0.2.0] - 2020-12-22
 ### Added
 - init commit
 

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
+All notable changes to this project will be documented in this file.
 
-- All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-  and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+All logs must start with the format: [x.y.z] - yyyy-mm-dd
 
 ## [Unreleased]
 ### Added
@@ -298,7 +299,7 @@ Upgrade priority: High.
 ### Added
 - support callHandler and eventHandler (#47)
 
-## 0.2.0 - 2020-12-22
+## [0.2.0] - 2020-12-22
 ### Added
 - support block handler
 - put subquery tables in their own db schema

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+All logs must start with the format: [x.y.z] - yyyy-mm-dd
+
 ## [Unreleased]
 
 ## [0.7.3] - 2021-09-25
@@ -56,7 +58,7 @@ Upgrade priority: High. This fix the entities name conflict issue, for users who
 - refactor logger: support --output-fmt and --log-level (#220)
 - use read db host (DB_HOST_READ from env) as priority (#221)
 
-## 0.2.0 - 2021-02-05
+## [0.2.0] - 2021-02-05
 ### Added
 - init query service project
 - customise first/last plugin to give max record to query (#114)

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-- All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file.
 
-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-  and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+All logs must start with the format: [x.y.z] - yyyy-mm-dd
 
 ## [Unreleased]
 
@@ -58,7 +60,7 @@
 ### Added
 - support callHandler and eventHandler (#47)
 
-## 0.2.0 - 2020-12-22
+## [0.2.0] - 2020-12-22
 ### Added
 - support block handler
 

--- a/packages/validator/CHANGELOG.md
+++ b/packages/validator/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-- All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file.
 
-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-  and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+All logs must start with the format: [x.y.z] - yyyy-mm-dd
 
 ## [Unreleased]
 


### PR DESCRIPTION
- add small guiding information to changelogs 
- remove contract-processors from github release workflow