### PR TITLE
Deprecate local mode

### DIFF
--- a/packages/node/src/configure/configure.module.ts
+++ b/packages/node/src/configure/configure.module.ts
@@ -68,6 +68,19 @@ export function validDbSchemaName(name: string): boolean {
   }
 }
 
+function warnDeprecations() {
+  const yargsOptions = getYargsOption();
+  const { argv } = yargsOptions;
+  if (argv['subquery-name']) {
+    logger.warn(
+      'Note that argument --subquery-name has been deprecated in favour of --db-schema',
+    );
+  }
+  if (argv.local) {
+    logger.warn('Note that argument --local has been deprecated');
+  }
+}
+
 @Global()
 @Module({})
 export class ConfigureModule {
@@ -85,12 +98,8 @@ export class ConfigureModule {
         yargsOptions.showHelp();
         process.exit(1);
       }
-      if (argv['subquery-name']) {
-        logger.info(
-          'Note that argument --subquery-name has been deprecated in favour of --schema',
-        );
-      }
 
+      warnDeprecations();
       assert(argv.subquery, 'subquery path is missing');
       config = new NodeConfig(defaultSubqueryName(yargsToIConfig(argv)));
     }

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -6,129 +6,134 @@ import yargs from 'yargs/yargs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getYargsOption() {
-  return yargs(hideBin(process.argv)).options({
-    subquery: {
-      alias: 'f',
-      demandOption: false,
-      describe: 'Local path of the subquery project',
-      type: 'string',
-    },
-    'subquery-name': {
-      deprecated: true,
-      demandOption: false,
-      describe: 'Name of the subquery project',
-      type: 'string',
-    },
-    config: {
-      alias: 'c',
-      demandOption: false,
-      describe: 'Specify configuration file',
-      type: 'string',
-    },
-    local: {
-      type: 'boolean',
-      demandOption: false,
-      describe: 'Use local mode',
-    },
-    'force-clean': {
-      type: 'boolean',
-      demandOption: false,
-      describe: 'Force clean the database, dropping project schemas and tables',
-    },
-    'db-schema': {
-      demandOption: false,
-      describe: 'Db schema name of the project',
-      type: 'string',
-    },
-    unsafe: {
-      type: 'boolean',
-      demandOption: false,
-      describe: 'Allows usage of any built-in module within the sandbox',
-    },
-    'batch-size': {
-      demandOption: false,
-      describe: 'Batch size of blocks to fetch in one round',
-      type: 'number',
-    },
-    'scale-batch-size': {
-      type: 'boolean',
-      demandOption: false,
-      describe: 'scale batch size based on memory usage',
-      default: false,
-    },
-    timeout: {
-      demandOption: false,
-      describe: 'Timeout for indexer sandbox to execute the mapping functions',
-      type: 'number',
-    },
-    debug: {
-      demandOption: false,
-      describe:
-        'Show debug information to console output. will forcefully set log level to debug',
-      type: 'boolean',
-      default: false,
-    },
-    profiler: {
-      demandOption: false,
-      describe: 'Show profiler information to console output',
-      type: 'boolean',
-      default: false,
-    },
-    'network-endpoint': {
-      demandOption: false,
-      type: 'string',
-      describe: 'Blockchain network endpoint to connect',
-    },
-    'output-fmt': {
-      demandOption: false,
-      describe: 'Print log as json or plain text',
-      type: 'string',
-      choices: ['json', 'colored'],
-    },
-    'log-level': {
-      demandOption: false,
-      describe: 'Specify log level to print. Ignored when --debug is used',
-      type: 'string',
-      choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
-    },
-    migrate: {
-      demandOption: false,
-      describe: 'Migrate db schema (for management tables only)',
-      type: 'boolean',
-      default: false,
-    },
-    'timestamp-field': {
-      demandOption: false,
-      describe: 'Enable/disable created_at and updated_at in schema',
-      type: 'boolean',
-      default: false,
-    },
-    'network-dictionary': {
-      alias: 'd',
-      demandOption: false,
-      describe: 'Specify the dictionary api for this network',
-      type: 'string',
-    },
-    'mmr-path': {
-      alias: 'm',
-      demandOption: false,
-      describe: 'Local path of the merkle mountain range (.mmr) file',
-      type: 'string',
-    },
-    'proof-of-index': {
-      demandOption: false,
-      describe: 'Enable/disable proof of index',
-      type: 'boolean',
-      default: false,
-    },
-    port: {
-      alias: 'p',
-      demandOption: false,
-      describe: 'The port the service will bind to',
-      type: 'number',
-      default: 3000,
-    },
-  });
+  return yargs(hideBin(process.argv))
+    .options({
+      subquery: {
+        alias: 'f',
+        demandOption: false,
+        describe: 'Local path of the subquery project',
+        type: 'string',
+      },
+      'subquery-name': {
+        deprecated: true,
+        demandOption: false,
+        describe: 'Name of the subquery project',
+        type: 'string',
+      },
+      config: {
+        alias: 'c',
+        demandOption: false,
+        describe: 'Specify configuration file',
+        type: 'string',
+      },
+      local: {
+        deprecated: true,
+        type: 'boolean',
+        demandOption: false,
+        describe: 'Use local mode',
+      },
+      'force-clean': {
+        type: 'boolean',
+        demandOption: false,
+        describe:
+          'Force clean the database, dropping project schemas and tables',
+      },
+      'db-schema': {
+        demandOption: false,
+        describe: 'Db schema name of the project',
+        type: 'string',
+      },
+      unsafe: {
+        type: 'boolean',
+        demandOption: false,
+        describe: 'Allows usage of any built-in module within the sandbox',
+      },
+      'batch-size': {
+        demandOption: false,
+        describe: 'Batch size of blocks to fetch in one round',
+        type: 'number',
+      },
+      'scale-batch-size': {
+        type: 'boolean',
+        demandOption: false,
+        describe: 'scale batch size based on memory usage',
+        default: false,
+      },
+      timeout: {
+        demandOption: false,
+        describe:
+          'Timeout for indexer sandbox to execute the mapping functions',
+        type: 'number',
+      },
+      debug: {
+        demandOption: false,
+        describe:
+          'Show debug information to console output. will forcefully set log level to debug',
+        type: 'boolean',
+        default: false,
+      },
+      profiler: {
+        demandOption: false,
+        describe: 'Show profiler information to console output',
+        type: 'boolean',
+        default: false,
+      },
+      'network-endpoint': {
+        demandOption: false,
+        type: 'string',
+        describe: 'Blockchain network endpoint to connect',
+      },
+      'output-fmt': {
+        demandOption: false,
+        describe: 'Print log as json or plain text',
+        type: 'string',
+        choices: ['json', 'colored'],
+      },
+      'log-level': {
+        demandOption: false,
+        describe: 'Specify log level to print. Ignored when --debug is used',
+        type: 'string',
+        choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
+      },
+      migrate: {
+        demandOption: false,
+        describe: 'Migrate db schema (for management tables only)',
+        type: 'boolean',
+        default: false,
+      },
+      'timestamp-field': {
+        demandOption: false,
+        describe: 'Enable/disable created_at and updated_at in schema',
+        type: 'boolean',
+        default: false,
+      },
+      'network-dictionary': {
+        alias: 'd',
+        demandOption: false,
+        describe: 'Specify the dictionary api for this network',
+        type: 'string',
+      },
+      'mmr-path': {
+        alias: 'm',
+        demandOption: false,
+        describe: 'Local path of the merkle mountain range (.mmr) file',
+        type: 'string',
+      },
+      'proof-of-index': {
+        demandOption: false,
+        describe: 'Enable/disable proof of index',
+        type: 'boolean',
+        default: false,
+      },
+      port: {
+        alias: 'p',
+        demandOption: false,
+        describe: 'The port the service will bind to',
+        type: 'number',
+        default: 3000,
+      },
+    })
+    .strictOptions();
 }
 
 export function argv(arg: string): unknown {


### PR DESCRIPTION
Deprecates local mode with warning. Also adds `strictOptions()` to `getYargsOptions` to early exist when given invalid options. Here is a trace of an invalid option provided:
```
[nodemon] starting `node -r dotenv/config -r tsconfig-paths/register -r ts-node/register src/main.ts --force-clean -f /home/wqsz7xn/Desktop/subql-dictionary --local --fake-opt`
Options:
      --help                Show help                                  [boolean]
      --version             Show version number                        [boolean]
  -f, --subquery            Local path of the subquery project          [string]
      --subquery-name       Name of the subquery project   [deprecated] [string]
  -c, --config              Specify configuration file                  [string]
      --local               Use local mode                [deprecated] [boolean]
      --force-clean         Force clean the database, dropping project schemas
                            and tables                                 [boolean]
      --db-schema           Db schema name of the project               [string]
      --unsafe              Allows usage of any built-in module within the
                            sandbox                                    [boolean]
      --batch-size          Batch size of blocks to fetch in one round  [number]
      --scale-batch-size    scale batch size based on memory usage
                                                      [boolean] [default: false]
      --timeout             Timeout for indexer sandbox to execute the mapping
                            functions                                   [number]
      --debug               Show debug information to console output. will
                            forcefully set log level to debug
                                                      [boolean] [default: false]
      --profiler            Show profiler information to console output
                                                      [boolean] [default: false]
      --network-endpoint    Blockchain network endpoint to connect      [string]
      --output-fmt          Print log as json or plain text
                                           [string] [choices: "json", "colored"]
      --log-level           Specify log level to print. Ignored when --debug is
                            used
          [string] [choices: "fatal", "error", "warn", "info", "debug", "trace",
                                                                       "silent"]
      --migrate             Migrate db schema (for management tables only)
                                                      [boolean] [default: false]
      --timestamp-field     Enable/disable created_at and updated_at in schema
                                                      [boolean] [default: false]
  -d, --network-dictionary  Specify the dictionary api for this network [string]
  -m, --mmr-path            Local path of the merkle mountain range (.mmr) file
                                                                        [string]
      --proof-of-index      Enable/disable proof of index
                                                      [boolean] [default: false]
  -p, --port                The port the service will bind to
                                                        [number] [default: 3000]

Unknown arguments: fake-opt, fakeOpt
```
Todo:
- [x] Deprecate `--local`
- [ ] Remove local mode from each of our starter projects docker images
- [x] Inform folks on discord of the change