### PR TITLE
Display chaintypes error

### DIFF
--- a/packages/node/src/configure/project.model.ts
+++ b/packages/node/src/configure/project.model.ts
@@ -11,6 +11,7 @@ import {
   manifestIsV0_0_1,
   manifestIsV0_2_0,
   loadChainTypes,
+  ChainTypes,
 } from '@subql/common';
 import { SubqlDatasource } from '@subql/types';
 import chalk from 'chalk';
@@ -120,15 +121,18 @@ export class SubqueryProject {
       }
 
       let rawChainTypes: unknown;
+      let parsedChainTypes: ChainTypes;
       try {
         rawChainTypes = loadChainTypes(
           path.join(this._path, impl.network.chaintypes.file),
           this.path,
         );
+        parsedChainTypes = parseChainTypes(rawChainTypes);
       } catch (e) {
-        logger.error(`failed to load chaintypes file, ${e}`);
+        logger.error(`Failed to load chaintypes file, ${e}`);
+        process.exit(1);
       }
-      return parseChainTypes(rawChainTypes);
+      return parsedChainTypes;
     }
   }
 }


### PR DESCRIPTION
Display a swallowed chaintypes error that was only visible from `--debug`. Quick fix for https://github.com/subquery/subql/issues/727. Although doesn't move the validation logic to `ProjectManifestVersioned -> validate()`.

In order to fix this further down the line we should consider adding validation as a prebuild step to the starter project so that invalid chain types result in a build error. Enhancement ticket about that here https://github.com/subquery/subql-starter/issues/38