### PR TITLE
Create processorOptions on custom ds

### DIFF
--- a/packages/common/src/project/models.ts
+++ b/packages/common/src/project/models.ts
@@ -174,8 +174,9 @@ export class FileReferenceImpl implements FileReference {
 export class CustomDataSourceBase<
   K extends string,
   T extends SubqlNetworkFilter,
-  M extends SubqlMapping = SubqlMapping<SubqlCustomHandler>
-> implements SubqlCustomDatasource<K, T, M>
+  M extends SubqlMapping = SubqlMapping<SubqlCustomHandler>,
+  O = any
+> implements SubqlCustomDatasource<K, T, M, O>
 {
   @IsString()
   kind: K;
@@ -195,9 +196,6 @@ export class CustomDataSourceBase<
   @IsObject()
   filter?: T;
   @IsOptional()
-  @IsString()
-  abi: string;
-  @IsOptional()
-  @IsEthereumAddress()
-  address: string;
+  @IsObject()
+  processorOptions?: O;
 }

--- a/packages/common/src/project/models.ts
+++ b/packages/common/src/project/models.ts
@@ -171,6 +171,12 @@ export class FileReferenceImpl implements FileReference {
   file: string;
 }
 
+export class Processor<O = any> extends FileReferenceImpl {
+  @IsOptional()
+  @IsObject()
+  options?: O;
+}
+
 export class CustomDataSourceBase<
   K extends string,
   T extends SubqlNetworkFilter,
@@ -195,7 +201,4 @@ export class CustomDataSourceBase<
   @IsOptional()
   @IsObject()
   filter?: T;
-  @IsOptional()
-  @IsObject()
-  processorOptions?: O;
 }

--- a/packages/contract-processors/src/moonbeam.spec.ts
+++ b/packages/contract-processors/src/moonbeam.spec.ts
@@ -205,7 +205,7 @@ describe('MoonbeamDs', () => {
 
       it('filters just a non-matching address', () => {
         expect(
-          processor.filterProcessor({}, log, {processorOptions: {address: '0x00'}} as MoonbeamDatasource)
+          processor.filterProcessor({}, log, {processor: {options: {address: '0x00'}}} as MoonbeamDatasource)
         ).toBeFalsy();
       });
 
@@ -345,12 +345,12 @@ describe('MoonbeamDs', () => {
       it('can filter contract address', () => {
         expect(
           processor.filterProcessor({}, transaction, {
-            processorOptions: {address: '0xAA30eF758139ae4a7f798112902Bf6d65612045f'},
+            processor: {options: {address: '0xAA30eF758139ae4a7f798112902Bf6d65612045f'}},
           } as MoonbeamDatasource)
         ).toBeTruthy();
         expect(
           processor.filterProcessor({}, transaction, {
-            processorOptions: {address: '0x0000000000000000000000000000000000000000'},
+            processor: {options: {address: '0x0000000000000000000000000000000000000000'}},
           } as MoonbeamDatasource)
         ).toBeFalsy();
       });
@@ -361,7 +361,7 @@ describe('MoonbeamDs', () => {
 
         const contractTx = extrinsics[4];
         expect(
-          processor.filterProcessor({}, contractTx, {processorOptions: {address: null}} as MoonbeamDatasource)
+          processor.filterProcessor({}, contractTx, {processor: {options: {address: null}}} as MoonbeamDatasource)
         ).toBeTruthy();
       }, 40000);
 
@@ -401,9 +401,11 @@ describe('MoonbeamDs', () => {
     const baseDS: MoonbeamDatasource = {
       kind: 'substrate/Moonbeam',
       assets: new Map([['erc20', {file: erc20MiniAbi}]]),
-      processor: {file: ''},
-      processorOptions: {
-        abi: 'erc20',
+      processor: {
+        file: '',
+        options: {
+          abi: 'erc20',
+        },
       },
       mapping: {
         handlers: [

--- a/packages/contract-processors/src/moonbeam.spec.ts
+++ b/packages/contract-processors/src/moonbeam.spec.ts
@@ -3,7 +3,7 @@
 
 import {ApiPromise, WsProvider} from '@polkadot/api';
 import {fetchBlocks} from '@subql/node/src/utils/substrate';
-import {SubqlCustomDatasource, SubstrateEvent, SubstrateExtrinsic} from '@subql/types';
+import {SubstrateEvent, SubstrateExtrinsic} from '@subql/types';
 import {typesBundle} from 'moonbeam-types-bundle';
 import MoonbeamDatasourcePlugin, {MoonbeamCall, MoonbeamDatasource, MoonbeamEvent} from './moonbeam';
 
@@ -198,13 +198,15 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {address: '0x6bd193ee6d2104f14f94e2ca6efefae561a4334b'},
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
       });
 
       it('filters just a non-matching address', () => {
-        expect(processor.filterProcessor({}, log, {address: '0x00'} as SubqlCustomDatasource)).toBeFalsy();
+        expect(
+          processor.filterProcessor({}, log, {processorOptions: {address: '0x00'}} as MoonbeamDatasource)
+        ).toBeFalsy();
       });
 
       it('filters topics matching 1', () => {
@@ -212,7 +214,7 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {topics: ['0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef']},
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
       });
@@ -222,7 +224,7 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {topics: [null, null, '0x000000000000000000000000f884c8774b09b3302f98e38c944eb352264024f8']},
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
       });
@@ -238,7 +240,7 @@ describe('MoonbeamDs', () => {
               ],
             },
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
       });
@@ -248,7 +250,7 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {topics: [['0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef', '0x00']]},
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
       });
@@ -258,7 +260,7 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {topics: [['Transfer(address indexed from, address indexed to, uint256 value)']]},
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
 
@@ -266,16 +268,12 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {topics: [['Transfer(address from, address to, uint256 value)']]},
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
 
         expect(
-          processor.filterProcessor(
-            {topics: [['Transfer(address, address, uint256)']]},
-            log,
-            {} as SubqlCustomDatasource
-          )
+          processor.filterProcessor({topics: [['Transfer(address, address, uint256)']]}, log, {} as MoonbeamDatasource)
         ).toBeTruthy();
       });
 
