### PR TITLE
fix lastProcessedHeight value representation

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -63,6 +63,5 @@
   "files": [
     "/dist",
     "/bin"
-  ],
-  "stableVersion": "0.25.4-5"
+  ]
 }

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -167,7 +167,7 @@ export class IndexerManager {
     const lastProcessedHeight = await this.metadataRepo.findOne({
       where: { key: 'lastProcessedHeight' },
     });
-    if (lastProcessedHeight.value !== null) {
+    if (lastProcessedHeight !== null && lastProcessedHeight.value !== null) {
       startHeight = Number(lastProcessedHeight.value) + 1;
     } else {
       const project = await this.subqueryRepo.findOne({

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -167,7 +167,7 @@ export class IndexerManager {
     const lastProcessedHeight = await this.metadataRepo.findOne({
       where: { key: 'lastProcessedHeight' },
     });
-    if (lastProcessedHeight !== null) {
+    if (lastProcessedHeight.value !== null) {
       startHeight = Number(lastProcessedHeight.value) + 1;
     } else {
       const project = await this.subqueryRepo.findOne({


### PR DESCRIPTION
- fix lastProcessedHeight value being misrepresented. `lastProcessedHeight` can be non null even when the value itself is null due to sequelize wrapping the query. Use query value directly for true state of value instead of query object. 