### PR TITLE
Fix cli description hint

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -232,11 +232,18 @@ export default class Init extends Command {
       cli.action.stop();
     }
 
+    // Cut description to appropriate size
+    const descriptionHint = defaultDescription.substring(0, 40).concat('...');
     project.author = await cli.prompt('Author', {required: true, default: defaultAuthor});
-    project.description = await cli.prompt('Description', {
-      required: false,
-      default: defaultDescription.substring(0, 40).concat('...'),
-    });
+    project.description = await cli
+      .prompt('Description', {
+        required: false,
+        default: descriptionHint,
+      })
+      .then((description) => {
+        return description === descriptionHint ? defaultDescription : description;
+      });
+
     project.version = await cli.prompt('Version', {required: true, default: defaultVersion});
     project.license = await cli.prompt('License', {required: true, default: defaultLicense});
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -111,7 +111,9 @@ export default class Init extends Command {
     let selectedNetwork: string;
 
     try {
-      templates = await fetchTemplates();
+      templates = await fetchTemplates(
+        'https://raw.githubusercontent.com/subquery/templates/additional-networks/templates.json'
+      );
     } catch (e) {
       this.error(e);
     }
@@ -124,9 +126,7 @@ export default class Init extends Command {
     }
 
     if (!useCustomTemplate) {
-      const networks = uniq(templates.map(({network}) => network));
-      networks.push('Other');
-
+      const networks = uniq(templates.map(({network}) => network)).sort();
       // Network selection
       await inquirer
         .prompt([
@@ -136,6 +136,7 @@ export default class Init extends Command {
             type: 'autocomplete',
             searchText: '',
             emptyText: 'Network not found',
+            pageSize: 20,
             source: filterInput(networks),
           },
         ])

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -111,9 +111,7 @@ export default class Init extends Command {
     let selectedNetwork: string;
 
     try {
-      templates = await fetchTemplates(
-        'https://raw.githubusercontent.com/subquery/templates/additional-networks/templates.json'
-      );
+      templates = await fetchTemplates();
     } catch (e) {
       this.error(e);
     }
@@ -233,7 +231,6 @@ export default class Init extends Command {
       cli.action.stop();
     }
 
-    // Cut description to appropriate size
     const descriptionHint = defaultDescription.substring(0, 40).concat('...');
     project.author = await cli.prompt('Author', {required: true, default: defaultAuthor});
     project.description = await cli


### PR DESCRIPTION
- Bug with the cli templates tool where the description hint (substring of description) is applied as the default subscription instead of the whole description string
- This fixes that bug by checking if the selection for the description is the hint, and then applies the full description as the selected description 
- Adds larger pageSize because we are adding over 20 networks
- Sorts the networks by name