### PR TITLE
Ready endpoint

### DIFF
--- a/packages/node/Dockerfile
+++ b/packages/node/Dockerfile
@@ -7,7 +7,7 @@ RUN npm i -g --unsafe-perm @subql/node@${RELEASE_VERSION}
 FROM node:16-alpine
 ENV TZ utc
 
-RUN apk add --no-cache tini git
+RUN apk add --no-cache tini git curl
 COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/lib/node_modules/@subql/node/bin/run"]

--- a/packages/node/src/indexer/events.ts
+++ b/packages/node/src/indexer/events.ts
@@ -13,6 +13,7 @@ export enum IndexerEvent {
   NetworkMetadata = 'network_metadata',
   UsingDictionary = 'using_dictionary',
   SkipDictionary = 'skip_dictionary',
+  Ready = 'ready',
 }
 
 export interface ProcessBlockPayload {

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -227,6 +227,11 @@ export class IndexerManager {
         schema = await this.createProjectSchema();
       }
     }
+
+    this.eventEmitter.emit(IndexerEvent.Ready, {
+      value: true,
+    });
+
     return schema;
   }
 

--- a/packages/node/src/meta/meta.module.ts
+++ b/packages/node/src/meta/meta.module.ts
@@ -12,10 +12,12 @@ import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
 import { MetaController } from './meta.controller';
 import { MetaService } from './meta.service';
+import { ReadyController } from './ready.controller';
+import { ReadyService } from './ready.service';
 
 @Module({
   imports: [PrometheusModule.register(), IndexerModule],
-  controllers: [MetaController, HealthController],
+  controllers: [MetaController, HealthController, ReadyController],
   providers: [
     MetricEventListener,
     makeGaugeProvider({
@@ -60,6 +62,7 @@ import { MetaService } from './meta.service';
     }),
     MetaService,
     HealthService,
+    ReadyService,
   ],
 })
 export class MetaModule {}

--- a/packages/node/src/meta/ready.controller.ts
+++ b/packages/node/src/meta/ready.controller.ts
@@ -1,0 +1,18 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { Controller, Get } from '@nestjs/common';
+import { getLogger } from '../utils/logger';
+import { ReadyService } from './ready.service';
+
+const logger = getLogger('ready');
+
+@Controller('ready')
+export class ReadyController {
+  constructor(private readyService: ReadyService) {}
+
+  @Get()
+  getReady() {
+    return { ready: this.readyService.getReady };
+  }
+}

--- a/packages/node/src/meta/ready.controller.ts
+++ b/packages/node/src/meta/ready.controller.ts
@@ -13,6 +13,6 @@ export class ReadyController {
 
   @Get()
   getReady() {
-    return { ready: this.readyService.getReady };
+    return { ready: this.readyService.ready };
   }
 }

--- a/packages/node/src/meta/ready.service.ts
+++ b/packages/node/src/meta/ready.service.ts
@@ -7,18 +7,18 @@ import { EventPayload, IndexerEvent } from '../indexer/events';
 
 @Injectable()
 export class ReadyService {
-  private ready: boolean;
+  private _ready: boolean;
 
   constructor() {
-    this.ready = false;
+    this._ready = false;
   }
 
   @OnEvent(IndexerEvent.Ready)
   handleReady({ value }: EventPayload<boolean>): void {
-    this.ready = value;
+    this._ready = value;
   }
 
-  get getReady() {
-    return this.ready;
+  get ready() {
+    return this._ready;
   }
 }

--- a/packages/node/src/meta/ready.service.ts
+++ b/packages/node/src/meta/ready.service.ts
@@ -1,0 +1,24 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { EventPayload, IndexerEvent } from '../indexer/events';
+
+@Injectable()
+export class ReadyService {
+  private ready: boolean;
+
+  constructor() {
+    this.ready = false;
+  }
+
+  @OnEvent(IndexerEvent.Ready)
+  handleReady({ value }: EventPayload<boolean>): void {
+    this.ready = value;
+  }
+
+  get getReady() {
+    return this.ready;
+  }
+}


### PR DESCRIPTION
A ready endpoint separate from the health endpoint which indicates that all schemas have been created and the node is ready for the query service to begin indexing against created db schemas. Includes additional docker include of `curl` so that query docker image can get status of endpoint for a healthcheck before starting itself within docker-compose.

Partially implements #726 for functionality

Todo:
- [ ] Modify the starter projects `docker-compose.yml` using the [following healthcheck](https://gist.github.com/wqsz7xn/2afe714f587b9f19c976859ece629e05) to ensure proper timing of starting docker images. This pr should be merged before making this modification though

