### PR TITLE
Remove .github directory from new projects

### DIFF
--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -109,6 +109,11 @@ export async function prepare(projectPath: string, project: ProjectSpecBase): Pr
   } catch (e) {
     throw new Error('Failed to remove .git from template project');
   }
+  // Only some templates will have  github actions/workflows
+  try {
+    await promisify(rimraf)(`${projectPath}/.github`);
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
 }
 
 async function preparePackage(projectPath: string, project: ProjectSpecBase): Promise<void> {

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -109,11 +109,11 @@ export async function prepare(projectPath: string, project: ProjectSpecBase): Pr
   } catch (e) {
     throw new Error('Failed to remove .git from template project');
   }
-  // Only some templates will have  github actions/workflows
   try {
     await promisify(rimraf)(`${projectPath}/.github`);
-    // eslint-disable-next-line no-empty
-  } catch (e) {}
+  } catch (e) {
+    throw new Error('Failed to remove .github from template project');
+  }
 }
 
 async function preparePackage(projectPath: string, project: ProjectSpecBase): Promise<void> {


### PR DESCRIPTION
Some templates have a `.github` directory which contains repository specific workflows/actions. This deletes the `.github` directory when a project is created (for example the `subql-starter` contains this directory)