### PR TITLE
Improve types of entity create function

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "eslint --cache --fix",
       "prettier --write"
     ],
-    "packages/**/*.!(*ts)": [
+    "packages/**/*.!(*ejs|ts)": [
       "prettier --write"
     ]
   }

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -59,7 +59,7 @@ describe('Cli publish', () => {
 
   afterEach(() => {
     try {
-      promisify(rimraf)(projectDir);
+      await promisify(rimraf)(projectDir);
     } catch (e) {
       console.warn('Failed to clean up tmp dir after test');
     }

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -46,7 +46,7 @@ async function createTestProject(projectSpec: ProjectSpecBase): Promise<string> 
   await createProject(tmpdir, projectSpec);
 
   // Install dependencies
-  childProcess.execSync('npm i', {cwd: projectDir});
+  childProcess.execSync(`npm i`, {cwd: projectDir});
 
   await Codegen.run(['-l', projectDir]);
   await Build.run(['-l', projectDir]);
@@ -58,7 +58,11 @@ describe('Cli publish', () => {
   let projectDir: string;
 
   afterEach(() => {
-    promisify(rimraf)(projectDir);
+    try {
+      promisify(rimraf)(projectDir);
+    } catch (e) {
+      console.warn('Failed to clean up tmp dir after test');
+    }
   });
 
   it('should not allow uploading a v0.0.1 spec version project', async () => {

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -54,6 +54,7 @@ export class <%= props.className %> implements Entity {
 <% }); %>
 
     static create(record: Partial<Omit<<%=props.className %>, FunctionPropertyNames<<%=props.className %>>>> & Entity): <%=props.className %> {
+        assert(typeof record.id === 'string', "id must be provided");
         let entity = new <%=props.className %>(record.id);
         Object.assign(entity,record);
         return entity;

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -1,5 +1,5 @@
 // Auto-generated , DO NOT EDIT
-import {Entity} from "@subql/types";
+import {Entity, FunctionPropertyNames} from "@subql/types";
 import assert from 'assert';
 <%if (props.importJsonInterfaces.length !== 0) { %>
 import {<% props.importJsonInterfaces.forEach(function(interface){ %>
@@ -53,7 +53,7 @@ export class <%= props.className %> implements Entity {
     }
 <% }); %>
 
-    static create(record){
+    static create(record: Partial<Omit<<%=props.className %>, FunctionPropertyNames<<%=props.className %>>>> & Entity): <%=props.className %> {
         let entity = new <%=props.className %>(record.id);
         Object.assign(entity,record);
         return entity;

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -7,6 +7,10 @@ export interface Entity {
   id: string;
 }
 
+export type FunctionPropertyNames<T> = {
+  [K in keyof T]: T[K] extends Function ? K : never;
+}[keyof T];
+
 export interface Store {
   get(entity: string, id: string): Promise<Entity | null>;
   getByField(entity: string, field: string, value): Promise<Entity[]>;


### PR DESCRIPTION
Better type checking of the `create` function on entities.
- Requires an `id`
- Only allows properties of the entity and with the correct type
- Returns explicit type

Before:

```ts
static create(record) {
        let entity = new Project(record.id);
        Object.assign(entity,record);
        return entity;
}
```

After:

```ts
static create(record: Partial<Omit<Project, FunctionPropertyNames<Project>>> & Entity): Project {
        let entity = new Project(record.id);
        Object.assign(entity,record);
        return entity;
}
```