### PR TITLE
Suggest install git

### DIFF
--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import childProcess from 'child_process';
+import childProcess, {execSync} from 'child_process';
 import fs from 'fs';
 import * as path from 'path';
 import {promisify} from 'util';
@@ -23,7 +23,13 @@ export async function createProject(localPath: string, project: ProjectSpecBase)
   try {
     await simpleGit().clone(STARTER_PATH, projectPath, cloneArgs);
   } catch (e) {
-    throw new Error('Failed to clone starter template from git');
+    let err = 'Failed to clone starter template from git';
+    try {
+      execSync('git --version');
+    } catch (_) {
+      err += ', please install git and ensure that it is available from command line';
+    }
+    throw new Error(err);
   }
   try {
     await prepareManifest(projectPath, project);


### PR DESCRIPTION
`simple-git` has a path dependency on `git`. I just noticed that a [discord user](https://discord.com/channels/796198414798028831/809621232361668609/928011406425604096) had a problem with building a basic problem and thought that the error message could be a bit more helpful beyond saying that it failed to clone the starter project.