### PR TITLE
Change default for node back to 3000

### DIFF
--- a/packages/node/src/main.ts
+++ b/packages/node/src/main.ts
@@ -8,7 +8,7 @@ import { IndexerManager } from './indexer/indexer.manager';
 import { getLogger, NestLogger } from './utils/logger';
 import { getYargsOption } from './yargs';
 
-const DEFAULT_PORT = 3001;
+const DEFAULT_PORT = 3000;
 const logger = getLogger('subql-node');
 const { argv } = getYargsOption();
 


### PR DESCRIPTION
- Changes the default port of node back to 3000 so that hosted services doesn't have to change anything
- If the port is explicitly bound (using `--port`) there will not be a check to see if it's bound and the node will fail to start as expected 
- If the port is **not** explicitly stated then we will begin a scan from 3000 to find a free port 
- Default behaviour without any ports bound (via flags or environment variable for either service) is that both services will do a scan from the default port of 3000