### PR TITLE
Fix validating if location param is provided

### DIFF
--- a/packages/validator/src/rules/require-custom-ds-validation.ts
+++ b/packages/validator/src/rules/require-custom-ds-validation.ts
@@ -17,7 +17,7 @@ export class RequireCustomDsValidation implements Rule {
 
     if (schema.isV0_2_0) {
       for (const customDs of schema.dataSources.filter(isCustomDs)) {
-        const processor: SubqlDatasourceProcessor<string, SubqlNetworkFilter> = require(path.join(
+        const processor: SubqlDatasourceProcessor<string, SubqlNetworkFilter> = require(path.resolve(
           ctx.data.projectPath,
           customDs.processor.file
         )).default;


### PR DESCRIPTION
DS processor path was resolved incorrectly and unable to be required if location parameter is provided, this is now fixed