### PR TITLE
Add jq to node image

### DIFF
--- a/packages/node/Dockerfile
+++ b/packages/node/Dockerfile
@@ -7,7 +7,7 @@ RUN npm i -g --unsafe-perm @subql/node@${RELEASE_VERSION}
 FROM node:16-alpine
 ENV TZ utc
 
-RUN apk add --no-cache tini git curl
+RUN apk add --no-cache tini git curl jq
 COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/lib/node_modules/@subql/node/bin/run"]


### PR DESCRIPTION
I have just realised that I have left out `jq` from the node docker image. I need this for a health check to fix an error a bunch of people are getting on starting with docker compose. Either this or I can just change the ready endpoint to return a non json object (eg `true` instead of `{ready: true}`, but I think these endpoints should always be returning json objects

```
  subquery-node:
    image: onfinality/subql-node:latest
    depends_on:
      "postgres":
        condition: service_healthy
    restart: always
    environment:
      DB_USER: postgres
      DB_PASS: postgres
      DB_DATABASE: postgres
      DB_HOST: postgres
      DB_PORT: 5432
    volumes:
      - ./:/app
    command:
      - -f=/app
      - --db-schema=app
    healthcheck:
      test: ["CMD", "[ $(curl -s -f http://subquery-node:3000/ready | jq '.ready') == 'true' ]"]
      interval: 2s
      timeout: 5s
      retries: 10
```