@@ -284,7 +282,7 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {topics: ['0x6bd193ee6d2104f14f94e2ca6efefae561a4334b']},
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeFalsy();
       });
@@ -300,7 +298,7 @@ describe('MoonbeamDs', () => {
               ],
             },
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeFalsy();
       });
@@ -310,7 +308,7 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {topics: [null, null, '0xf884c8774b09b3302f98e38c944eb352264024f8']},
             log,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
       });
@@ -332,14 +330,14 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {from: '0x0a3f21A6B1B93f15F0d9Dbf0685e3dFdC4889EB0'},
             transaction,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
         expect(
           processor.filterProcessor(
             {from: '0x0000000000000000000000000000000000000000'},
             transaction,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeFalsy();
       });
@@ -347,13 +345,13 @@ describe('MoonbeamDs', () => {
       it('can filter contract address', () => {
         expect(
           processor.filterProcessor({}, transaction, {
-            address: '0xAA30eF758139ae4a7f798112902Bf6d65612045f',
-          } as SubqlCustomDatasource)
+            processorOptions: {address: '0xAA30eF758139ae4a7f798112902Bf6d65612045f'},
+          } as MoonbeamDatasource)
         ).toBeTruthy();
         expect(
           processor.filterProcessor({}, transaction, {
-            address: '0x0000000000000000000000000000000000000000',
-          } as SubqlCustomDatasource)
+            processorOptions: {address: '0x0000000000000000000000000000000000000000'},
+          } as MoonbeamDatasource)
         ).toBeFalsy();
       });
 
