### PR TITLE
Fix indexer for new projects

### DIFF
--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -170,18 +170,16 @@ export class IndexerManager {
     if (lastProcessedHeight !== null) {
       startHeight = Number(lastProcessedHeight.value) + 1;
     } else {
-      const nextBlockHeight = (
-        await this.subqueryRepo.findOne({
-          where: { name: this.nodeConfig.subqueryName },
-        })
-      ).nextBlockHeight;
+      const project = await this.subqueryRepo.findOne({
+        where: { name: this.nodeConfig.subqueryName },
+      });
       assert(
-        nextBlockHeight !== null,
+        project !== null,
         new Error(
           'Invalid project state, unable to find block height to begin indexing at',
         ),
       );
-      startHeight = nextBlockHeight;
+      startHeight = project.nextBlockHeight;
     }
 
     void this.fetchService.startLoop(startHeight).catch((err) => {
@@ -325,6 +323,15 @@ export class IndexerManager {
 
     // blockOffset and genesisHash should only have been created once, never updated.
     // If blockOffset is changed, will require re-index and re-sync poi.
+
+    // Project is new and requries a starting block
+    if (!project && !keyValue.lastProcessedHeight) {
+      await metadataRepo.upsert({
+        key: 'lastProcessedHeight',
+        value: (this.getStartBlockFromDataSources() - 1).toString(),
+      });
+    }
+
     if (!keyValue.blockOffset) {
       const offsetValue = (this.getStartBlockFromDataSources() - 1).toString();
       await metadataRepo.upsert({ key: 'blockOffset', value: offsetValue });


### PR DESCRIPTION
Made a mistake where I forgot to seed the initial `lastProcessedHeight` when creating a new project. Was causing `nextBlockHeight` error