### PR TITLE
fix fetch metadata

### DIFF
--- a/packages/query/src/graphql/plugins/GetMetadataPlugin.ts
+++ b/packages/query/src/graphql/plugins/GetMetadataPlugin.ts
@@ -57,7 +57,7 @@ async function fetchFromTable(pgClient: any, schemaName: string): Promise<MetaDa
   const metadata = {} as MetaData;
   const keys = Object.keys(METADATA_TYPES);
 
-  const {rows} = await pgClient.query(`select key, value from ${schemaName}._metadata WHERE key = ANY ($1)`, [keys]);
+  const {rows} = await pgClient.query(`select key, value from "${schemaName}"._metadata WHERE key = ANY ($1)`, [keys]);
 
   const dbKeyValue = rows.reduce((array: MetaEntry[], curr: MetaEntry) => {
     array[curr.key] = curr.value;


### PR DESCRIPTION
This is a small bug fix as you can't fetch metadata when schemaName contains "-".
Below are logs from postgres when I try to fetch metadata in graphql.

`postgres_1  | 2021-12-11 23:54:41.515 UTC [1513] ERROR:  syntax error at or near "-" at character 29
postgres_1  | 2021-12-11 23:54:41.515 UTC [1513] STATEMENT:  select key, value from subql-starter._metadata WHERE key = ANY ($1)`