@@ -362,7 +360,9 @@ describe('MoonbeamDs', () => {
         const [{extrinsics}] = await fetchBlocks(api, blockNumber, blockNumber);
 
         const contractTx = extrinsics[4];
-        expect(processor.filterProcessor({}, contractTx, {address: null} as SubqlCustomDatasource)).toBeTruthy();
+        expect(
+          processor.filterProcessor({}, contractTx, {processorOptions: {address: null}} as MoonbeamDatasource)
+        ).toBeTruthy();
       }, 40000);
 
       it('can filter function with signature', () => {
@@ -370,14 +370,14 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {function: 'swapExactETHForTokens(uint256 amountOutMin, address[] path, address to, uint256 deadline)'},
             transaction,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
         expect(
           processor.filterProcessor(
             {function: 'swapExactETHForTokens(uint256, address[], address, uint256)'},
             transaction,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
       });
@@ -387,16 +387,12 @@ describe('MoonbeamDs', () => {
           processor.filterProcessor(
             {function: '0x7ff36ab500000000000000000000000000000000000000000000000000000000'},
             transaction,
-            {} as SubqlCustomDatasource
+            {} as MoonbeamDatasource
           )
         ).toBeTruthy();
-        expect(
-          processor.filterProcessor({function: '0x7ff36ab5'}, transaction, {} as SubqlCustomDatasource)
-        ).toBeTruthy();
+        expect(processor.filterProcessor({function: '0x7ff36ab5'}, transaction, {} as MoonbeamDatasource)).toBeTruthy();
 
-        expect(
-          processor.filterProcessor({function: '0x0000000'}, transaction, {} as SubqlCustomDatasource)
-        ).toBeFalsy();
+        expect(processor.filterProcessor({function: '0x0000000'}, transaction, {} as MoonbeamDatasource)).toBeFalsy();
       });
     });
   });
