### PR TITLE
Edit interval metadata

### DIFF
--- a/packages/node/src/indexer/events.ts
+++ b/packages/node/src/indexer/events.ts
@@ -7,7 +7,6 @@ export enum IndexerEvent {
   BlockTarget = 'block_target_height',
   BlockBest = 'block_best_height',
   BlockProcessing = 'block_processing_height',
-  BlockLastProcessed = 'block_processed_height',
   BlockQueueSize = 'block_queue_size',
   BlocknumberQueueSize = 'blocknumber_queue_size',
   NetworkMetadata = 'network_metadata',

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -108,11 +108,9 @@ export class IndexerManager {
         }
       }
 
-      this.storeService.setMetadata(
-        'lastProcessedHeight',
-        block.block.header.number.toNumber(),
-        { transaction: tx },
-      );
+      this.storeService.setMetadata('lastProcessedHeight', blockHeight, {
+        transaction: tx,
+      });
       this.storeService.setMetadata('lastProcessedTimestamp', Date.now(), {
         transaction: tx,
       });
@@ -129,7 +127,7 @@ export class IndexerManager {
             this.project.path, //projectId // TODO, define projectId
           );
           poiBlockHash = poiBlock.hash;
-          await this.storeService.setPoi(tx, poiBlock);
+          await this.storeService.setPoi(poiBlock, { transaction: tx });
         }
       }
     } catch (e) {

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -108,12 +108,12 @@ export class IndexerManager {
         }
       }
 
-      this.storeService.setMetadata('lastProcessedHeight', blockHeight, {
-        transaction: tx,
-      });
-      this.storeService.setMetadata('lastProcessedTimestamp', Date.now(), {
-        transaction: tx,
-      });
+      const metadata: Record<string, string | number | boolean> = {
+        lastProcessedHeight: blockHeight,
+        lastProcessedTimestamp: Date.now(),
+      };
+
+      await this.storeService.setMetadataBatch(metadata, { transaction: tx });
 
       if (this.nodeConfig.proofOfIndex) {
         const operationHash = this.storeService.getOperationMerkleRoot();

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -108,13 +108,14 @@ export class IndexerManager {
         }
       }
 
