### PR TITLE
Lock down class-transformer version

### DIFF
--- a/packages/contract-processors/package.json
+++ b/packages/contract-processors/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "@subql/types": "workspace:*",
-    "class-transformer": "^0.4.0",
+    "class-transformer": "0.4.0",
     "class-validator": "^0.13.1",
     "ethers": "^5.5.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5370,7 +5370,7 @@ __metadata:
   resolution: "@subql/contract-processors@workspace:packages/contract-processors"
   dependencies:
     "@subql/types": "workspace:*"
-    class-transformer: ^0.4.0
+    class-transformer: 0.4.0
     class-validator: ^0.13.1
     ethers: ^5.5.1
     moonbeam-types-bundle: ^1.2.7
@@ -9705,7 +9705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"class-transformer@npm:0.4.0, class-transformer@npm:^0.4.0":
+"class-transformer@npm:0.4.0":
   version: 0.4.0
   resolution: "class-transformer@npm:0.4.0"
   checksum: 915db337796f6a4d0c2c09bf1c0214eff01e1247836524fdaa170f0c3457f4b5f9ece1068cdb2667e42e01572aa1b08b9995c298f2956d1c8a84884c8d5ea5ff


### PR DESCRIPTION
For some stupid reason `class-transformer` decided to release a breaking change in a minor release. 

https://github.com/typestack/class-transformer/blob/develop/CHANGELOG.md#041-breaking-change---2021-11-20

Locks down the version to match the other packages that use `class-transformer`.


In the mean time adding the below snippet to a projects package.json if they use `@subql/contract-processors` will fix the issue
```
  "resolutions": {
    "class-transformer": "0.4.0"
  }
```