### PR TITLE
Fix CI: Revert chaintypes change and move check to API module

### DIFF
--- a/packages/node/src/configure/project.model.ts
+++ b/packages/node/src/configure/project.model.ts
@@ -120,19 +120,12 @@ export class SubqueryProject {
         return;
       }
 
-      let rawChainTypes: unknown;
-      let parsedChainTypes: ChainTypes;
-      try {
-        rawChainTypes = loadChainTypes(
-          path.join(this._path, impl.network.chaintypes.file),
-          this.path,
-        );
-        parsedChainTypes = parseChainTypes(rawChainTypes);
-      } catch (e) {
-        logger.error(`Failed to load chaintypes file, ${e}`);
-        process.exit(1);
-      }
-      return parsedChainTypes;
+      const rawChainTypes = loadChainTypes(
+        path.join(this._path, impl.network.chaintypes.file),
+        this.path,
+      );
+
+      return parseChainTypes(rawChainTypes);
     }
   }
 }

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -36,7 +36,15 @@ export class ApiService implements OnApplicationShutdown {
   }
 
   async init(): Promise<ApiService> {
-    const { chainTypes, network } = this.project;
+    let chainTypes, network;
+    try {
+      chainTypes = this.project.chainTypes;
+      network = this.project.network;
+    } catch (e) {
+      logger.error(e);
+      process.exit(1);
+    }
+
     let provider: WsProvider | HttpProvider;
     let throwOnConnect = false;
     if (network.endpoint.startsWith('ws')) {


### PR DESCRIPTION
Move chaintypes process exit to api module so that jest doesn't die