-      await this.metadataRepo.upsert(
-        {
-          key: 'lastProcessedHeight',
-          value: block.block.header.number.toNumber(),
-        },
+      this.storeService.setMetadata(
+        'lastProcessedHeight',
+        block.block.header.number.toNumber(),
         { transaction: tx },
       );
+      this.storeService.setMetadata('lastProcessedTimestamp', Date.now(), {
+        transaction: tx,
+      });
 
       if (this.nodeConfig.proofOfIndex) {
         const operationHash = this.storeService.getOperationMerkleRoot();
@@ -141,11 +142,6 @@ export class IndexerManager {
     if (this.nodeConfig.proofOfIndex) {
       this.poiService.setLatestPoiBlockHash(poiBlockHash);
     }
-
-    this.eventEmitter.emit(IndexerEvent.BlockLastProcessed, {
-      height: blockHeight,
-      timestamp: Date.now(),
-    });
   }
 
   async start(): Promise<void> {

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -108,12 +108,13 @@ export class IndexerManager {
         }
       }
 
-      const metadata: Record<string, string | number | boolean> = {
-        lastProcessedHeight: blockHeight,
-        lastProcessedTimestamp: Date.now(),
-      };
-
-      await this.storeService.setMetadataBatch(metadata, { transaction: tx });
+      await this.storeService.setMetadataBatch(
+        [
+          { key: 'lastProcessedHeight', value: blockHeight },
+          { key: 'lastProcessedTimestamp', value: Date.now() },
+        ],
+        { transaction: tx },
+      );
 
       if (this.nodeConfig.proofOfIndex) {
         const operationHash = this.storeService.getOperationMerkleRoot();

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -243,12 +243,15 @@ export class StoreService {
     await this.metaDataRepo.upsert({ key, value }, options);
   }
 
-  async setPoi(tx: Transaction, blockPoi: ProofOfIndex): Promise<void> {
+  async setPoi(
+    blockPoi: ProofOfIndex,
+    options?: UpsertOptions<ProofOfIndex>,
+  ): Promise<void> {
     assert(this.poiRepo, `Model _poi does not exist`);
     blockPoi.chainBlockHash = u8aToBuffer(blockPoi.chainBlockHash);
     blockPoi.hash = u8aToBuffer(blockPoi.hash);
     blockPoi.parentHash = u8aToBuffer(blockPoi.parentHash);
-    await this.poiRepo.upsert(blockPoi, { transaction: tx });
+    await this.poiRepo.upsert(blockPoi, options);
   }
 
   getOperationMerkleRoot(): Uint8Array {

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -235,14 +235,11 @@ export class StoreService {
   }
 
   async setMetadataBatch(
-    metadata: Record<string, string | number | boolean>,
+    metadata: Metadata[],
     options?: UpsertOptions<Metadata>,
   ): Promise<void> {
-    const xs = [];
-    for (const [key, value] of Object.entries(metadata)) {
-      xs.push(this.setMetadata(key, value, options));
-    }
-    await Promise.all(xs);
+    assert(this.metaDataRepo, `Model _metadata does not exist`);
+    await this.metaDataRepo.bulkCreate(metadata, options);
   }
 
   async setMetadata(

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -234,6 +234,17 @@ export class StoreService {
     }
   }
 
+  async setMetadataBatch(
+    metadata: Record<string, string | number | boolean>,
+    options?: UpsertOptions<Metadata>,
+  ): Promise<void> {
+    const xs = [];
+    for (const [key, value] of Object.entries(metadata)) {
+      xs.push(this.setMetadata(key, value, options));
+    }
+    await Promise.all(xs);
+  }
+
   async setMetadata(
     key: string,
     value: string | number | boolean,

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -8,7 +8,13 @@ import { blake2AsHex } from '@polkadot/util-crypto';
 import { GraphQLModelsRelationsEnums } from '@subql/common/graphql/types';
 import { Entity, Store } from '@subql/types';
 import { camelCase, flatten, upperFirst, isEqual } from 'lodash';
-import { QueryTypes, Sequelize, Transaction, Utils } from 'sequelize';
+import {
+  QueryTypes,
+  Sequelize,
+  Transaction,
+  UpsertOptions,
+  Utils,
+} from 'sequelize';
 import { NodeConfig } from '../configure/NodeConfig';
 import { modelsTypeToModelAttributes } from '../utils/graphql';
 import { getLogger } from '../utils/logger';
@@ -19,7 +25,11 @@ import {
   getFkConstraint,
   smartTags,
 } from '../utils/sync-helper';
-import { MetadataFactory, MetadataRepo } from './entities/Metadata.entity';
+import {
+  Metadata,
+  MetadataFactory,
+  MetadataRepo,
+} from './entities/Metadata.entity';
 import { PoiFactory, PoiRepo, ProofOfIndex } from './entities/Poi.entity';
 import { PoiService } from './poi.service';
 import { StoreOperations } from './StoreOperations';
@@ -227,13 +237,14 @@ export class StoreService {
   async setMetadata(
     key: string,
     value: string | number | boolean,
+    options?: UpsertOptions<Metadata>,
   ): Promise<void> {
-    assert(this.metaDataRepo, `model _metadata does not exist`);
-    await this.metaDataRepo.upsert({ key, value });
+    assert(this.metaDataRepo, `Model _metadata does not exist`);
+    await this.metaDataRepo.upsert({ key, value }, options);
   }
 
   async setPoi(tx: Transaction, blockPoi: ProofOfIndex): Promise<void> {
-    assert(this.poiRepo, `model _poi does not exist`);
+    assert(this.poiRepo, `Model _poi does not exist`);
     blockPoi.chainBlockHash = u8aToBuffer(blockPoi.chainBlockHash);
     blockPoi.hash = u8aToBuffer(blockPoi.hash);
     blockPoi.parentHash = u8aToBuffer(blockPoi.parentHash);

--- a/packages/node/src/meta/event.listener.ts
+++ b/packages/node/src/meta/event.listener.ts
@@ -62,10 +62,6 @@ export class MetricEventListener {
   handleProcessingBlock(blockPayload: ProcessBlockPayload) {
     this.processingBlockHeight.set(blockPayload.height);
   }
-  @OnEvent(IndexerEvent.BlockLastProcessed)
-  handleProcessedBlock(blockPayload: ProcessBlockPayload) {
-    this.processedBlockHeight.set(blockPayload.height);
-  }
 
   @OnEvent(IndexerEvent.BlockTarget)
   handleTargetBlock(blockPayload: TargetBlockPayload) {

--- a/packages/node/src/meta/meta.service.ts
+++ b/packages/node/src/meta/meta.service.ts
@@ -64,12 +64,6 @@ export class MetaService {
     this.currentProcessingTimestamp = blockPayload.timestamp;
   }
 
-  @OnEvent(IndexerEvent.BlockLastProcessed)
-  handleLastProcessedBlock(blockPayload: ProcessBlockPayload): void {
-    this.lastProcessedHeight = blockPayload.height;
-    this.lastProcessedTimestamp = blockPayload.timestamp;
-  }
-
   @OnEvent(IndexerEvent.BlockTarget)
   handleTargetBlock(blockPayload: TargetBlockPayload): void {
     this.targetHeight = blockPayload.height;

--- a/packages/node/src/meta/meta.service.ts
+++ b/packages/node/src/meta/meta.service.ts
@@ -54,18 +54,8 @@ export class MetaService {
   }
 
   @Interval(UPDATE_HEIGHT_INTERVAL)
-  async checkHeight() {
-    await Promise.all([
-      this.storeService.setMetadata(
-        'lastProcessedHeight',
-        this.lastProcessedHeight,
-      ),
-      this.storeService.setMetadata(
-        'lastProcessedTimestamp',
-        this.lastProcessedTimestamp,
-      ),
-      this.storeService.setMetadata('targetHeight', this.targetHeight),
-    ]);
+  async getTargetHeight(): Promise<void> {
+    await this.storeService.setMetadata('targetHeight', this.targetHeight);
   }
 
   @OnEvent(IndexerEvent.BlockProcessing)


### PR DESCRIPTION
- Changes the data that is updated during the interval, `lastProcessedHeight` and `lastProcessedTimestamp` must be tied to a transaction otherwise it can lead to an inconsistent db state. The `targetHeight` remains tied to an interval as this is the finalized target height of the chain that you are indexing. Db inconsistency is currently created in the following way:
```
block is processed --> interval event updates metadata --> block is rolled back but interval event updates are not
```
- Should fix a critical issue that we are facing with the moonbeam dictionary project