### PR TITLE
Fix publish failing with custom ds and assets

### DIFF
--- a/packages/cli/src/controller/publish-controller.ts
+++ b/packages/cli/src/controller/publish-controller.ts
@@ -3,13 +3,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import {
-  loadProjectManifest,
-  manifestIsV0_2_0,
-  ProjectManifestV0_0_1Impl,
-  ProjectManifestV0_2_0Impl,
-} from '@subql/common';
-import {SubqlCustomDatasource, SubqlDatasource, SubqlNetworkFilter} from '@subql/types';
+import {loadProjectManifest, manifestIsV0_2_0, ProjectManifestV0_2_0Impl, isCustomDs} from '@subql/common';
 import IPFS from 'ipfs-http-client';
 import yaml from 'js-yaml';
 
@@ -23,10 +17,6 @@ type FileObject = {
   mode?: number | string;
   mtime?: Date | number[] | {secs: number; nsecs?: number};
 };
-
-function isCustomDs<F extends SubqlNetworkFilter>(ds: SubqlDatasource): ds is SubqlCustomDatasource<string, F> {
-  return !!(ds as SubqlCustomDatasource).processor?.file;
-}
 
 export async function uploadToIpfs(ipfsEndpoint: string, projectDir: string): Promise<string> {
   const ipfs = IPFS.create({url: ipfsEndpoint});

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -1,7 +1,15 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {SecondLayerHandlerProcessor, SubqlHandlerKind, SubqlNetworkFilter} from '@subql/types';
+import {
+  SecondLayerHandlerProcessor,
+  SubqlCustomDatasource,
+  SubqlDatasource,
+  SubqlDatasourceKind,
+  SubqlHandlerKind,
+  SubqlNetworkFilter,
+  SubqlRuntimeDatasource,
+} from '@subql/types';
 
 export function isBlockHandlerProcessor<T extends SubqlNetworkFilter, E>(
   hp: SecondLayerHandlerProcessor<SubqlHandlerKind, T, unknown>
@@ -19,4 +27,12 @@ export function isCallHandlerProcessor<T extends SubqlNetworkFilter, E>(
   hp: SecondLayerHandlerProcessor<SubqlHandlerKind, T, unknown>
 ): hp is SecondLayerHandlerProcessor<SubqlHandlerKind.Call, T, E> {
   return hp.baseHandlerKind === SubqlHandlerKind.Call;
+}
+
+export function isCustomDs<F extends SubqlNetworkFilter>(ds: SubqlDatasource): ds is SubqlCustomDatasource<string, F> {
+  return ds.kind !== SubqlDatasourceKind.Runtime && !!(ds as SubqlCustomDatasource<string, F>).processor;
+}
+
+export function isRuntimeDs(ds: SubqlDatasource): ds is SubqlRuntimeDatasource {
+  return ds.kind === SubqlDatasourceKind.Runtime;
 }

--- a/packages/node/src/indexer/ds-processor.service.spec.ts
+++ b/packages/node/src/indexer/ds-processor.service.spec.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import path from 'path';
-import { ProjectManifestVersioned } from '@subql/common';
+import { ProjectManifestVersioned, isCustomDs } from '@subql/common';
 import { SubqlCustomDatasource } from '@subql/types';
 import { SubqueryProject } from '../configure/project.model';
-import { isCustomDs } from '../utils/project';
 import { DsProcessorService } from './ds-processor.service';
 
 function getTestProject(extraDataSources?: SubqlCustomDatasource[]) {

--- a/packages/node/src/indexer/ds-processor.service.ts
+++ b/packages/node/src/indexer/ds-processor.service.ts
@@ -4,6 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import { Injectable } from '@nestjs/common';
+import { isCustomDs } from '@subql/common';
 import {
   SubqlCustomDatasource,
   SubqlDatasourceProcessor,
@@ -12,7 +13,6 @@ import {
 import { VMScript } from '@subql/x-vm2';
 import { SubqueryProject } from '../configure/project.model';
 import { getLogger } from '../utils/logger';
-import { isCustomDs } from '../utils/project';
 import { Sandbox } from './sandbox.service';
 
 export interface DsPluginSandboxOption {

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -8,6 +8,8 @@ import { ApiPromise } from '@polkadot/api';
 import {
   isRuntimeDataSourceV0_2_0,
   RuntimeDataSourceV0_0_1,
+  isCustomDs,
+  isRuntimeDs,
 } from '@subql/common';
 import {
   SubqlCallFilter,
@@ -22,12 +24,7 @@ import { NodeConfig } from '../configure/NodeConfig';
 import { SubqueryProject } from '../configure/project.model';
 import { getLogger } from '../utils/logger';
 import { profiler, profilerWrap } from '../utils/profiler';
-import {
-  isBaseHandler,
-  isCustomDs,
-  isCustomHandler,
-  isRuntimeDs,
-} from '../utils/project';
+import { isBaseHandler, isCustomHandler } from '../utils/project';
 import { delay } from '../utils/promise';
 import * as SubstrateUtil from '../utils/substrate';
 import { getYargsOption } from '../yargs';

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -11,6 +11,8 @@ import {
   isBlockHandlerProcessor,
   isCallHandlerProcessor,
   isEventHandlerProcessor,
+  isCustomDs,
+  isRuntimeDs,
 } from '@subql/common';
 import {
   RuntimeHandlerInputMap,
@@ -28,7 +30,6 @@ import { SubqueryProject } from '../configure/project.model';
 import { SubqueryModel, SubqueryRepo } from '../entities';
 import { getLogger } from '../utils/logger';
 import { profiler } from '../utils/profiler';
-import { isCustomDs, isRuntimeDs } from '../utils/project';
 import * as SubstrateUtil from '../utils/substrate';
 import { getYargsOption } from '../yargs';
 import { ApiService } from './api.service';

--- a/packages/node/src/utils/project.ts
+++ b/packages/node/src/utils/project.ts
@@ -6,14 +6,9 @@ import os from 'os';
 import path from 'path';
 import {
   SubqlRuntimeHandler,
-  SubqlCustomDatasource,
   SubqlCustomHandler,
-  SubqlDatasource,
-  SubqlDatasourceKind,
   SubqlHandler,
   SubqlHandlerKind,
-  SubqlNetworkFilter,
-  SubqlRuntimeDatasource,
 } from '@subql/types';
 import tar from 'tar';
 
@@ -29,19 +24,6 @@ export async function prepareProjectDir(projectPath: string): Promise<string> {
   } else if (stats.isDirectory()) {
     return projectPath;
   }
-}
-
-export function isRuntimeDs(ds: SubqlDatasource): ds is SubqlRuntimeDatasource {
-  return ds.kind === SubqlDatasourceKind.Runtime;
-}
-
-export function isCustomDs<F extends SubqlNetworkFilter>(
-  ds: SubqlDatasource,
-): ds is SubqlCustomDatasource<string, F> {
-  return (
-    ds.kind !== SubqlDatasourceKind.Runtime &&
-    !!(ds as SubqlCustomDatasource<string, F>).processor
-  );
 }
 
 // We cache this to avoid repeated reads from fs

--- a/packages/validator/src/rules/require-custom-ds-validation.ts
+++ b/packages/validator/src/rules/require-custom-ds-validation.ts
@@ -2,13 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import path from 'path';
-import {SubqlCustomDatasource, SubqlDatasource, SubqlDatasourceProcessor, SubqlNetworkFilter} from '@subql/types';
+import {isCustomDs} from '@subql/common';
+import {SubqlDatasourceProcessor, SubqlNetworkFilter} from '@subql/types';
 import {Context} from '../context';
 import {Rule, RuleType} from './rule';
-
-function isCustomDs<F extends SubqlNetworkFilter>(ds: SubqlDatasource): ds is SubqlCustomDatasource<string, F> {
-  return !!(ds as SubqlCustomDatasource).processor?.file;
-}
 
 export class RequireCustomDsValidation implements Rule {
   type = RuleType.Schema;


### PR DESCRIPTION
A parsed project uses a `Map` type for assets because of limitations to class-validator but js-yaml cant dump the map type so we need to convert it to an object