### PR TITLE
Remove endpoint from templates

### DIFF
--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -20,7 +20,6 @@ export interface Template {
   remote: string;
   branch: string;
   network: string;
-  endpoint: string;
   specVersion: string;
 }
 


### PR DESCRIPTION
- Remove the endpoint field from the templates type because it's no longer used.
- **This should be merged after https://github.com/subquery/templates/pull/6 is merged because this removes the field from the json file**
- Note that if the other pull is merged without this being merged everything still works fine