### PR TITLE
Remove subqueries table

### DIFF
--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -150,7 +150,6 @@ function createIndexerManager(project: SubqueryProject): IndexerManager {
   );
   const poiService = new PoiService(nodeConfig, project, sequilize);
   const storeService = new StoreService(sequilize, nodeConfig, poiService);
-  const subqueryRepo = SubqueryFactory(sequilize);
   const mmrService = new MmrService(nodeConfig, project, sequilize);
   const sandboxService = new SandboxService(
     apiService,
@@ -170,7 +169,6 @@ function createIndexerManager(project: SubqueryProject): IndexerManager {
     nodeConfig,
     sandboxService,
     dsPluginService,
-    subqueryRepo,
     eventEmitter,
   );
 }

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -40,7 +40,7 @@ export class StoreService {
   private schema: string;
   private modelsRelations: GraphQLModelsRelationsEnums;
   private poiRepo: PoiRepo;
-  private metaDataRepo: MetadataRepo;
+  metaDataRepo: MetadataRepo;
   private operationStack: StoreOperations;
 
   constructor(

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -18,7 +18,6 @@ import {
   getFkConstraint,
   smartTags,
 } from '../utils/sync-helper';
-import { MetadataFactory, MetadataRepo } from './entities/Metadata.entity';
 import { PoiFactory, PoiRepo, ProofOfIndex } from './entities/Poi.entity';
 import { PoiService } from './poi.service';
 import { StoreOperations } from './StoreOperations';
@@ -219,7 +218,6 @@ export class StoreService {
       this.operationStack = new StoreOperations(this.modelsRelations.models);
     }
   }
-
 
   async setPoi(tx: Transaction, blockPoi: ProofOfIndex): Promise<void> {
     assert(this.poiRepo, `model _poi does not exist`);

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -40,7 +40,6 @@ export class StoreService {
   private schema: string;
   private modelsRelations: GraphQLModelsRelationsEnums;
   private poiRepo: PoiRepo;
-  public metaDataRepo: MetadataRepo;
   private operationStack: StoreOperations;
 
   constructor(
@@ -206,7 +205,6 @@ export class StoreService {
     if (this.config.proofOfIndex) {
       this.poiRepo = PoiFactory(this.sequelize, schema);
     }
-    this.metaDataRepo = MetadataFactory(this.sequelize, schema);
 
     await this.sequelize.sync();
     for (const query of extraQueries) {
@@ -222,20 +220,6 @@ export class StoreService {
     }
   }
 
-  async setMetadata(
-    key: string,
-    value: string | number | boolean,
-  ): Promise<void> {
-    assert(this.metaDataRepo, `model _metadata does not exist`);
-    await this.metaDataRepo.upsert({ key, value });
-  }
-
-  async getMetadata(key: string): Promise<string | number | boolean> {
-    assert(this.metaDataRepo, `model _metadata does not exist`);
-    return await this.metaDataRepo
-      .findOne({ where: { key: key } })
-      .then((res) => res.value);
-  }
 
   async setPoi(tx: Transaction, blockPoi: ProofOfIndex): Promise<void> {
     assert(this.poiRepo, `model _poi does not exist`);

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -40,7 +40,7 @@ export class StoreService {
   private schema: string;
   private modelsRelations: GraphQLModelsRelationsEnums;
   private poiRepo: PoiRepo;
-  metaDataRepo: MetadataRepo;
+  public metaDataRepo: MetadataRepo;
   private operationStack: StoreOperations;
 
   constructor(
@@ -228,6 +228,13 @@ export class StoreService {
   ): Promise<void> {
     assert(this.metaDataRepo, `model _metadata does not exist`);
     await this.metaDataRepo.upsert({ key, value });
+  }
+
+  async getMetadata(key: string): Promise<string | number | boolean> {
+    assert(this.metaDataRepo, `model _metadata does not exist`);
+    return await this.metaDataRepo
+      .findOne({ where: { key: key } })
+      .then((res) => res.value);
   }
 
   async setPoi(tx: Transaction, blockPoi: ProofOfIndex): Promise<void> {

--- a/packages/node/src/meta/health.service.ts
+++ b/packages/node/src/meta/health.service.ts
@@ -47,7 +47,8 @@ export class HealthService {
     }
 
     if (healthy !== this.indexerHealthy) {
-      await this.storeService.setMetadata('indexerHealthy', healthy);
+      // XXX: Just for now!
+      // await this.storeService.setMetadata('indexerHealthy', healthy);
       this.indexerHealthy = healthy;
     }
   }

--- a/packages/node/src/meta/meta.service.ts
+++ b/packages/node/src/meta/meta.service.ts
@@ -56,15 +56,16 @@ export class MetaService {
   @Interval(UPDATE_HEIGHT_INTERVAL)
   async checkHeight() {
     await Promise.all([
-      this.storeService.setMetadata(
-        'lastProcessedHeight',
-        this.lastProcessedHeight,
-      ),
-      this.storeService.setMetadata(
-        'lastProcessedTimestamp',
-        this.lastProcessedTimestamp,
-      ),
-      this.storeService.setMetadata('targetHeight', this.targetHeight),
+      // XXX: just for now!
+      // this.storeService.setMetadata(
+      //   'lastProcessedHeight',
+      //   this.lastProcessedHeight,
+      // ),
+      // this.storeService.setMetadata(
+      //   'lastProcessedTimestamp',
+      //   this.lastProcessedTimestamp,
+      // ),
+      // this.storeService.setMetadata('targetHeight', this.targetHeight),
     ]);
   }
 


### PR DESCRIPTION
Subqueries table is empty on this draft but not completely removed. 
- [ ] Remove the creation of the subqueries table
- [ ] Still support the subqueries table but make sure that a new `_metadata` table is created and seeded for projects that were created before this, basically just transition them so that they are not dependent on it, remove their entry from the subqueries table such that in the end the subqueries table can be deleted because it's just going to be empty and unused
- [ ] Comment back in code that I commented out