### PR TITLE
Change node default port

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,6 +19,7 @@
     "bn.js": "4.11.6",
     "class-transformer": "0.4.0",
     "class-validator": "^0.13.1",
+    "detect-port": "^1.3.0",
     "flatted": "^3.2.2",
     "graphql": "^15.7.2",
     "graphql-tag": "^2.12.5",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@types/bn.js": "4.11.6",
+    "@types/detect-port": "^1",
     "@types/js-yaml": "^4.0.4",
     "@types/pino": "^6.3.12"
   }

--- a/packages/common/src/project/utils.spec.ts
+++ b/packages/common/src/project/utils.spec.ts
@@ -1,15 +1,26 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import {createServer} from 'http';
 import {findAvailablePort} from './utils';
 
 describe('Utility', () => {
   describe('findAvailablePorts', () => {
-    it('unbound port', async () => {
-      expect(await findAvailablePort(1337)).toEqual(1337);
+    const port = 1337;
+    it('unbound port with large range', async () => {
+      expect(await findAvailablePort(port)).toEqual(port);
     });
-    it('bound port', async () => {
-      expect(await findAvailablePort(53)).toEqual(null);
+    it('bound port single', async () => {
+      const server = createServer();
+      server.listen(port);
+      expect(await findAvailablePort(port, 0)).toEqual(null);
+      server.close();
+    });
+    it('bound port range partial', async () => {
+      const server = createServer();
+      server.listen(port);
+      expect(await findAvailablePort(1337, 1)).toEqual(port + 1);
+      server.close();
     });
   });
 });

--- a/packages/common/src/project/utils.spec.ts
+++ b/packages/common/src/project/utils.spec.ts
@@ -1,0 +1,15 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {findAvailablePort} from './utils';
+
+describe('Utility', () => {
+  describe('findAvailablePorts', () => {
+    it('unbound port', async () => {
+      expect(await findAvailablePort(1337)).toEqual(1337);
+    });
+    it('bound port', async () => {
+      expect(await findAvailablePort(53)).toEqual(null);
+    });
+  });
+});

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -11,6 +11,8 @@ import {
   SubqlRuntimeDatasource,
 } from '@subql/types';
 
+import detectPort from 'detect-port';
+
 export function isBlockHandlerProcessor<T extends SubqlNetworkFilter, E>(
   hp: SecondLayerHandlerProcessor<SubqlHandlerKind, T, unknown>
 ): hp is SecondLayerHandlerProcessor<SubqlHandlerKind.Block, T, E> {
@@ -35,4 +37,26 @@ export function isCustomDs<F extends SubqlNetworkFilter>(ds: SubqlDatasource): d
 
 export function isRuntimeDs(ds: SubqlDatasource): ds is SubqlRuntimeDatasource {
   return ds.kind === SubqlDatasourceKind.Runtime;
+}
+
+export async function findAvailablePort(startPort: number, range = 10): Promise<number> {
+  for (let p = startPort; p < startPort + range; p++) {
+    const candidatePort = await detectPort(p)
+      .then((_port) => {
+        if (p === _port) {
+          return p;
+        } else {
+          return null;
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+
+    if (candidatePort) {
+      return candidatePort;
+    }
+  }
+
+  return null;
 }

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -41,11 +41,13 @@ export function isRuntimeDs(ds: SubqlDatasource): ds is SubqlRuntimeDatasource {
 
 export async function findAvailablePort(startPort: number, range = 10): Promise<number> {
   for (let port = startPort; port <= startPort + range; port++) {
-    const _port = await detectPort(port).catch(() => {
+    try {
+      const _port = await detectPort(port);
+      if (_port === port) {
+        return port;
+      }
+    } catch (e) {
       return null;
-    });
-    if (_port === port) {
-      return port;
     }
   }
 

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -40,21 +40,12 @@ export function isRuntimeDs(ds: SubqlDatasource): ds is SubqlRuntimeDatasource {
 }
 
 export async function findAvailablePort(startPort: number, range = 10): Promise<number> {
-  for (let p = startPort; p < startPort + range; p++) {
-    const candidatePort = await detectPort(p)
-      .then((_port) => {
-        if (p === _port) {
-          return p;
-        } else {
-          return null;
-        }
-      })
-      .catch((err) => {
-        console.error(err);
-      });
-
-    if (candidatePort) {
-      return candidatePort;
+  for (let port = startPort; port <= startPort + range; port++) {
+    const _port = await detectPort(port).catch(() => {
+      return null;
+    });
+    if (_port === port) {
+      return port;
     }
   }
 

--- a/packages/node/src/main.ts
+++ b/packages/node/src/main.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { NestFactory } from '@nestjs/core';
+import { findAvailablePort } from '@subql/common';
 import { AppModule } from './app.module';
 import { IndexerManager } from './indexer/indexer.manager';
 import { getLogger, NestLogger } from './utils/logger';
@@ -11,7 +12,18 @@ const logger = getLogger('subql-node');
 
 async function bootstrap() {
   const debug = argv('debug');
-  const port = argv('port') as number;
+  const candidatePort = argv('port') as number;
+  const port = await findAvailablePort(candidatePort);
+
+  if (!port) {
+    logger.error(
+      `Unable to find available port (tried ports in range (${candidatePort}..${
+        candidatePort + 10
+      })). Try setting a free port manually by setting the --port flag`,
+    );
+    process.exit(1);
+  }
+
   if (argv('unsafe')) {
     logger.warn(
       'UNSAFE MODE IS ENABLED. This is not recommended for most projects and will not be supported by our hosted service',

--- a/packages/node/src/main.ts
+++ b/packages/node/src/main.ts
@@ -6,25 +6,26 @@ import { findAvailablePort } from '@subql/common';
 import { AppModule } from './app.module';
 import { IndexerManager } from './indexer/indexer.manager';
 import { getLogger, NestLogger } from './utils/logger';
-import { argv } from './yargs';
+import { getYargsOption } from './yargs';
 
+const DEFAULT_PORT = 3001;
 const logger = getLogger('subql-node');
+const { argv } = getYargsOption();
 
 async function bootstrap() {
-  const debug = argv('debug');
-  const candidatePort = argv('port') as number;
-  const port = await findAvailablePort(candidatePort);
+  const debug = argv.debug;
+  const port = (argv.port as number) ?? (await findAvailablePort(DEFAULT_PORT));
 
   if (!port) {
     logger.error(
-      `Unable to find available port (tried ports in range (${candidatePort}..${
-        candidatePort + 10
+      `Unable to find available port (tried ports in range (${port}..${
+        port + 10
       })). Try setting a free port manually by setting the --port flag`,
     );
     process.exit(1);
   }
 
-  if (argv('unsafe')) {
+  if (argv.unsafe) {
     logger.warn(
       'UNSAFE MODE IS ENABLED. This is not recommended for most projects and will not be supported by our hosted service',
     );
@@ -40,9 +41,9 @@ async function bootstrap() {
     await indexerManager.start();
     await app.listen(port);
 
-    logger.info(`node started on port: ${port}`);
+    logger.info(`Node started on port: ${port}`);
   } catch (e) {
-    logger.error(e, 'node failed to start');
+    logger.error(e, 'Node failed to start');
     process.exit(1);
   }
 }

--- a/packages/node/src/main.ts
+++ b/packages/node/src/main.ts
@@ -14,8 +14,13 @@ const { argv } = getYargsOption();
 
 async function bootstrap() {
   const debug = argv.debug;
-  const port = (argv.port as number) ?? (await findAvailablePort(DEFAULT_PORT));
 
+  const validate = (x: any) => {
+    const p = parseInt(x);
+    return isNaN(p) ? null : p;
+  };
+
+  const port = validate(argv.port) ?? (await findAvailablePort(DEFAULT_PORT));
   if (!port) {
     logger.error(
       `Unable to find available port (tried ports in range (${port}..${

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -130,7 +130,7 @@ export function getYargsOption() {
         demandOption: false,
         describe: 'The port the service will bind to',
         type: 'number',
-        default: 3000,
+        default: 3001,
       },
     })
     .strictOptions();

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -6,134 +6,130 @@ import yargs from 'yargs/yargs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getYargsOption() {
-  return yargs(hideBin(process.argv))
-    .options({
-      subquery: {
-        alias: 'f',
-        demandOption: false,
-        describe: 'Local path of the subquery project',
-        type: 'string',
-      },
-      'subquery-name': {
-        deprecated: true,
-        demandOption: false,
-        describe: 'Name of the subquery project',
-        type: 'string',
-      },
-      config: {
-        alias: 'c',
-        demandOption: false,
-        describe: 'Specify configuration file',
-        type: 'string',
-      },
-      local: {
-        deprecated: true,
-        type: 'boolean',
-        demandOption: false,
-        describe: 'Use local mode',
-      },
-      'force-clean': {
-        type: 'boolean',
-        demandOption: false,
-        describe:
-          'Force clean the database, dropping project schemas and tables',
-      },
-      'db-schema': {
-        demandOption: false,
-        describe: 'Db schema name of the project',
-        type: 'string',
-      },
-      unsafe: {
-        type: 'boolean',
-        demandOption: false,
-        describe: 'Allows usage of any built-in module within the sandbox',
-      },
-      'batch-size': {
-        demandOption: false,
-        describe: 'Batch size of blocks to fetch in one round',
-        type: 'number',
-      },
-      'scale-batch-size': {
-        type: 'boolean',
-        demandOption: false,
-        describe: 'scale batch size based on memory usage',
-        default: false,
-      },
-      timeout: {
-        demandOption: false,
-        describe:
-          'Timeout for indexer sandbox to execute the mapping functions',
-        type: 'number',
-      },
-      debug: {
-        demandOption: false,
-        describe:
-          'Show debug information to console output. will forcefully set log level to debug',
-        type: 'boolean',
-        default: false,
-      },
-      profiler: {
-        demandOption: false,
-        describe: 'Show profiler information to console output',
-        type: 'boolean',
-        default: false,
-      },
-      'network-endpoint': {
-        demandOption: false,
-        type: 'string',
-        describe: 'Blockchain network endpoint to connect',
-      },
-      'output-fmt': {
-        demandOption: false,
-        describe: 'Print log as json or plain text',
-        type: 'string',
-        choices: ['json', 'colored'],
-      },
-      'log-level': {
-        demandOption: false,
-        describe: 'Specify log level to print. Ignored when --debug is used',
-        type: 'string',
-        choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
-      },
-      migrate: {
-        demandOption: false,
-        describe: 'Migrate db schema (for management tables only)',
-        type: 'boolean',
-        default: false,
-      },
-      'timestamp-field': {
-        demandOption: false,
-        describe: 'Enable/disable created_at and updated_at in schema',
-        type: 'boolean',
-        default: false,
-      },
-      'network-dictionary': {
-        alias: 'd',
-        demandOption: false,
-        describe: 'Specify the dictionary api for this network',
-        type: 'string',
-      },
-      'mmr-path': {
-        alias: 'm',
-        demandOption: false,
-        describe: 'Local path of the merkle mountain range (.mmr) file',
-        type: 'string',
-      },
-      'proof-of-index': {
-        demandOption: false,
-        describe: 'Enable/disable proof of index',
-        type: 'boolean',
-        default: false,
-      },
-      port: {
-        alias: 'p',
-        demandOption: false,
-        describe: 'The port the service will bind to',
-        type: 'number',
-        default: 3001,
-      },
-    })
-    .strictOptions();
+  return yargs(hideBin(process.argv)).options({
+    subquery: {
+      alias: 'f',
+      demandOption: false,
+      describe: 'Local path of the subquery project',
+      type: 'string',
+    },
+    'subquery-name': {
+      deprecated: true,
+      demandOption: false,
+      describe: 'Name of the subquery project',
+      type: 'string',
+    },
+    config: {
+      alias: 'c',
+      demandOption: false,
+      describe: 'Specify configuration file',
+      type: 'string',
+    },
+    local: {
+      deprecated: true,
+      type: 'boolean',
+      demandOption: false,
+      describe: 'Use local mode',
+    },
+    'force-clean': {
+      type: 'boolean',
+      demandOption: false,
+      describe: 'Force clean the database, dropping project schemas and tables',
+    },
+    'db-schema': {
+      demandOption: false,
+      describe: 'Db schema name of the project',
+      type: 'string',
+    },
+    unsafe: {
+      type: 'boolean',
+      demandOption: false,
+      describe: 'Allows usage of any built-in module within the sandbox',
+    },
+    'batch-size': {
+      demandOption: false,
+      describe: 'Batch size of blocks to fetch in one round',
+      type: 'number',
+    },
+    'scale-batch-size': {
+      type: 'boolean',
+      demandOption: false,
+      describe: 'scale batch size based on memory usage',
+      default: false,
+    },
+    timeout: {
+      demandOption: false,
+      describe: 'Timeout for indexer sandbox to execute the mapping functions',
+      type: 'number',
+    },
+    debug: {
+      demandOption: false,
+      describe:
+        'Show debug information to console output. will forcefully set log level to debug',
+      type: 'boolean',
+      default: false,
+    },
+    profiler: {
+      demandOption: false,
+      describe: 'Show profiler information to console output',
+      type: 'boolean',
+      default: false,
+    },
+    'network-endpoint': {
+      demandOption: false,
+      type: 'string',
+      describe: 'Blockchain network endpoint to connect',
+    },
+    'output-fmt': {
+      demandOption: false,
+      describe: 'Print log as json or plain text',
+      type: 'string',
+      choices: ['json', 'colored'],
+    },
+    'log-level': {
+      demandOption: false,
+      describe: 'Specify log level to print. Ignored when --debug is used',
+      type: 'string',
+      choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
+    },
+    migrate: {
+      demandOption: false,
+      describe: 'Migrate db schema (for management tables only)',
+      type: 'boolean',
+      default: false,
+    },
+    'timestamp-field': {
+      demandOption: false,
+      describe: 'Enable/disable created_at and updated_at in schema',
+      type: 'boolean',
+      default: false,
+    },
+    'network-dictionary': {
+      alias: 'd',
+      demandOption: false,
+      describe: 'Specify the dictionary api for this network',
+      type: 'string',
+    },
+    'mmr-path': {
+      alias: 'm',
+      demandOption: false,
+      describe: 'Local path of the merkle mountain range (.mmr) file',
+      type: 'string',
+    },
+    'proof-of-index': {
+      demandOption: false,
+      describe: 'Enable/disable proof of index',
+      type: 'boolean',
+      default: false,
+    },
+    port: {
+      alias: 'p',
+      demandOption: false,
+      describe: 'The port the service will bind to',
+      type: 'number',
+      default: 3001,
+    },
+  });
 }
 
 export function argv(arg: string): unknown {

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -127,7 +127,6 @@ export function getYargsOption() {
       demandOption: false,
       describe: 'The port the service will bind to',
       type: 'number',
-      default: 3001,
     },
   });
 }

--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -86,10 +86,6 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
       cors: true,
     });
 
-    if (this.config.get('playground')) {
-      logger.info('Started playground at http://localhost:3000');
-    }
-
     return server;
   }
 }

--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -17,6 +17,8 @@ import {getLogger} from '../utils/logger';
 import {plugins} from './plugins';
 import {ProjectService} from './project.service';
 
+const logger = getLogger('express');
+
 @Module({
   providers: [ProjectService],
 })
@@ -71,7 +73,7 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
     });
     app.use(
       ExpressPinoLogger({
-        logger: getLogger('express'),
+        logger: logger,
         autoLogging: {
           ignorePaths: ['/.well-known/apollo/server-health'],
         },
@@ -83,6 +85,10 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
       path: '/',
       cors: true,
     });
+
+    if (this.config.get('playground')) {
+      logger.info('Started playground at http://localhost:3000');
+    }
 
     return server;
   }

--- a/packages/query/src/main.ts
+++ b/packages/query/src/main.ts
@@ -12,5 +12,5 @@ void (async () => {
   const app = await NestFactory.create(AppModule, {
     logger: new NestLogger(),
   });
-  await app.listen(process.env.PORT ?? argv.port);
+  await app.listen(process.env.PORT ?? argv.port ?? 3000);
 })();

--- a/packages/query/src/main.ts
+++ b/packages/query/src/main.ts
@@ -4,10 +4,13 @@
 import {NestFactory} from '@nestjs/core';
 import {AppModule} from './app.module';
 import {NestLogger} from './utils/logger';
+import {getYargsOption} from './yargs';
+
+const {argv} = getYargsOption();
 
 void (async () => {
   const app = await NestFactory.create(AppModule, {
     logger: new NestLogger(),
   });
-  await app.listen(process.env.PORT ?? 3000);
+  await app.listen(process.env.PORT ?? argv.port);
 })();

--- a/packages/query/src/main.ts
+++ b/packages/query/src/main.ts
@@ -7,20 +7,19 @@ import {AppModule} from './app.module';
 import {getLogger, NestLogger} from './utils/logger';
 import {getYargsOption} from './yargs';
 
+const DEFAULT_PORT = 3000;
 const {argv} = getYargsOption();
 
 void (async () => {
   const app = await NestFactory.create(AppModule, {
     logger: new NestLogger(),
   });
-  const candidatePort = parseInt(process.env.PORT) ?? argv.port;
-  const port = await findAvailablePort(candidatePort);
 
+  const port = parseInt(process.env.PORT) ?? argv.port ?? (await findAvailablePort(DEFAULT_PORT));
   if (!port) {
-    const logger = getLogger('configure');
-    logger.error(
-      `Unable to find available port (tried ports in range (${candidatePort}..${
-        candidatePort + 10
+    getLogger('subql-query').error(
+      `Unable to find available port (tried ports in range (${DEFAULT_PORT}..${
+        DEFAULT_PORT + 10
       })). Try setting a free port manually by setting the PORT environment variable or by setting the --port flag`
     );
     process.exit(1);

--- a/packages/query/src/main.ts
+++ b/packages/query/src/main.ts
@@ -15,7 +15,12 @@ void (async () => {
     logger: new NestLogger(),
   });
 
-  const port = parseInt(process.env.PORT) ?? argv.port ?? (await findAvailablePort(DEFAULT_PORT));
+  const validate = (x: any) => {
+    const p = parseInt(x);
+    return isNaN(p) ? null : p;
+  };
+
+  const port = validate(process.env.PORT) ?? validate(argv.port) ?? (await findAvailablePort(DEFAULT_PORT));
   if (!port) {
     getLogger('subql-query').error(
       `Unable to find available port (tried ports in range (${DEFAULT_PORT}..${
@@ -23,6 +28,10 @@ void (async () => {
       })). Try setting a free port manually by setting the PORT environment variable or by setting the --port flag`
     );
     process.exit(1);
+  }
+
+  if (argv.playground) {
+    getLogger('subql-query').info(`Started playground at http://localhost:${port}`);
   }
 
   await app.listen(port);

--- a/packages/query/src/main.ts
+++ b/packages/query/src/main.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {NestFactory} from '@nestjs/core';
+import {findAvailablePort} from '@subql/common';
 import {AppModule} from './app.module';
-import {NestLogger} from './utils/logger';
+import {getLogger, NestLogger} from './utils/logger';
 import {getYargsOption} from './yargs';
 
 const {argv} = getYargsOption();
@@ -12,5 +13,18 @@ void (async () => {
   const app = await NestFactory.create(AppModule, {
     logger: new NestLogger(),
   });
-  await app.listen(process.env.PORT ?? argv.port ?? 3000);
+  const candidatePort = parseInt(process.env.PORT) ?? argv.port;
+  const port = await findAvailablePort(candidatePort);
+
+  if (!port) {
+    const logger = getLogger('configure');
+    logger.error(
+      `Unable to find available port (tried ports in range (${candidatePort}..${
+        candidatePort + 10
+      })). Try setting a free port manually by setting the PORT environment variable or by setting the --port flag`
+    );
+    process.exit(1);
+  }
+
+  await app.listen(port);
 })();

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -59,7 +59,6 @@ export function getYargsOption() {
       demandOption: false,
       describe: 'The port the service will bind to',
       type: 'number',
-      default: 3000,
     },
   });
 }

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -7,54 +7,63 @@ import yargs from 'yargs/yargs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getYargsOption() {
-  return yargs(hideBin(process.argv)).options({
-    name: {
-      demandOption: true,
-      alias: 'n',
-      describe: 'Project name',
-      type: 'string',
-    },
-    playground: {
-      demandOption: false,
-      describe: 'Enable graphql playground',
-      type: 'boolean',
-    },
-    'output-fmt': {
-      demandOption: false,
-      describe: 'Print log as json or plain text',
-      type: 'string',
-      default: 'colored',
-      choices: ['json', 'colored'],
-    },
-    'log-level': {
-      demandOption: false,
-      describe: 'Specify log level to print.',
-      type: 'string',
-      default: 'info',
-      choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
-    },
-    'log-path': {
-      demandOption: false,
-      describe: 'Path to create log file e.g ./src/name.log',
-      type: 'string',
-    },
-    'log-rotate': {
-      demandOption: false,
-      describe: 'Rotate log files in directory specified by log-path',
-      type: 'boolean',
-      default: false,
-    },
-    indexer: {
-      demandOption: false,
-      describe: 'Url that allows query to access indexer metadata',
-      type: 'string',
-    },
-    unsafe: {
-      demandOption: false,
-      describe: 'Disable limits on query depth and allowable number returned query records',
-      type: 'boolean',
-    },
-  });
+  return yargs(hideBin(process.argv))
+    .options({
+      name: {
+        demandOption: true,
+        alias: 'n',
+        describe: 'Project name',
+        type: 'string',
+      },
+      playground: {
+        demandOption: false,
+        describe: 'Enable graphql playground',
+        type: 'boolean',
+      },
+      'output-fmt': {
+        demandOption: false,
+        describe: 'Print log as json or plain text',
+        type: 'string',
+        default: 'colored',
+        choices: ['json', 'colored'],
+      },
+      'log-level': {
+        demandOption: false,
+        describe: 'Specify log level to print.',
+        type: 'string',
+        default: 'info',
+        choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
+      },
+      'log-path': {
+        demandOption: false,
+        describe: 'Path to create log file e.g ./src/name.log',
+        type: 'string',
+      },
+      'log-rotate': {
+        demandOption: false,
+        describe: 'Rotate log files in directory specified by log-path',
+        type: 'boolean',
+        default: false,
+      },
+      indexer: {
+        demandOption: false,
+        describe: 'Url that allows query to access indexer metadata',
+        type: 'string',
+      },
+      unsafe: {
+        demandOption: false,
+        describe: 'Disable limits on query depth and allowable number returned query records',
+        type: 'boolean',
+      },
+      port: {
+        alias: 'p',
+        demandOption: false,
+        describe: 'The port the service will bind to',
+        type: 'number',
+        default: 3000,
+      },
+    })
+    .strictOptions();
 }
 
 export function argv(arg: string): unknown {

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -7,63 +7,61 @@ import yargs from 'yargs/yargs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getYargsOption() {
-  return yargs(hideBin(process.argv))
-    .options({
-      name: {
-        demandOption: true,
-        alias: 'n',
-        describe: 'Project name',
-        type: 'string',
-      },
-      playground: {
-        demandOption: false,
-        describe: 'Enable graphql playground',
-        type: 'boolean',
-      },
-      'output-fmt': {
-        demandOption: false,
-        describe: 'Print log as json or plain text',
-        type: 'string',
-        default: 'colored',
-        choices: ['json', 'colored'],
-      },
-      'log-level': {
-        demandOption: false,
-        describe: 'Specify log level to print.',
-        type: 'string',
-        default: 'info',
-        choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
-      },
-      'log-path': {
-        demandOption: false,
-        describe: 'Path to create log file e.g ./src/name.log',
-        type: 'string',
-      },
-      'log-rotate': {
-        demandOption: false,
-        describe: 'Rotate log files in directory specified by log-path',
-        type: 'boolean',
-        default: false,
-      },
-      indexer: {
-        demandOption: false,
-        describe: 'Url that allows query to access indexer metadata',
-        type: 'string',
-      },
-      unsafe: {
-        demandOption: false,
-        describe: 'Disable limits on query depth and allowable number returned query records',
-        type: 'boolean',
-      },
-      port: {
-        alias: 'p',
-        demandOption: false,
-        describe: 'The port the service will bind to',
-        type: 'number',
-        default: 3000,
-      },
-    })
-    .strictOptions();
+  return yargs(hideBin(process.argv)).options({
+    name: {
+      demandOption: true,
+      alias: 'n',
+      describe: 'Project name',
+      type: 'string',
+    },
+    playground: {
+      demandOption: false,
+      describe: 'Enable graphql playground',
+      type: 'boolean',
+    },
+    'output-fmt': {
+      demandOption: false,
+      describe: 'Print log as json or plain text',
+      type: 'string',
+      default: 'colored',
+      choices: ['json', 'colored'],
+    },
+    'log-level': {
+      demandOption: false,
+      describe: 'Specify log level to print.',
+      type: 'string',
+      default: 'info',
+      choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
+    },
+    'log-path': {
+      demandOption: false,
+      describe: 'Path to create log file e.g ./src/name.log',
+      type: 'string',
+    },
+    'log-rotate': {
+      demandOption: false,
+      describe: 'Rotate log files in directory specified by log-path',
+      type: 'boolean',
+      default: false,
+    },
+    indexer: {
+      demandOption: false,
+      describe: 'Url that allows query to access indexer metadata',
+      type: 'string',
+    },
+    unsafe: {
+      demandOption: false,
+      describe: 'Disable limits on query depth and allowable number returned query records',
+      type: 'boolean',
+    },
+    port: {
+      alias: 'p',
+      demandOption: false,
+      describe: 'The port the service will bind to',
+      type: 'number',
+      default: 3000,
+    },
+  });
 }
 
 export function argv(arg: string): unknown {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3635,11 +3635,13 @@ __metadata:
     "@subql/types": "workspace:*"
     "@subql/x-vm2": ^3.9.3-0.1.0
     "@types/bn.js": 4.11.6
+    "@types/detect-port": ^1
     "@types/js-yaml": ^4.0.4
     "@types/pino": ^6.3.12
     bn.js: 4.11.6
     class-transformer: 0.4.0
     class-validator: ^0.13.1
+    detect-port: ^1.3.0
     flatted: ^3.2.2
     graphql: ^15.7.2
     graphql-tag: ^2.12.5
@@ -3980,6 +3982,13 @@ __metadata:
   version: 2.8.12
   resolution: "@types/cors@npm:2.8.12"
   checksum: 8c45f112c7d1d2d831b4b266f2e6ed33a1887a35dcbfe2a18b28370751fababb7cd045e745ef84a523c33a25932678097bf79afaa367c6cb3fa0daa7a6438257
+  languageName: node
+  linkType: hard
+
+"@types/detect-port@npm:^1":
+  version: 1.3.2
+  resolution: "@types/detect-port@npm:1.3.2"
+  checksum: e4678244fbe8801014798b3efb967c886e6fc0fe94fb771a1be9558b35c68910b23bd30984df4a276b927820ce436b244506fb0972116d1b18506ac96bfd1a50
   languageName: node
   linkType: hard
 
@@ -5004,6 +5013,13 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 2e4c1dbed3da327684863debf31d341bf8882c6893c506653872c00977eee45675feb9129255d6c74c88424d2b20d889ca6de5b39776e5e3cccfc756b3ca1da8
+  languageName: node
+  linkType: hard
+
+"address@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "address@npm:1.1.2"
+  checksum: d966deee6ab9a0f96ed1d25dc73e91a248f64479c91f9daeb15237b8e3c39a02faac4e6afe8987ef9e5aea60a1593cef5882b7456ab2e6196fc0229a93ec39c2
   languageName: node
   linkType: hard
 
@@ -6903,7 +6919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.6.9":
+"debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.6.0, debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -7058,6 +7074,19 @@ __metadata:
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
   checksum: ae6cd429c41ad01b164c59ea36f264a2c479598e61cba7c99da24175a7ab80ddf066420f2bec9a1c57a6bead411b4655ff15ad7d281c000a89791f48cbe939e7
+  languageName: node
+  linkType: hard
+
+"detect-port@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "detect-port@npm:1.3.0"
+  dependencies:
+    address: ^1.0.1
+    debug: ^2.6.0
+  bin:
+    detect: ./bin/detect-port
+    detect-port: ./bin/detect-port
+  checksum: 93c40febe714f56711d1fedc2b7a9cc4cbaa0fcddec0509876c46b9dd6099ed6bfd6662a4f35e5fa0301660f48ed516829253ab0fc90b9e79b823dd77786b379
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Changes the default port of the node service to `3001` and keeps the default port of the query service as `3000`
- Reason for decision above is that people will be used to going to localhost:3000 in their browsers so we don't want to change this
- Adds a log for the URL of the playground as a shortcut
- Add strict options to `getYargsOptions` so that invalid flags are not swallowed
- **I need to change the docker images on the templates so that they support the new ports so let me put that up before this is merged**