@@ -405,8 +401,10 @@ describe('MoonbeamDs', () => {
     const baseDS: MoonbeamDatasource = {
       kind: 'substrate/Moonbeam',
       assets: new Map([['erc20', {file: erc20MiniAbi}]]),
-      abi: 'erc20',
       processor: {file: ''},
+      processorOptions: {
+        abi: 'erc20',
+      },
       mapping: {
         handlers: [
           {

--- a/packages/contract-processors/src/moonbeam.ts
+++ b/packages/contract-processors/src/moonbeam.ts
@@ -162,7 +162,7 @@ async function getEtheruemBlockHash(api: ApiPromise, blockNumber: number): Promi
 const contractInterfaces: Record<string, Interface> = {};
 
 function buildInterface(ds: MoonbeamDatasource, assets: Record<string, string>): Interface | undefined {
-  const abi = ds.processorOptions.abi;
+  const abi = ds.processor?.options?.abi;
   if (!abi) {
     return;
   }
@@ -237,7 +237,10 @@ const EventProcessor: SecondLayerHandlerProcessor<
     const [eventData] = input.event.data;
     const rawEvent = eventData as EvmLog;
 
-    if (ds.processorOptions?.address && !stringNormalizedEq(ds.processorOptions.address, rawEvent.address.toString())) {
+    if (
+      ds.processor?.options?.address &&
+      !stringNormalizedEq(ds.processor.options.address, rawEvent.address.toString())
+    ) {
       return false;
     }
 
@@ -341,8 +344,8 @@ const CallProcessor: SecondLayerHandlerProcessor<
 
       // if `to` is null then we handle contract creation
       if (
-        (ds.processorOptions?.address && !stringNormalizedEq(ds.processorOptions.address, to)) ||
-        (ds.processorOptions?.address === null && !tx.action.isCreate)
+        (ds.processor?.options?.address && !stringNormalizedEq(ds.processor.options.address, to)) ||
+        (ds.processor?.options?.address === null && !tx.action.isCreate)
       ) {
         return false;
       }
@@ -376,8 +379,8 @@ export const MoonbeamDatasourcePlugin: SubqlDatasourceProcessor<
 > = {
   kind: 'substrate/Moonbeam',
   validate(ds: MoonbeamDatasource, assets: Record<string, string>): void {
-    if (ds.processorOptions) {
-      const opts = plainToClass(MoonbeamProcessorOptions, ds.processorOptions);
+    if (ds.processor.options) {
+      const opts = plainToClass(MoonbeamProcessorOptions, ds.processor.options);
       const errors = validateSync(opts, {whitelist: true, forbidNonWhitelisted: true});
       if (errors?.length) {
         const errorMsgs = errors.map((e) => e.toString()).join('\n');

--- a/packages/contract-processors/src/moonbeam.ts
+++ b/packages/contract-processors/src/moonbeam.ts
@@ -15,6 +15,8 @@ import {
   SubstrateEvent,
   SecondLayerHandlerProcessor,
   SubstrateExtrinsic,
+  SubqlCustomHandler,
+  SubqlMapping,
 } from '@subql/types';
 import {plainToClass} from 'class-transformer';
 import {
@@ -30,7 +32,12 @@ import {eventToTopic, functionToSighash, hexStringEq, stringNormalizedEq} from '
 
 type TopicFilter = string | string[] | null | undefined;
 
-export type MoonbeamDatasource = SubqlCustomDatasource<'substrate/Moonbeam'>;
+export type MoonbeamDatasource = SubqlCustomDatasource<
+  'substrate/Moonbeam',
+  SubqlNetworkFilter,
+  SubqlMapping<SubqlCustomHandler>,
+  MoonbeamProcessorOptions
+>;
 
 export interface MoonbeamEventFilter {
   topics?: [TopicFilter, TopicFilter, TopicFilter, TopicFilter];
@@ -67,6 +74,15 @@ export class TopicFilterValidator implements ValidatorConstraintInterface {
   defaultMessage(): string {
     return 'Value must be either null, undefined, hex string or hex string[]';
   }
+}
+
+class MoonbeamProcessorOptions {
+  @IsOptional()
+  @IsString()
+  abi?: string;
+  @IsOptional()
+  @IsEthereumAddress()
+  address?: string;
 }
 
 class MoonbeamEventFilterImpl implements MoonbeamEventFilter {
@@ -145,35 +161,41 @@ async function getEtheruemBlockHash(api: ApiPromise, blockNumber: number): Promi
 
 const contractInterfaces: Record<string, Interface> = {};
 
-function buildInterface(ds: SubqlCustomDatasource, assets: Record<string, string>): Interface | undefined {
-  if (!ds.abi) {
+function buildInterface(ds: MoonbeamDatasource, assets: Record<string, string>): Interface | undefined {
+  const abi = ds.processorOptions.abi;
+  if (!abi) {
     return;
   }
 
-  if (!ds.assets?.get(ds.abi)) {
-    throw new Error(`ABI named "${ds.abi}" not referenced in assets`);
+  if (!ds.assets?.get(abi)) {
+    throw new Error(`ABI named "${abi}" not referenced in assets`);
   }
 
   // This assumes that all datasources have a different abi name or they are the same abi
-  if (!contractInterfaces[ds.abi]) {
+  if (!contractInterfaces[abi]) {
     // Constructing the interface validates the ABI
     try {
-      contractInterfaces[ds.abi] = new Interface(assets[ds.abi]);
+      contractInterfaces[abi] = new Interface(assets[abi]);
     } catch (e) {
       (global as any).logger.error(`Unable to parse ABI: ${e.message}`);
       throw new Error('ABI is invalid');
     }
   }
 
-  return contractInterfaces[ds.abi];
+  return contractInterfaces[abi];
 }
 
-const EventProcessor: SecondLayerHandlerProcessor<SubqlHandlerKind.Event, MoonbeamEventFilter, MoonbeamEvent> = {
+const EventProcessor: SecondLayerHandlerProcessor<
+  SubqlHandlerKind.Event,
+  MoonbeamEventFilter,
+  MoonbeamEvent,
+  MoonbeamDatasource
+> = {
   baseFilter: [{module: 'evm', method: 'Log'}],
   baseHandlerKind: SubqlHandlerKind.Event,
   async transformer(
     original: SubstrateEvent,
-    ds: SubqlCustomDatasource,
+    ds: MoonbeamDatasource,
     api: ApiPromise,
     assets: Record<string, string>
   ): Promise<MoonbeamEvent> {
@@ -211,11 +233,11 @@ const EventProcessor: SecondLayerHandlerProcessor<SubqlHandlerKind.Event, Moonbe
 
     return log;
   },
-  filterProcessor(filter: MoonbeamEventFilter | undefined, input: SubstrateEvent, ds: SubqlCustomDatasource): boolean {
+  filterProcessor(filter: MoonbeamEventFilter | undefined, input: SubstrateEvent, ds: MoonbeamDatasource): boolean {
     const [eventData] = input.event.data;
     const rawEvent = eventData as EvmLog;
 
-    if (ds.address && !stringNormalizedEq(ds.address, rawEvent.address.toString())) {
+    if (ds.processorOptions?.address && !stringNormalizedEq(ds.processorOptions.address, rawEvent.address.toString())) {
       return false;
     }
 
@@ -248,12 +270,17 @@ const EventProcessor: SecondLayerHandlerProcessor<SubqlHandlerKind.Event, Moonbe
   },
 };
 
-const CallProcessor: SecondLayerHandlerProcessor<SubqlHandlerKind.Call, MoonbeamCallFilter, MoonbeamCall> = {
+const CallProcessor: SecondLayerHandlerProcessor<
+  SubqlHandlerKind.Call,
+  MoonbeamCallFilter,
+  MoonbeamCall,
+  MoonbeamDatasource
+> = {
   baseFilter: [{module: 'ethereum', method: 'transact'}],
   baseHandlerKind: SubqlHandlerKind.Call,
   async transformer(
     original: SubstrateExtrinsic,
-    ds: SubqlCustomDatasource,
+    ds: MoonbeamDatasource,
     api: ApiPromise,
     assets: Record<string, string>
   ): Promise<MoonbeamCall> {
@@ -302,11 +329,7 @@ const CallProcessor: SecondLayerHandlerProcessor<SubqlHandlerKind.Call, Moonbeam
 
     return call;
   },
-  filterProcessor(
-    filter: MoonbeamCallFilter | undefined,
-    input: SubstrateExtrinsic,
-    ds: SubqlCustomDatasource
-  ): boolean {
+  filterProcessor(filter: MoonbeamCallFilter | undefined, input: SubstrateExtrinsic, ds: MoonbeamDatasource): boolean {
     try {
       const {from, to} = getExecutionEvent(input);
 
@@ -317,7 +340,10 @@ const CallProcessor: SecondLayerHandlerProcessor<SubqlHandlerKind.Call, Moonbeam
       const [tx] = input.extrinsic.method.args as [EthTransaction];
 
       // if `to` is null then we handle contract creation
-      if ((ds.address && !stringNormalizedEq(ds.address, to)) || (ds.address === null && !tx.action.isCreate)) {
+      if (
+        (ds.processorOptions?.address && !stringNormalizedEq(ds.processorOptions.address, to)) ||
+        (ds.processorOptions?.address === null && !tx.action.isCreate)
+      ) {
         return false;
       }
 
@@ -343,9 +369,22 @@ const CallProcessor: SecondLayerHandlerProcessor<SubqlHandlerKind.Call, Moonbeam
   },
 };
 
-export const MoonbeamDatasourcePlugin: SubqlDatasourceProcessor<'substrate/Moonbeam', SubqlNetworkFilter> = {
+export const MoonbeamDatasourcePlugin: SubqlDatasourceProcessor<
+  'substrate/Moonbeam',
+  SubqlNetworkFilter,
+  MoonbeamDatasource
+> = {
   kind: 'substrate/Moonbeam',
   validate(ds: MoonbeamDatasource, assets: Record<string, string>): void {
+    if (ds.processorOptions) {
+      const opts = plainToClass(MoonbeamProcessorOptions, ds.processorOptions);
+      const errors = validateSync(opts, {whitelist: true, forbidNonWhitelisted: true});
+      if (errors?.length) {
+        const errorMsgs = errors.map((e) => e.toString()).join('\n');
+        throw new Error(`Invalid Moonbeam call filter.\n${errorMsgs}`);
+      }
+    }
+
     buildInterface(ds, assets); // Will throw if unable to construct
 
     return;

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -122,43 +122,46 @@ export type CustomDataSourceAsset = FileReference;
 export interface SubqlCustomDatasource<
   K extends string = string,
   T extends SubqlNetworkFilter = SubqlNetworkFilter,
-  M extends SubqlMapping = SubqlMapping<SubqlCustomHandler>
+  M extends SubqlMapping = SubqlMapping<SubqlCustomHandler>,
+  O = any
 > extends ISubqlDatasource<M, T> {
   kind: K;
   assets: Map<string, CustomDataSourceAsset>;
   processor: FileReference;
-  abi?: string; // Should be a key of assets
-  address?: string;
-  // [more: string]: unknown;
+  processorOptions?: O;
 }
 
 //export type SubqlBuiltinDataSource = ISubqlDatasource;
 
-export interface HandlerInputTransformer<T extends SubqlHandlerKind, U> {
-  (
-    original: RuntimeHandlerInputMap[T],
-    ds: SubqlCustomDatasource,
-    api: ApiPromise,
-    assets: Record<string, string>
-  ): Promise<U>; //  | SubqlBuiltinDataSource
+export interface HandlerInputTransformer<
+  T extends SubqlHandlerKind,
+  U,
+  DS extends SubqlCustomDatasource = SubqlCustomDatasource
+> {
+  (original: RuntimeHandlerInputMap[T], ds: DS, api: ApiPromise, assets: Record<string, string>): Promise<U>; //  | SubqlBuiltinDataSource
 }
 
-export interface SubqlDatasourceProcessor<K extends string, F extends SubqlNetworkFilter> {
+export interface SubqlDatasourceProcessor<
+  K extends string,
+  F extends SubqlNetworkFilter,
+  DS extends SubqlCustomDatasource<K, F> = SubqlCustomDatasource<K, F>
+> {
   kind: K;
-  validate(ds: SubqlCustomDatasource<K, F>, assets: Record<string, string>): void;
-  dsFilterProcessor(ds: SubqlCustomDatasource<K, F>, api: ApiPromise): boolean;
-  handlerProcessors: {[kind: string]: SecondLayerHandlerProcessor<SubqlHandlerKind, unknown, unknown>};
+  validate(ds: DS, assets: Record<string, string>): void;
+  dsFilterProcessor(ds: DS, api: ApiPromise): boolean;
+  handlerProcessors: {[kind: string]: SecondLayerHandlerProcessor<SubqlHandlerKind, unknown, unknown, DS>};
 }
 
 // only allow one custom handler for each baseHandler kind
-export interface SecondLayerHandlerProcessor<K extends SubqlHandlerKind, F, E> {
+export interface SecondLayerHandlerProcessor<
+  K extends SubqlHandlerKind,
+  F,
+  E,
+  DS extends SubqlCustomDatasource = SubqlCustomDatasource
+> {
   baseHandlerKind: K;
   baseFilter: RuntimeFilterMap[K] | RuntimeFilterMap[K][];
-  transformer: HandlerInputTransformer<K, E>;
-  filterProcessor: (
-    filter: F | undefined,
-    input: RuntimeHandlerInputMap[K],
-    ds: SubqlCustomDatasource<string, SubqlNetworkFilter>
-  ) => boolean;
+  transformer: HandlerInputTransformer<K, E, DS>;
+  filterProcessor: (filter: F | undefined, input: RuntimeHandlerInputMap[K], ds: DS) => boolean;
   filterValidator: (filter: F) => void;
 }

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -119,6 +119,8 @@ export interface FileReference {
 
 export type CustomDataSourceAsset = FileReference;
 
+export type Processor<O = any> = FileReference & {options?: O};
+
 export interface SubqlCustomDatasource<
   K extends string = string,
   T extends SubqlNetworkFilter = SubqlNetworkFilter,
@@ -127,8 +129,7 @@ export interface SubqlCustomDatasource<
 > extends ISubqlDatasource<M, T> {
   kind: K;
   assets: Map<string, CustomDataSourceAsset>;
-  processor: FileReference;
-  processorOptions?: O;
+  processor: Processor<O>;
 }
 
 //export type SubqlBuiltinDataSource = ISubqlDatasource;


### PR DESCRIPTION
- Move abi and address from top level for moonbeam processor
- Add validation for moonbeam processor options
- Improve types


Change:
```diff
dataSources:
  - kind: substrate/Moonbeam
    startBlock: 752073
    processor:
      file: './node_modules/@subql/contract-processors/dist/moonbeam.js'
+     options:
+        abi: erc20
+        address: '0x6bd193ee6d2104f14f94e2ca6efefae561a4334b'
-    abi: erc20
-    address: '0x6bd193ee6d2104f14f94e2ca6efefae561a4334b'
    assets:
      erc20:
        file: './erc20.abi.json'

    mapping:
      file: './dist/index.js'
      handlers:
        - handler: handleMoonriverEvent
          kind: substrate/MoonbeamEvent
```