### PR TITLE
Detect changed project metadata

### DIFF
--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -342,27 +342,17 @@ export class IndexerManager {
       }
     } else {
       assert(
-        this.project.network === keyValue.genesisHash,
+        this.project.network.genesisHash === keyValue.genesisHash,
         'Specified project manifest genesis hash does not match database stored genesis hash, consider cleaning project schema using --force-clean',
       );
     }
 
     if (keyValue.chain !== chain) {
       await metadataRepo.upsert({ key: 'chain', value: chain });
-    } else {
-      assert(
-        chain === keyValue.chain,
-        'Specified project manifest chain does not match database stored chain, consider cleaning project schema using --force-clean',
-      );
     }
 
     if (keyValue.specName !== specName) {
       await metadataRepo.upsert({ key: 'specName', value: specName });
-    } else {
-      assert(
-        specName === keyValue.chain,
-        'Specified project manifest specName does not match database stored specName, consider cleaning project schema using --force-clean',
-      );
     }
 
     if (keyValue.indexerNodeVersion !== packageVersion) {

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -340,14 +340,29 @@ export class IndexerManager {
       } else {
         await metadataRepo.upsert({ key: 'genesisHash', value: genesisHash });
       }
+    } else {
+      assert(
+        this.project.network === keyValue.genesisHash,
+        'Specified project manifest genesis hash does not match database stored genesis hash, consider cleaning project schema using --force-clean',
+      );
     }
 
     if (keyValue.chain !== chain) {
       await metadataRepo.upsert({ key: 'chain', value: chain });
+    } else {
+      assert(
+        chain === keyValue.chain,
+        'Specified project manifest chain does not match database stored chain, consider cleaning project schema using --force-clean',
+      );
     }
 
     if (keyValue.specName !== specName) {
       await metadataRepo.upsert({ key: 'specName', value: specName });
+    } else {
+      assert(
+        specName === keyValue.chain,
+        'Specified project manifest specName does not match database stored specName, consider cleaning project schema using --force-clean',
+      );
     }
 
     if (keyValue.indexerNodeVersion !== packageVersion) {


### PR DESCRIPTION
Fixes: https://github.com/subquery/subql/issues/731
Unhandled cases where the project has run and has stored metadata. Project then changes manifest entry (genesis hash, spec version or chain) and the project will not detect the changes made and attempt (and fail at) indexing. This pull now creates a detection for these metadata fields and exits the node with an assert. 

 Tested with recreating the scenario in issue linked