### PR TITLE
enable dictionary for custom ds

### DIFF
--- a/packages/contract-processors/src/moonbeam.test.ts
+++ b/packages/contract-processors/src/moonbeam.test.ts
@@ -275,7 +275,7 @@ describe('MoonbeamDs', () => {
         ).toBeTruthy();
 
         expect(
-          processor.filterProcessor({topics: [['Transfer(address, address, uint256)']]}, log, {} as MoonbeamDatasource)
+          processor.filterProcessor({topics: ['Transfer(address, address, uint256)']}, log, {} as MoonbeamDatasource)
         ).toBeTruthy();
       });
 

--- a/packages/contract-processors/src/moonbeam.test.ts
+++ b/packages/contract-processors/src/moonbeam.test.ts
@@ -157,7 +157,7 @@ describe('MoonbeamDs', () => {
         ).not.toThrow();
       });
 
-      it('validates topics with OR option', () => {
+      it.skip('validates topics with OR option', () => {
         expect(() =>
           processor.filterValidator({
             topics: [
@@ -178,7 +178,7 @@ describe('MoonbeamDs', () => {
         expect(() => processor.filterValidator({topics: ['Hello World']})).toThrow();
       });
 
-      it('checks OR topics are valid hex strings', () => {
+      it.skip('checks OR topics are valid hex strings', () => {
         expect(() => processor.filterValidator({topics: [['Hello', 'World']]})).toThrow();
       });
     });
@@ -247,7 +247,7 @@ describe('MoonbeamDs', () => {
         ).toBeTruthy();
       });
 
-      it('filters topics matching 4', () => {
+      it.skip('filters topics matching 4', () => {
         expect(
           processor.filterProcessor(
             {topics: [['0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef', '0x00']]},
@@ -260,7 +260,7 @@ describe('MoonbeamDs', () => {
       it('filters topics matching with event', () => {
         expect(
           processor.filterProcessor(
-            {topics: [['Transfer(address indexed from, address indexed to, uint256 value)']]},
+            {topics: ['Transfer(address indexed from, address indexed to, uint256 value)']},
             log,
             {} as MoonbeamDatasource
           )
@@ -268,7 +268,7 @@ describe('MoonbeamDs', () => {
 
         expect(
           processor.filterProcessor(
-            {topics: [['Transfer(address from, address to, uint256 value)']]},
+            {topics: ['Transfer(address from, address to, uint256 value)']},
             log,
             {} as MoonbeamDatasource
           )

--- a/packages/contract-processors/src/moonbeam.ts
+++ b/packages/contract-processors/src/moonbeam.ts
@@ -52,7 +52,6 @@ export interface MoonbeamCallFilter {
 export type MoonbeamEvent<T extends Result = Result> = Log & {args?: T; blockTimestamp: Date};
 export type MoonbeamCall<T extends Result = Result> = Omit<TransactionResponse, 'wait' | 'confirmations'> & {
   args?: T;
-  function?: string;
   success: boolean;
 };
 

--- a/packages/contract-processors/src/moonbeam.ts
+++ b/packages/contract-processors/src/moonbeam.ts
@@ -7,7 +7,6 @@ import {BigNumber} from '@ethersproject/bignumber';
 import {hexDataSlice} from '@ethersproject/bytes';
 import {ApiPromise} from '@polkadot/api';
 import {EthTransaction, EvmLog, ExitReason} from '@polkadot/types/interfaces';
-import {DictionaryQueryEntry} from '@subql/node/dist/indexer/dictionary.service';
 import {
   SubqlDatasourceProcessor,
   SubqlCustomDatasource,
@@ -18,6 +17,7 @@ import {
   SubstrateExtrinsic,
   SubqlCustomHandler,
   SubqlMapping,
+  DictionaryQueryEntry,
 } from '@subql/types';
 import {plainToClass} from 'class-transformer';
 import {

--- a/packages/contract-processors/src/moonbeam.ts
+++ b/packages/contract-processors/src/moonbeam.ts
@@ -411,7 +411,7 @@ const CallProcessor: SecondLayerHandlerProcessor<
     }
 
     if (filter?.function) {
-      queryEntry.conditions.push({field: 'function', value: functionToSighash(filter.function)});
+      queryEntry.conditions.push({field: 'func', value: functionToSighash(filter.function)});
     }
     return queryEntry;
   },

--- a/packages/contract-processors/src/moonbeam.ts
+++ b/packages/contract-processors/src/moonbeam.ts
@@ -31,7 +31,7 @@ import {
 } from 'class-validator';
 import {eventToTopic, functionToSighash, hexStringEq, stringNormalizedEq} from './utils';
 
-type TopicFilter = string | string[] | null | undefined;
+type TopicFilter = string | null | undefined;
 
 export type MoonbeamDatasource = SubqlCustomDatasource<
   'substrate/Moonbeam',
@@ -59,14 +59,7 @@ export type MoonbeamCall<T extends Result = Result> = Omit<TransactionResponse, 
 export class TopicFilterValidator implements ValidatorConstraintInterface {
   validate(value: TopicFilter): boolean {
     try {
-      return (
-        !value ||
-        (typeof value === 'string'
-          ? !!eventToTopic(value)
-          : Array.isArray(value)
-          ? !!value.map((v) => !eventToTopic(v))
-          : false)
-      );
+      return !value || (typeof value === 'string' ? !!eventToTopic(value) : false);
     } catch (e) {
       return false;
     }
@@ -253,8 +246,7 @@ const EventProcessor: SecondLayerHandlerProcessor<
           continue;
         }
 
-        const topicArr = typeof topic === 'string' ? [topic] : topic;
-        if (!topicArr.find((singleTopic) => hexStringEq(eventToTopic(singleTopic), rawEvent.topics[i].toHex()))) {
+        if (!hexStringEq(eventToTopic(topic), rawEvent.topics[i].toHex())) {
           return false;
         }
       }
@@ -291,10 +283,7 @@ const EventProcessor: SecondLayerHandlerProcessor<
           continue;
         }
         const field = `topics${i}`;
-        const topicArr = typeof topic === 'string' ? [topic] : topic;
-        for (const singleTopic of topicArr) {
-          queryEntry.conditions.push({field, value: eventToTopic(singleTopic)});
-        }
+        queryEntry.conditions.push({field, value: eventToTopic(topic)});
       }
     }
     return queryEntry;

--- a/packages/contract-processors/src/moonbeam.ts
+++ b/packages/contract-processors/src/moonbeam.ts
@@ -29,7 +29,7 @@ import {
   IsEthereumAddress,
   IsString,
 } from 'class-validator';
-import {eventToTopic, functionToSighash, hexStringEq, inputToFunctionSighash, stringNormalizedEq} from './utils';
+import {eventToTopic, functionToSighash, hexStringEq, stringNormalizedEq} from './utils';
 
 type TopicFilter = string | string[] | null | undefined;
 
@@ -337,9 +337,6 @@ const CallProcessor: SecondLayerHandlerProcessor<
       gasLimit: BigNumber.from(rawTx.gasLimit),
       gasPrice: BigNumber.from(rawTx.gasPrice),
       data: rawTx.input,
-      function: contractInterfaces[ds.processor?.options?.abi]
-        ?.getFunction(inputToFunctionSighash(rawTx.input))
-        ?.format('sighash'),
       value: BigNumber.from(rawTx.value),
       chainId: undefined, // TODO
       ...rawTx.signature,
@@ -403,7 +400,7 @@ const CallProcessor: SecondLayerHandlerProcessor<
   },
   dictionaryQuery(filter: MoonbeamCallFilter, ds: MoonbeamDatasource): DictionaryQueryEntry {
     const queryEntry: DictionaryQueryEntry = {
-      entity: 'evmLogs',
+      entity: 'evmTransactions',
       conditions: [],
     };
     if (ds.processor?.options?.address) {

--- a/packages/contract-processors/src/utils.ts
+++ b/packages/contract-processors/src/utils.ts
@@ -4,7 +4,6 @@
 import {EventFragment, FunctionFragment} from '@ethersproject/abi';
 import {isHexString, hexStripZeros, hexDataSlice} from '@ethersproject/bytes';
 import {id} from '@ethersproject/hash';
-import {utils} from 'ethers';
 
 export function stringNormalizedEq(a: string, b: string): boolean {
   return a?.toLowerCase() === b?.toLowerCase();
@@ -30,6 +29,5 @@ export function functionToSighash(input: string): string {
 }
 
 export function inputToFunctionSighash(input: string): string {
-  const bytes = utils.arrayify(input);
-  return utils.hexlify(bytes.slice(0, 4));
+  return hexDataSlice(input, 0, 4);
 }

--- a/packages/contract-processors/src/utils.ts
+++ b/packages/contract-processors/src/utils.ts
@@ -27,7 +27,3 @@ export function functionToSighash(input: string): string {
 
   return hexDataSlice(id(FunctionFragment.fromString(input).format()), 0, 4);
 }
-
-export function inputToFunctionSighash(input: string): string {
-  return hexDataSlice(input, 0, 4);
-}

--- a/packages/contract-processors/src/utils.ts
+++ b/packages/contract-processors/src/utils.ts
@@ -4,6 +4,7 @@
 import {EventFragment, FunctionFragment} from '@ethersproject/abi';
 import {isHexString, hexStripZeros, hexDataSlice} from '@ethersproject/bytes';
 import {id} from '@ethersproject/hash';
+import {utils} from 'ethers';
 
 export function stringNormalizedEq(a: string, b: string): boolean {
   return a?.toLowerCase() === b?.toLowerCase();
@@ -26,4 +27,9 @@ export function functionToSighash(input: string): string {
   if (isHexString(input)) return input;
 
   return hexDataSlice(id(FunctionFragment.fromString(input).format()), 0, 4);
+}
+
+export function inputToFunctionSighash(input: string): string {
+  const bytes = utils.arrayify(input);
+  return utils.hexlify(bytes.slice(0, 4));
 }

--- a/packages/node/src/indexer/dictionary.service.test.ts
+++ b/packages/node/src/indexer/dictionary.service.test.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ProjectManifestVersioned } from '@subql/common';
+import { DictionaryQueryEntry } from '@subql/types';
 import { range } from 'lodash';
 import { SubqueryProject } from '../configure/project.model';
-import { DictionaryQueryEntry, DictionaryService } from './dictionary.service';
+import { DictionaryService } from './dictionary.service';
 
 function testSubqueryProject(): SubqueryProject {
   const project = new SubqueryProject(

--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@apollo/client/core';
 import { Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { buildQuery, GqlNode, GqlQuery, GqlVar, MetaData } from '@subql/common';
+import { DictionaryQueryCondition, DictionaryQueryEntry } from '@subql/types';
 import fetch from 'node-fetch';
 import { SubqueryProject } from '../configure/project.model';
 import { getLogger } from '../utils/logger';
@@ -24,16 +25,6 @@ export type Dictionary = {
 };
 const logger = getLogger('dictionary');
 const { argv } = getYargsOption();
-
-interface DictionaryQueryCondition {
-  field: string;
-  value: string;
-}
-
-export interface DictionaryQueryEntry {
-  entity: string;
-  conditions: DictionaryQueryCondition[];
-}
 
 function extractVar(name: string, cond: DictionaryQueryCondition): GqlVar {
   return {

--- a/packages/node/src/indexer/fetch.service.spec.ts
+++ b/packages/node/src/indexer/fetch.service.spec.ts
@@ -229,6 +229,11 @@ describe('FetchService', () => {
   beforeEach(() => {
     apiService = mockApiService();
     project = testSubqueryProject();
+    (fetchBlocksBatches as jest.Mock).mockImplementation((api, blockArray) =>
+      blockArray.map((height) => ({
+        block: { block: { header: { number: { toNumber: () => height } } } },
+      })),
+    );
   });
 
   it('get finalized head when reconnect', async () => {
@@ -270,11 +275,6 @@ describe('FetchService', () => {
 
   it('loop until shutdown', async () => {
     const batchSize = 20;
-    (fetchBlocksBatches as jest.Mock).mockImplementation((api, blockArray) =>
-      blockArray.map((height) => ({
-        block: { block: { header: { number: { toNumber: () => height } } } },
-      })),
-    );
     const dictionaryService = new DictionaryService(project);
 
     const fetchService = createFetchService(
@@ -561,6 +561,6 @@ describe('FetchService', () => {
     await loopPromise;
 
     expect(baseHandlerFilters).toHaveBeenCalledTimes(1);
-    expect(getDsProcessor).toHaveBeenCalledTimes(2);
+    expect(getDsProcessor).toHaveBeenCalledTimes(3);
   }, 500000);
 });

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -148,6 +148,7 @@ export class FetchService implements OnApplicationShutdown {
         } else {
           filterList = [handler.filter];
         }
+        filterList = filterList.filter((f) => f);
         if (!filterList.length) return [];
         switch (baseHandlerKind) {
           case SubqlHandlerKind.Block:

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -138,8 +138,11 @@ export class FetchService implements OnApplicationShutdown {
         if (isCustomDs(ds)) {
           const processor = plugin.handlerProcessors[handler.kind];
           if (processor.dictionaryQuery) {
-            queryEntries.push(processor.dictionaryQuery(handler.filter));
-            continue;
+            const queryEntry = processor.dictionaryQuery(handler.filter, ds);
+            if (queryEntry) {
+              queryEntries.push(queryEntry);
+              continue;
+            }
           }
           filterList = this.getBaseHandlerFilters<SubqlHandlerFilter>(
             ds,

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -18,6 +18,7 @@ import {
   SubqlHandler,
   SubqlDatasource,
   SubqlHandlerFilter,
+  DictionaryQueryEntry,
 } from '@subql/types';
 import { isUndefined, range, sortBy, uniqBy } from 'lodash';
 import { NodeConfig } from '../configure/NodeConfig';
@@ -30,11 +31,7 @@ import * as SubstrateUtil from '../utils/substrate';
 import { getYargsOption } from '../yargs';
 import { ApiService } from './api.service';
 import { BlockedQueue } from './BlockedQueue';
-import {
-  Dictionary,
-  DictionaryQueryEntry,
-  DictionaryService,
-} from './dictionary.service';
+import { Dictionary, DictionaryService } from './dictionary.service';
 import { DsProcessorService } from './ds-processor.service';
 import { IndexerEvent } from './events';
 import { BlockContent } from './types';

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -3,6 +3,7 @@
 
 import {ApiPromise} from '@polkadot/api';
 import {RegistryTypes} from '@polkadot/types/types';
+import {DictionaryQueryEntry} from '@subql/node/dist/indexer/dictionary.service';
 import {SubstrateBlock, SubstrateEvent, SubstrateExtrinsic} from './interfaces';
 
 export enum SubqlDatasourceKind {
@@ -170,5 +171,5 @@ export interface SecondLayerHandlerProcessor<
   transformer: HandlerInputTransformer<K, E, DS>;
   filterProcessor: (filter: F | undefined, input: RuntimeHandlerInputMap[K], ds: DS) => boolean;
   filterValidator: (filter: F) => void;
-  // dictionaryQuery: (filter: F) => DictionaryQuery;
+  dictionaryQuery: (filter: F) => DictionaryQueryEntry;
 }

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -3,7 +3,6 @@
 
 import {ApiPromise} from '@polkadot/api';
 import {RegistryTypes} from '@polkadot/types/types';
-import {DictionaryQueryEntry} from '@subql/node/dist/indexer/dictionary.service';
 import {SubstrateBlock, SubstrateEvent, SubstrateExtrinsic} from './interfaces';
 
 export enum SubqlDatasourceKind {
@@ -154,10 +153,15 @@ export interface SubqlDatasourceProcessor<
   handlerProcessors: {[kind: string]: SecondLayerHandlerProcessor<SubqlHandlerKind, unknown, unknown, DS>};
 }
 
-// interface DictionaryQuery {
-//   entity: string;
-//   conditions: {field: string; value: string}[];
-// }
+export interface DictionaryQueryCondition {
+  field: string;
+  value: string;
+}
+
+export interface DictionaryQueryEntry {
+  entity: string;
+  conditions: DictionaryQueryCondition[];
+}
 
 // only allow one custom handler for each baseHandler kind
 export interface SecondLayerHandlerProcessor<

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -171,5 +171,5 @@ export interface SecondLayerHandlerProcessor<
   transformer: HandlerInputTransformer<K, E, DS>;
   filterProcessor: (filter: F | undefined, input: RuntimeHandlerInputMap[K], ds: DS) => boolean;
   filterValidator: (filter: F) => void;
-  dictionaryQuery: (filter: F) => DictionaryQueryEntry;
+  dictionaryQuery?: (filter: F, ds: DS) => DictionaryQueryEntry;
 }

--- a/packages/validator/src/readers/github-reader.spec.ts
+++ b/packages/validator/src/readers/github-reader.spec.ts
@@ -8,17 +8,17 @@ describe('GithubReader', () => {
   let reader: Reader;
 
   beforeAll(() => {
-    const key = 'subquery/subql-starter';
+    const key = 'subquery/tutorials-block-timestamp';
     reader = new GithubReader(key);
   });
 
   it('should return the package json object', async () => {
     const data = await reader.getPkg();
-    expect(data.name).toBe('subquery-starter');
+    expect(data.name).toBe('block-timestamp');
   });
 
   it('should return the project schema object', async () => {
     const data: any = await reader.getProjectSchema();
-    expect(data.repository).toBe('https://github.com/subquery/subql-starter');
+    expect(data.repository).toBe('https://github.com/subquery/subql-examples');
   });
 });

--- a/packages/validator/src/validator.spec.ts
+++ b/packages/validator/src/validator.spec.ts
@@ -8,7 +8,7 @@ describe('Validator', () => {
   let v: Validator;
 
   beforeAll(() => {
-    const url = 'https://github.com/subquery/subql-starter';
+    const url = 'https://github.com/subquery/tutorials-block-timestamp';
     v = new Validator(url);
     v.addRule(...commonRules);
   });


### PR DESCRIPTION
Add `dictionaryQuery: (filter: F) => DictionaryQueryEntry;` to ds's SecondLayerHandlerProcessor interface.

Exclude baseFilter if dictionaryQuery is provided.