### PR TITLE
Genesis hash check fix for specVersion 0.0.1

### DIFF
--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -336,8 +336,11 @@ export class IndexerManager {
         await metadataRepo.upsert({ key: 'genesisHash', value: genesisHash });
       }
     } else {
+      // Check if the configured genesisHash matches the currently stored genesisHash
       assert(
-        this.project.network.genesisHash === keyValue.genesisHash,
+        // Configured project yaml genesisHash only exists in specVersion v0.2.0, fallback to api fetched genesisHash on v0.0.1
+        (this.project.network.genesisHash ?? genesisHash) ===
+          keyValue.genesisHash,
         'Specified project manifest genesis hash does not match database stored genesis hash, consider cleaning project schema using --force-clean',
       );
     }


### PR DESCRIPTION
- Problem with redeploying v0.0.1 projects on hosted as the project yaml doesn't contain genesisHash field. Instead we should fall back to the API fetched genesisHash from the configured endpoint