### PR TITLE
Update publish command to handle custom ds

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,8 @@
     "tslib": "^2.3.1",
     "webpack": "^5.61.0",
     "webpack-merge": "^5.8.0",
-    "websocket": "^1.0.34"
+    "websocket": "^1.0.34",
+    "yaml-loader": "^0.6.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.0",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -4,45 +4,9 @@
 import {lstatSync, readFileSync} from 'fs';
 import path from 'path';
 import {Command, flags} from '@oclif/command';
-import webpack from 'webpack';
-import {merge} from 'webpack-merge';
+import cli from 'cli-ux';
+import {runWebpack} from '../controller/build-controller';
 import Validate from './validate';
-
-const getBaseConfig = (dir: string, outputPath: string, development?: boolean): webpack.Configuration => ({
-  target: 'node',
-  mode: development ? 'development' : 'production',
-  entry: path.join(dir, 'src/index.ts'),
-  devtool: development && 'inline-source-map',
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        exclude: /node_modules/,
-        loader: require.resolve('ts-loader'),
-        options: {
-          compilerOptions: {
-            declaration: false,
-          },
-        },
-      },
-      {
-        test: /\.ya?ml$/,
-        use: 'yaml-loader',
-      },
-    ],
-  },
-
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js', '.json'],
-  },
-
-  output: {
-    path: path.dirname(outputPath),
-    filename: path.basename(outputPath),
-    libraryTarget: 'commonjs',
-    clean: true,
-  },
-});
 
 export default class Build extends Command {
   static description = 'Build this SubQuery project code';
@@ -73,32 +37,8 @@ export default class Build extends Command {
     const pjson = JSON.parse(readFileSync(path.join(directory, 'package.json')).toString());
     const outputPath = path.resolve(directory, pjson.main || 'dist/index.js');
 
-    const config = merge(
-      getBaseConfig(directory, outputPath, isDev)
-      // Can allow projects to override webpack config here
-    );
-
-    // Use webpack to build TS code and package into a single file
-    this.log(`Building code${isDev ? ' with development mode' : ''}`);
-    await new Promise((resolve, reject) => {
-      webpack(config).run((error, stats) => {
-        if (error) {
-          reject(error);
-          this.log(error.message);
-          return;
-        }
-
-        if (stats.hasErrors()) {
-          const info = stats.toJson();
-
-          reject(info.errors[0]);
-          this.log(info.errors[0].details);
-          return;
-        }
-
-        this.log('Finished building code');
-        resolve(true);
-      });
-    });
+    cli.action.start('Building and packing code');
+    await runWebpack(path.join(directory, 'src/index.ts'), outputPath, isDev, true);
+    cli.action.stop();
   }
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -25,11 +25,15 @@ const getBaseConfig = (dir: string, outputPath: string, development?: boolean): 
           },
         },
       },
+      {
+        test: /\.ya?ml$/,
+        use: 'yaml-loader',
+      },
     ],
   },
 
   resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
+    extensions: ['.tsx', '.ts', '.js', '.json'],
   },
 
   output: {

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -32,7 +32,7 @@ export default class Publish extends Command {
       this.error('Failed to build project');
     }
 
-    this.log('Uploading SupQuery project to ipfs');
+    this.log('Uploading SupQuery project to IPFS');
     const cid = await uploadToIpfs(flags.ipfs, directory);
 
     this.log(`SubQuery Project uploaded to IPFS: ${cid}`);

--- a/packages/cli/src/controller/build-controller.ts
+++ b/packages/cli/src/controller/build-controller.ts
@@ -1,0 +1,68 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'path';
+import webpack from 'webpack';
+import {merge} from 'webpack-merge';
+
+const getBaseConfig = (entryPath: string, outputPath: string, development?: boolean): webpack.Configuration => ({
+  target: 'node',
+  mode: development ? 'development' : 'production',
+  entry: entryPath,
+  devtool: development && 'inline-source-map',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        exclude: /node_modules/,
+        loader: require.resolve('ts-loader'),
+        options: {
+          compilerOptions: {
+            declaration: false,
+          },
+        },
+      },
+      {
+        test: /\.ya?ml$/,
+        use: 'yaml-loader',
+      },
+    ],
+  },
+
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js', '.json'],
+  },
+
+  output: {
+    path: path.dirname(outputPath),
+    filename: path.basename(outputPath),
+    libraryTarget: 'commonjs',
+  },
+});
+
+export async function runWebpack(entryPath: string, outputPath: string, isDev = false, clean = false): Promise<void> {
+  const config = merge(
+    getBaseConfig(entryPath, outputPath, isDev),
+    {output: {clean}}
+    // Can allow projects to override webpack config here
+  );
+
+  await new Promise((resolve, reject) => {
+    webpack(config).run((error, stats) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      if (stats.hasErrors()) {
+        const info = stats.toJson();
+
+        reject(info.errors[0]);
+        this.log(info.errors[0].details);
+        return;
+      }
+
+      resolve(true);
+    });
+  });
+}

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -65,13 +65,13 @@ describe('Cli publish', () => {
     }
   });
 
