### PR TITLE
Support block 0

### DIFF
--- a/packages/node/src/configure/project.model.ts
+++ b/packages/node/src/configure/project.model.ts
@@ -41,9 +41,9 @@ export class SubqueryProject {
     this._path = path;
 
     manifest.dataSources?.forEach(function (dataSource) {
-      if (!dataSource.startBlock || dataSource.startBlock < 1) {
-        if (dataSource.startBlock < 1) logger.warn('start block changed to #1');
-        dataSource.startBlock = 1;
+      if (!dataSource.startBlock || dataSource.startBlock < 0) {
+        logger.warn('start block changed to #0');
+        dataSource.startBlock = 0;
       }
     });
   }

--- a/packages/node/src/indexer/ds-processor.service.spec.ts
+++ b/packages/node/src/indexer/ds-processor.service.spec.ts
@@ -22,7 +22,7 @@ function getTestProject(extraDataSources?: SubqlCustomDatasource[]) {
         {
           kind: 'substrate/Jsonfy',
           processor: { file: 'contract-processors/dist/jsonfy.js' },
-          startBlock: 1,
+          startBlock: 0,
           mapping: {
             handlers: [
               { handler: 'testSandbox', kind: 'substrate/JsonfyEvent' },

--- a/packages/node/src/indexer/fetch.service.spec.ts
+++ b/packages/node/src/indexer/fetch.service.spec.ts
@@ -189,7 +189,7 @@ function testSubqueryProjectV0_2_0(): SubqueryProject {
           processor: {
             file: 'contract-processors/dist/jsonfy.js',
           },
-          startBlock: 1,
+          startBlock: 0,
           mapping: {
             handlers: [
               {
@@ -303,7 +303,7 @@ describe('FetchService', () => {
       {
         name: 'runtime',
         kind: SubqlDatasourceKind.Runtime,
-        startBlock: 1,
+        startBlock: 0,
         mapping: {
           handlers: [
             {
@@ -366,7 +366,7 @@ describe('FetchService', () => {
       {
         name: 'runtime',
         kind: SubqlDatasourceKind.Runtime,
-        startBlock: 1,
+        startBlock: 0,
         mapping: {
           handlers: [
             {
@@ -427,7 +427,7 @@ describe('FetchService', () => {
       {
         name: 'runtime',
         kind: SubqlDatasourceKind.Runtime,
-        startBlock: 1,
+        startBlock: 0,
         mapping: {
           handlers: [
             {
@@ -482,7 +482,7 @@ describe('FetchService', () => {
       {
         name: 'runtime',
         kind: SubqlDatasourceKind.Runtime,
-        startBlock: 1,
+        startBlock: 0,
         mapping: {
           handlers: [
             {

--- a/packages/node/src/indexer/fetch.service.test.ts
+++ b/packages/node/src/indexer/fetch.service.test.ts
@@ -25,7 +25,7 @@ function testSubqueryProject(): SubqueryProject {
         {
           name: 'runtime',
           kind: SubqlDatasourceKind.Runtime,
-          startBlock: 1,
+          startBlock: 0,
           mapping: {
             handlers: [{ handler: 'handleTest', kind: SubqlHandlerKind.Event }],
           },
@@ -116,7 +116,7 @@ describe('FetchService', () => {
       {
         name: 'runtime',
         kind: SubqlDatasourceKind.Runtime,
-        startBlock: 1,
+        startBlock: 0,
         mapping: {
           handlers: [
             {
@@ -193,7 +193,7 @@ describe('FetchService', () => {
       {
         name: 'runtime',
         kind: SubqlDatasourceKind.Runtime,
-        startBlock: 1,
+        startBlock: 0,
         mapping: {
           handlers: [
             {
@@ -237,7 +237,7 @@ describe('FetchService', () => {
       {
         name: 'runtime',
         kind: SubqlDatasourceKind.Runtime,
-        startBlock: 1,
+        startBlock: 0,
         mapping: {
           handlers: [
             {
@@ -292,7 +292,7 @@ describe('FetchService', () => {
       {
         name: 'runtime',
         kind: SubqlDatasourceKind.Runtime,
-        startBlock: 1,
+        startBlock: 0,
         mapping: {
           handlers: [
             {

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -258,7 +258,8 @@ export class FetchService implements OnApplicationShutdown {
         : initBlockHeight;
       if (
         this.blockNumberBuffer.freeSize < this.nodeConfig.batchSize ||
-        startBlockHeight > this.latestFinalizedHeight
+        startBlockHeight > this.latestFinalizedHeight ||
+        this.latestFinalizedHeight === 0
       ) {
         await delay(1);
         continue;

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -65,7 +65,7 @@ function testSubqueryProjectV0_0_1(): SubqueryProject {
         {
           name: 'runtime0',
           kind: SubqlDatasourceKind.Runtime,
-          startBlock: 1,
+          startBlock: 0,
           mapping: {
             handlers: [
               { handler: 'testSandbox', kind: SubqlHandlerKind.Event },
@@ -75,7 +75,7 @@ function testSubqueryProjectV0_0_1(): SubqueryProject {
         {
           name: 'runtime1',
           kind: SubqlDatasourceKind.Runtime,
-          startBlock: 1,
+          startBlock: 0,
           mapping: {
             handlers: [
               { handler: 'testSandbox', kind: SubqlHandlerKind.Event },
@@ -102,7 +102,7 @@ function testSubqueryProject(): SubqueryProject {
         {
           name: 'runtime0',
           kind: SubqlDatasourceKind.Runtime,
-          startBlock: 1,
+          startBlock: 0,
           mapping: {
             file: './main.js',
             handlers: [
@@ -113,7 +113,7 @@ function testSubqueryProject(): SubqueryProject {
         {
           name: 'runtime1',
           kind: SubqlDatasourceKind.Runtime,
-          startBlock: 1,
+          startBlock: 0,
           mapping: {
             file: './main.js',
             handlers: [

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -71,10 +71,21 @@ export class IndexerManager {
   async indexBlock(blockContent: BlockContent): Promise<void> {
     const { block, events, extrinsics } = blockContent;
     const blockHeight = block.block.header.number.toNumber();
+
     this.eventEmitter.emit(IndexerEvent.BlockProcessing, {
       height: blockHeight,
       timestamp: Date.now(),
     });
+
+    if (blockHeight === 0) {
+      this.eventEmitter.emit(IndexerEvent.BlockLastProcessed, {
+        height: blockHeight,
+        timestamp: Date.now(),
+      });
+
+      return;
+    }
+
     const tx = await this.sequelize.transaction();
     this.storeService.setTransaction(tx);
 


### PR DESCRIPTION
## Change
Changed default start block to 0, and make indexer just ignore this block since the genesis block data is different format (and don't need to index). This will enable subql-node to run with a fresh substrate node which is started with `--instant-sealing` flag.

## Test
- `yarn test` all passed
- tested locally with `--instant-sealing` mandala node, and subql-node won't crash, just wait there listening to new block, when new block comes in, it will index new blocks.
- tested locally with mandala node that has transactions, still able to index all blocks.