### PR TITLE
Row count estimate

### DIFF
--- a/packages/common/src/query/types.ts
+++ b/packages/common/src/query/types.ts
@@ -11,4 +11,5 @@ export type MetaData = {
   indexerHealthy: boolean;
   indexerNodeVersion: string;
   queryNodeVersion: string;
+  rowCountEstimate: string;
 };

--- a/packages/common/src/query/types.ts
+++ b/packages/common/src/query/types.ts
@@ -1,6 +1,11 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+export type TableEstimate = {
+  table: string;
+  estimate: number;
+};
+
 export type MetaData = {
   lastProcessedHeight: number;
   lastProcessedTimestamp: number;
@@ -11,5 +16,5 @@ export type MetaData = {
   indexerHealthy: boolean;
   indexerNodeVersion: string;
   queryNodeVersion: string;
-  rowCountEstimate: string;
+  rowCountEstimate: [TableEstimate];
 };

--- a/packages/node/src/indexer/fetch.service.spec.ts
+++ b/packages/node/src/indexer/fetch.service.spec.ts
@@ -91,6 +91,7 @@ const mockDictionaryRet: Dictionary = {
     indexerHealthy: true,
     indexerNodeVersion: '0.16.1',
     queryNodeVersion: '0.6.0',
+    rowCountEstimate: [{ table: '', estimate: 0 }],
   },
   //simulate after last process height update to 1000
   batchBlocks: [1000],
@@ -107,6 +108,7 @@ const mockDictionaryNoBatches: Dictionary = {
     indexerHealthy: true,
     indexerNodeVersion: '0.16.1',
     queryNodeVersion: '0.6.0',
+    rowCountEstimate: [{ table: '', estimate: 0 }],
   },
   batchBlocks: [],
 };
@@ -122,6 +124,7 @@ const mockDictionaryBatches: Dictionary = {
     indexerHealthy: true,
     indexerNodeVersion: '0.16.1',
     queryNodeVersion: '0.6.0',
+    rowCountEstimate: [{ table: '', estimate: 0 }],
   },
   batchBlocks: [14000, 14200, 14300, 14500, 14600, 14700, 14800, 14900],
 };


### PR DESCRIPTION
Adds a row count estimate to the metadata plugin for query service. Although it uses a custom type rather than a generic json object.
Implements: https://github.com/subquery/subql/issues/734
Example:
```gql
query {
  _metadata {
    rowCountEstimate {
      table,
      estimate
    }
  }
}
```
```
{
  "data": {
    "_metadata": {
      "rowCountEstimate": [
        {
          "table": "starter_entities",
          "estimate": 195220
        },
        {
          "table": "_metadata",
          "estimate": 9
        }
      ]
    }
  }
}
```