-  it.skip('should not allow uploading a v0.0.1 spec version project', async () => {
+  it('should not allow uploading a v0.0.1 spec version project', async () => {
     projectDir = await createTestProject(projectSpecV0_0_1);
 
     await expect(uploadToIpfs(ipfsEndpoint, projectDir)).rejects.toBeDefined();
   });
 
-  it.skip('should upload appropriate files to IPFS', async () => {
+  it('should upload appropriate files to IPFS', async () => {
     projectDir = await createTestProject(projectSpecV0_2_0);
     const cid = await uploadToIpfs(ipfsEndpoint, projectDir);
 

--- a/packages/cli/src/controller/publish-controller.ts
+++ b/packages/cli/src/controller/publish-controller.ts
@@ -4,6 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import {loadProjectManifest, manifestIsV0_2_0, ProjectManifestV0_2_0Impl, isCustomDs} from '@subql/common';
+import {FileReference} from '@subql/types';
 import IPFS from 'ipfs-http-client';
 import yaml from 'js-yaml';
 
@@ -24,29 +25,38 @@ export async function uploadToIpfs(ipfsEndpoint: string, projectDir: string): Pr
   const projectManifestPath = path.resolve(projectDir, 'project.yaml');
   const manifest = loadProjectManifest(projectManifestPath).asImpl;
 
-  if (manifestIsV0_2_0(manifest)) {
-    const entryPaths = manifest.dataSources.map((ds) => ds.mapping.file);
-    const schemaPath = manifest.schema.file;
-
-    // Upload referenced files to IPFS
-    const [schema, ...entryPoints] = await Promise.all(
-      [schemaPath, ...entryPaths].map((filePath) =>
-        uploadFile(ipfs, fs.createReadStream(path.resolve(projectDir, filePath))).then((cid) => `ipfs://${cid}`)
-      )
-    );
-
-    // Update referenced file paths to IPFS cids
-    manifest.schema.file = schema;
-
-    entryPoints.forEach((entryPoint, index) => {
-      manifest.dataSources[index].mapping.file = entryPoint;
-    });
-  } else {
+  if (!manifestIsV0_2_0(manifest)) {
     throw new Error('Unsupported project manifest spec, only 0.2.0 is supported');
   }
 
+  const deployment = await replaceFileReferences(ipfs, projectDir, manifest);
+
   // Upload schema
-  return uploadFile(ipfs, toMinifiedYaml(manifest));
+  return uploadFile(ipfs, toMinifiedYaml(deployment));
+}
+
+/* Recursively finds all FileReferences in an object and replaces the files with IPFS references */
+async function replaceFileReferences<T>(ipfs: IPFS.IPFSHTTPClient, projectDir: string, input: T): Promise<T> {
+  if (Array.isArray(input)) {
+    return (await Promise.all(input.map((val) => replaceFileReferences(ipfs, projectDir, val)))) as T;
+  } else if (typeof input === 'object') {
+    if (input instanceof Map) {
+      input = mapToObject(input) as T;
+    }
+
+    if (isFileReference(input)) {
+      console.log('Replacing file reference', input.file);
+      input.file = await uploadFile(ipfs, fs.createReadStream(path.resolve(projectDir, input.file))).then(
+        (cid) => `ipfs://${cid}`
+      );
+    }
+
+    for (const key in input) {
+      input[key] = await replaceFileReferences(ipfs, projectDir, input[key]);
+    }
+  }
+
+  return input;
 }
 
 async function uploadFile(ipfs: IPFS.IPFSHTTPClient, content: FileObject | FileContent): Promise<string> {
@@ -55,20 +65,7 @@ async function uploadFile(ipfs: IPFS.IPFSHTTPClient, content: FileObject | FileC
 }
 
 function toMinifiedYaml(manifest: ProjectManifestV0_2_0Impl): string {
-  const mx = {
-    ...manifest,
-    dataSources: manifest.dataSources.map((ds) => {
-      if (!isCustomDs(ds)) {
-        return ds;
-      }
-
-      return {
-        ...ds,
-        assets: mapToObject(ds.assets),
-      };
-    }),
-  };
-  return yaml.dump(mx, {
+  return yaml.dump(manifest, {
     sortKeys: true,
     condenseFlow: true,
   });
@@ -82,4 +79,8 @@ function mapToObject(map: Map<string | number, unknown>): Record<string | number
   }
 
   return assetsObj;
+}
+
+function isFileReference(value: any): value is FileReference {
+  return value.file && typeof value.file === 'string';
 }

--- a/packages/cli/src/controller/publish-controller.ts
+++ b/packages/cli/src/controller/publish-controller.ts
@@ -38,7 +38,7 @@ export async function uploadToIpfs(ipfsEndpoint: string, projectDir: string): Pr
 /* Recursively finds all FileReferences in an object and replaces the files with IPFS references */
 async function replaceFileReferences<T>(ipfs: IPFS.IPFSHTTPClient, projectDir: string, input: T): Promise<T> {
   if (Array.isArray(input)) {
-    return (await Promise.all(input.map((val) => replaceFileReferences(ipfs, projectDir, val)))) as T;
+    return (await Promise.all(input.map((val) => replaceFileReferences(ipfs, projectDir, val)))) as unknown as T;
   } else if (typeof input === 'object') {
     if (input instanceof Map) {
       input = mapToObject(input) as T;

--- a/packages/cli/src/controller/publish-controller.ts
+++ b/packages/cli/src/controller/publish-controller.ts
@@ -57,9 +57,12 @@ async function replaceFileReferences<T>(ipfs: IPFS.IPFSHTTPClient, projectDir: s
       );
     }
 
-    for (const key in input) {
-      input[key] = await replaceFileReferences(ipfs, projectDir, input[key]);
-    }
+    const keys = Object.keys(input) as unknown as (keyof T)[];
+    await Promise.all(
+      keys.map(async (key) => {
+        input[key] = await replaceFileReferences(ipfs, projectDir, input[key]);
+      })
+    );
   }
 
   return input;
@@ -95,7 +98,7 @@ const processorCache: Record<string, string> = {};
 
 async function packProcessor(projectDir: string, processorEntry: string): Promise<string> {
   if (!processorCache[processorEntry]) {
-    const output = path.resolve(projectDir, `./dist/${path.basename(processorEntry)}`);
+    const output = path.resolve(projectDir, `./dist/processors/${path.basename(processorEntry)}`);
     await runWebpack(processorEntry, output, false);
 
     processorCache[processorEntry] = output;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5193,6 +5193,7 @@ __metadata:
     webpack: ^5.61.0
     webpack-merge: ^5.8.0
     websocket: ^1.0.34
+    yaml-loader: ^0.6.0
   bin:
     subql: ./bin/run
   languageName: unknown
@@ -26024,7 +26025,17 @@ typescript@4.3.5:
   languageName: node
   linkType: hard
 
-"yaml@npm:^1.10.0":
+"yaml-loader@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "yaml-loader@npm:0.6.0"
+  dependencies:
+    loader-utils: ^1.4.0
+    yaml: ^1.8.3
+  checksum: f3f5c00e531d86ea017259a010e41a5017f5797f4c129129803c5dc9ad8f7c30c913f397924d78421e5fef8ea4c3c899ca35c125b968265ba0c4b08ccdffe0b9
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^1.10.0, yaml@npm:^1.8.3":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 8d72062ea3dbfd8fae3d6ddd5b741c2aeb5835a31b0719bf14fac71dd84adde0829763d6fbac46387309da00af1440194c796da5efc349b0baf9de39d82ae69e


### PR DESCRIPTION
Completes https://github.com/subquery/subql/issues/560

Changes:

- Adds support for importing json/yaml files when using `subql build`
- `subql publish` now looks for any file references (`{ file: './path/to/file' }`)
- `subql publish` will webpack custom ds processors into a single file before uploading to IPFS