### PR TITLE
Add support for dynamic datasources

### DIFF
--- a/packages/cli/src/controller/publish-controller.ts
+++ b/packages/cli/src/controller/publish-controller.ts
@@ -3,17 +3,9 @@
 
 import fs from 'fs';
 import path from 'path';
-import {
-  manifestIsV0_2_0,
-  parseProjectManifest,
-  ProjectManifestV0_2_0Impl,
-  ReaderFactory,
-  isCustomDs,
-} from '@subql/common';
+import { parseProjectManifest, manifestIsV0_2_0, ReaderFactory } from '@subql/common';
 import {FileReference} from '@subql/types';
 import IPFS from 'ipfs-http-client';
-import yaml from 'js-yaml';
-import {runWebpack} from './build-controller';
 
 // https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#filecontent
 type FileContent = Uint8Array | string | Iterable<Uint8Array> | Iterable<number> | AsyncIterable<Uint8Array>;
@@ -71,13 +63,6 @@ async function replaceFileReferences<T>(ipfs: IPFS.IPFSHTTPClient, projectDir: s
 async function uploadFile(ipfs: IPFS.IPFSHTTPClient, content: FileObject | FileContent): Promise<string> {
   const result = await ipfs.add(content, {pin: true, cidVersion: 0});
   return result.cid.toString();
-}
-
-function toMinifiedYaml(manifest: ProjectManifestV0_2_0Impl): string {
-  return yaml.dump(manifest, {
-    sortKeys: true,
-    condenseFlow: true,
-  });
 }
 
 function mapToObject(map: Map<string | number, unknown>): Record<string | number, unknown> {

--- a/packages/cli/src/template/datasource-templates.ts.ejs
+++ b/packages/cli/src/template/datasource-templates.ts.ejs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Auto-generated , DO NOT EDIT
+<% props.forEach(function(e){ %>
+export function create<%= e.name %>Datasource(<% if (e.args) { %>args: <%- e.args %><% } %>): Promise<void> {
+  return global.createDynamicDatasource('<%= e.name %>'<% if (e.args) { %>, args<% } %>);
+}
+<% }); %>

--- a/packages/cli/src/template/datasource-templates.ts.ejs
+++ b/packages/cli/src/template/datasource-templates.ts.ejs
@@ -3,6 +3,6 @@
 // Auto-generated , DO NOT EDIT
 <% props.forEach(function(e){ %>
 export function create<%= e.name %>Datasource(<% if (e.args) { %>args: <%- e.args %><% } %>): Promise<void> {
-  return global.createDynamicDatasource('<%= e.name %>'<% if (e.args) { %>, args<% } %>);
+  return createDynamicDatasource('<%= e.name %>'<% if (e.args) { %>, args<% } %>);
 }
 <% }); %>

--- a/packages/cli/src/template/types-index.ts.ejs
+++ b/packages/cli/src/template/types-index.ts.ejs
@@ -4,3 +4,4 @@
 <%if (props.exportTypes.models){%>export * from "./models"; <% } %>
 <%if (props.exportTypes.interfaces){%>export * from "./interfaces";<% } %>
 <%if (props.exportTypes.enums){%>export * from "./enums";<% } %>
+<%if (props.exportTypes.datasources){%>export * from "./datasources";<% } %>

--- a/packages/common/src/project/load.ts
+++ b/packages/common/src/project/load.ts
@@ -25,7 +25,7 @@ export function parseProjectManifest(raw: unknown): ProjectManifestVersioned {
   return projectManifest;
 }
 
-export function loadChainTypes(file: string, projectRoot: string) {
+export function loadChainTypes(file: string, projectRoot: string): unknown {
   const {ext} = path.parse(file);
   const filePath = path.resolve(projectRoot, file);
   if (fs.existsSync(filePath)) {

--- a/packages/common/src/project/versioned/ProjectManifestVersioned.ts
+++ b/packages/common/src/project/versioned/ProjectManifestVersioned.ts
@@ -6,12 +6,14 @@ import {plainToClass} from 'class-transformer';
 import {IProjectManifest} from '../types';
 import {ProjectManifestV0_0_1Impl} from './v0_0_1';
 import {ProjectManifestV0_2_0Impl} from './v0_2_0';
+import {ProjectManifestV0_2_1Impl} from './v0_2_1';
 
 export type VersionedProjectManifest = {specVersion: string};
 
 const SUPPORTED_VERSIONS = {
   '0.0.1': ProjectManifestV0_0_1Impl,
   '0.2.0': ProjectManifestV0_2_0Impl,
+  '0.2.1': ProjectManifestV0_2_1Impl,
 };
 
 type Versions = keyof typeof SUPPORTED_VERSIONS;
@@ -24,6 +26,10 @@ export function manifestIsV0_0_1(manifest: IProjectManifest): manifest is Projec
 
 export function manifestIsV0_2_0(manifest: IProjectManifest): manifest is ProjectManifestV0_2_0Impl {
   return manifest.specVersion === '0.2.0';
+}
+
+export function manifestIsV0_2_1(manifest: IProjectManifest): manifest is ProjectManifestV0_2_1Impl {
+  return manifest.specVersion === '0.2.1';
 }
 
 export class ProjectManifestVersioned implements IProjectManifest {
@@ -53,8 +59,16 @@ export class ProjectManifestVersioned implements IProjectManifest {
     return this.specVersion === '0.2.0';
   }
 
+  get isV0_2_1(): boolean {
+    return this.specVersion === '0.2.1';
+  }
+
   get asV0_2_0(): ProjectManifestV0_2_0Impl {
     return this._impl as ProjectManifestV0_2_0Impl;
+  }
+
+  get asV0_2_1(): ProjectManifestV0_2_1Impl {
+    return this._impl as ProjectManifestV0_2_1Impl;
   }
 
   toDeployment(): string | undefined {

--- a/packages/common/src/project/versioned/index.ts
+++ b/packages/common/src/project/versioned/index.ts
@@ -4,3 +4,4 @@
 export * from './ProjectManifestVersioned';
 export * from './v0_0_1';
 export * from './v0_2_0';
+export * from './v0_2_1';

--- a/packages/common/src/project/versioned/v0_2_0/model.ts
+++ b/packages/common/src/project/versioned/v0_2_0/model.ts
@@ -43,6 +43,15 @@ export class ProjectMappingV0_2_0 extends Mapping {
   file: string;
 }
 
+function validateObject(object: any, errorMessage = 'failed to validate object.'): void {
+  const errors = validateSync(object, {whitelist: true, forbidNonWhitelisted: true});
+  if (errors?.length) {
+    // TODO: print error details
+    const errorMsgs = errors.map((e) => e.toString()).join('\n');
+    throw new Error(`${errorMessage}\n${errorMsgs}`);
+  }
+}
+
 export class RuntimeDataSourceV0_2_0Impl
   extends RuntimeDataSourceBase<SubqlMappingV0_2_0<SubqlRuntimeHandler>>
   implements RuntimeDataSourceV0_2_0
@@ -52,12 +61,7 @@ export class RuntimeDataSourceV0_2_0Impl
   mapping: SubqlMappingV0_2_0<SubqlRuntimeHandler>;
 
   validate(): void {
-    const errors = validateSync(this, {whitelist: true, forbidNonWhitelisted: true});
-    if (errors?.length) {
-      // TODO: print error details
-      const errorMsgs = errors.map((e) => e.toString()).join('\n');
-      throw new Error(`failed to validate runtime datasource.\n${errorMsgs}`);
-    }
+    return validateObject(this, 'failed to validate runtime datasource.');
   }
 }
 
@@ -67,7 +71,12 @@ export class CustomDataSourceV0_2_0Impl<
     M extends SubqlMapping = SubqlMappingV0_2_0<SubqlCustomHandler>
   >
   extends CustomDataSourceBase<K, T, M>
-  implements SubqlCustomDatasource<K, T, M> {}
+  implements SubqlCustomDatasource<K, T, M>
+{
+  validate(): void {
+    return validateObject(this, 'failed to validate custom datasource.');
+  }
+}
 
 export class DeploymentV0_2_0 {
   @Equals('0.2.0')
@@ -133,11 +142,6 @@ export class ProjectManifestV0_2_0Impl extends ProjectManifestBaseImpl implement
   }
 
   validate(): void {
-    const errors = validateSync(this.deployment, {whitelist: true, forbidNonWhitelisted: true});
-    if (errors?.length) {
-      // TODO: print error details
-      const errorMsgs = errors.map((e) => e.toString()).join('\n');
-      throw new Error(`failed to parse project.yaml.\n${errorMsgs}`);
-    }
+    return validateObject(this.deployment, 'failed to validate project.');
   }
 }

--- a/packages/common/src/project/versioned/v0_2_0/model.ts
+++ b/packages/common/src/project/versioned/v0_2_0/model.ts
@@ -50,12 +50,21 @@ export class RuntimeDataSourceV0_2_0Impl
   @Type(() => ProjectMappingV0_2_0)
   @ValidateNested()
   mapping: SubqlMappingV0_2_0<SubqlRuntimeHandler>;
+
+  validate(): void {
+    const errors = validateSync(this, {whitelist: true, forbidNonWhitelisted: true});
+    if (errors?.length) {
+      // TODO: print error details
+      const errorMsgs = errors.map((e) => e.toString()).join('\n');
+      throw new Error(`failed to validate runtime datasource.\n${errorMsgs}`);
+    }
+  }
 }
 
 export class CustomDataSourceV0_2_0Impl<
     K extends string = string,
     T extends SubqlNetworkFilter = SubqlNetworkFilter,
-    M extends SubqlMapping = SubqlMapping<SubqlCustomHandler>
+    M extends SubqlMapping = SubqlMappingV0_2_0<SubqlCustomHandler>
   >
   extends CustomDataSourceBase<K, T, M>
   implements SubqlCustomDatasource<K, T, M> {}
@@ -106,7 +115,7 @@ export class ProjectManifestV0_2_0Impl extends ProjectManifestBaseImpl implement
     keepDiscriminatorProperty: true,
   })
   dataSources: (RuntimeDataSourceV0_2_0 | CustomDatasourceV0_2_0)[];
-  private _deployment: DeploymentV0_2_0;
+  protected _deployment: DeploymentV0_2_0;
 
   toDeployment(): string {
     return yaml.dump(this._deployment, {

--- a/packages/common/src/project/versioned/v0_2_1/index.ts
+++ b/packages/common/src/project/versioned/v0_2_1/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './model';
+export * from './types';

--- a/packages/common/src/project/versioned/v0_2_1/model.ts
+++ b/packages/common/src/project/versioned/v0_2_1/model.ts
@@ -1,0 +1,63 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {plainToClass, Type} from 'class-transformer';
+import {Equals, IsArray, IsOptional, IsString, ValidateNested, validateSync} from 'class-validator';
+import {
+  CustomDataSourceV0_2_0Impl,
+  DeploymentV0_2_0,
+  ProjectManifestV0_2_0Impl,
+  RuntimeDataSourceV0_2_0Impl,
+} from '../v0_2_0';
+import {CustomDatasourceTemplate, ProjectManifestV0_2_1, RuntimeDatasourceTemplate} from './types';
+
+export class RuntimeDatasourceTemplateImpl extends RuntimeDataSourceV0_2_0Impl implements RuntimeDatasourceTemplate {
+  @IsString()
+  name: string;
+}
+
+export class CustomDatasourceTemplateImpl extends CustomDataSourceV0_2_0Impl implements CustomDatasourceTemplate {
+  @IsString()
+  name: string;
+}
+
+export class DeploymentV0_2_1 extends DeploymentV0_2_0 {
+  @Equals('0.2.1')
+  @IsString()
+  specVersion: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested()
+  @Type(() => CustomDatasourceTemplateImpl, {
+    discriminator: {
+      property: 'kind',
+      subTypes: [{value: RuntimeDatasourceTemplateImpl, name: 'substrate/Runtime'}],
+    },
+    keepDiscriminatorProperty: true,
+  })
+  templates?: (RuntimeDatasourceTemplate | CustomDatasourceTemplate)[];
+}
+
+export class ProjectManifestV0_2_1Impl extends ProjectManifestV0_2_0Impl implements ProjectManifestV0_2_1 {
+  @IsOptional()
+  @IsArray()
+  @ValidateNested()
+  @Type(() => CustomDatasourceTemplateImpl, {
+    discriminator: {
+      property: 'kind',
+      subTypes: [{value: RuntimeDatasourceTemplateImpl, name: 'substrate/Runtime'}],
+    },
+    keepDiscriminatorProperty: true,
+  })
+  templates?: (RuntimeDatasourceTemplate | CustomDatasourceTemplate)[];
+  protected _deployment: DeploymentV0_2_1;
+
+  get deployment(): DeploymentV0_2_1 {
+    if (!this._deployment) {
+      this._deployment = plainToClass(DeploymentV0_2_1, this);
+      validateSync(this._deployment, {whitelist: true});
+    }
+    return this._deployment;
+  }
+}

--- a/packages/common/src/project/versioned/v0_2_1/types.ts
+++ b/packages/common/src/project/versioned/v0_2_1/types.ts
@@ -1,0 +1,15 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {CustomDatasourceV0_2_0, ProjectManifestV0_2_0, RuntimeDataSourceV0_2_0} from '../v0_2_0';
+
+export interface DatasourceTemplate {
+  name: string;
+}
+
+export type RuntimeDatasourceTemplate = RuntimeDataSourceV0_2_0 & DatasourceTemplate;
+export type CustomDatasourceTemplate = CustomDatasourceV0_2_0 & DatasourceTemplate;
+
+export interface ProjectManifestV0_2_1 extends ProjectManifestV0_2_0 {
+  templates?: (RuntimeDatasourceTemplate | CustomDatasourceTemplate)[];
+}

--- a/packages/contract-processors/package.json
+++ b/packages/contract-processors/package.json
@@ -20,9 +20,9 @@
     "ethers": "^5.5.1"
   },
   "devDependencies": {
-    "moonbeam-types-bundle": "^1.2.7"
+    "moonbeam-types-bundle": "^2.0.3"
   },
   "peerDependencies": {
-    "@polkadot/api": "^6"
+    "@polkadot/api": "^7"
   }
 }

--- a/packages/contract-processors/src/moonbeam.test.ts
+++ b/packages/contract-processors/src/moonbeam.test.ts
@@ -5,7 +5,7 @@ import {ApiPromise, WsProvider} from '@polkadot/api';
 import {getLogger} from '@subql/node/src/utils/logger';
 import {fetchBlocks} from '@subql/node/src/utils/substrate';
 import {SubstrateEvent, SubstrateExtrinsic} from '@subql/types';
-import {typesBundle} from 'moonbeam-types-bundle';
+import {typesBundleDeprecated} from 'moonbeam-types-bundle';
 import MoonbeamDatasourcePlugin, {MoonbeamCall, MoonbeamDatasource, MoonbeamEvent} from './moonbeam';
 
 const erc20MiniAbi = `[
@@ -137,7 +137,7 @@ describe('MoonbeamDs', () => {
     (global as any).logger = getLogger('MoonbeamTests');
     api = await ApiPromise.create({
       provider: new WsProvider('wss://moonriver.api.onfinality.io/public-ws'),
-      typesBundle: typesBundle as any,
+      typesBundle: typesBundleDeprecated as any,
     });
   });
 
@@ -575,7 +575,7 @@ describe('MoonbeamDs', () => {
 
         api = await ApiPromise.create({
           provider: new WsProvider('wss://moonbeam-alpha.api.onfinality.io/public-ws'),
-          typesBundle: typesBundle as any,
+          typesBundle: typesBundleDeprecated as any,
         });
 
         const blockNumber = 131451;

--- a/packages/contract-processors/src/moonbeam.ts
+++ b/packages/contract-processors/src/moonbeam.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import '@polkadot/api-augment';
 import {Interface, Result} from '@ethersproject/abi';
 import {Log, TransactionResponse} from '@ethersproject/abstract-provider';
 import {BigNumber} from '@ethersproject/bignumber';

--- a/packages/node/src/configure/SubqueryProject.ts
+++ b/packages/node/src/configure/SubqueryProject.ts
@@ -11,6 +11,9 @@ import {
   Reader,
   buildSchemaFromString,
   ProjectManifestV0_2_0Impl,
+  ProjectManifestV0_2_1Impl,
+  RuntimeDatasourceTemplate,
+  CustomDatasourceTemplate,
 } from '@subql/common';
 import { SubqlDatasource } from '@subql/types';
 import { GraphQLSchema } from 'graphql';
@@ -32,6 +35,7 @@ export class SubqueryProject {
   network: Partial<ProjectNetworkConfig>;
   dataSources: SubqlProjectDs[];
   schema: GraphQLSchema;
+  templates: (RuntimeDatasourceTemplate | CustomDatasourceTemplate)[];
   chainTypes?: RegisteredTypes;
 
   static async create(
@@ -58,6 +62,13 @@ export class SubqueryProject {
         reader,
         path,
         networkOverrides,
+      );
+    } else if (manifest.isV0_2_1) {
+      return loadProjectFromManifest0_2_1(
+        manifest.asV0_2_1,
+        reader,
+        path,
+        networkOverrides
       );
     }
   }
@@ -88,6 +99,7 @@ async function loadProjectFromManifest0_0_1(
       'typesChain',
       'typesSpec',
     ]),
+    templates: []
   };
 }
 
@@ -135,5 +147,24 @@ async function loadProjectFromManifest0_2_0(
     dataSources,
     schema,
     chainTypes,
+    templates: [],
   };
+}
+
+async function loadProjectFromManifest0_2_1(
+  projectManifest: ProjectManifestV0_2_1Impl,
+  reader: Reader,
+  path: string,
+  networkOverrides?: Partial<ProjectNetworkConfig>,
+): Promise<SubqueryProject> {
+  const project = await loadProjectFromManifest0_2_0(
+    projectManifest,
+    reader,
+    path,
+    networkOverrides
+  );
+
+  project.templates = projectManifest.templates;
+
+  return project;
 }

--- a/packages/node/src/indexer/api.service.spec.ts
+++ b/packages/node/src/indexer/api.service.spec.ts
@@ -64,6 +64,7 @@ function testSubqueryProject(): SubqueryProject {
     id: 'test',
     root: './',
     schema: new GraphQLSchema({}),
+    templates: [],
   };
 }
 

--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -32,6 +32,7 @@ function testSubqueryProject(endpoint: string): SubqueryProject {
       },
     },
     schema: new GraphQLSchema({}),
+    templates: [],
   };
 }
 

--- a/packages/node/src/indexer/dictionary.service.test.ts
+++ b/packages/node/src/indexer/dictionary.service.test.ts
@@ -16,6 +16,7 @@ function testSubqueryProject(): SubqueryProject {
     id: 'test',
     root: './',
     schema: new GraphQLSchema({}),
+    templates: [],
   };
 }
 

--- a/packages/node/src/indexer/ds-processor.service.spec.ts
+++ b/packages/node/src/indexer/ds-processor.service.spec.ts
@@ -31,6 +31,7 @@ function getTestProject(
     id: 'test',
     root: path.resolve(__dirname, '../../../'),
     schema: new GraphQLSchema({}),
+    templates: [],
   };
 }
 
@@ -44,8 +45,9 @@ describe('DsProcessorService', () => {
   });
 
   it('can validate custom ds', async () => {
-    await service.validateCustomDs();
-    await expect(service.validateCustomDs()).resolves.not.toThrow();
+    await expect(
+      service.validateProjectCustomDatasources(),
+    ).resolves.not.toThrow();
   });
 
   it('can catch an invalid datasource kind', async () => {
@@ -61,7 +63,7 @@ describe('DsProcessorService', () => {
     project = getTestProject([badDs]);
     service = new DsProcessorService(project);
 
-    await expect(service.validateCustomDs()).rejects.toThrow();
+    await expect(service.validateProjectCustomDatasources()).rejects.toThrow();
   });
 
   it('can run a custom ds processor', () => {

--- a/packages/node/src/indexer/ds-processor.service.ts
+++ b/packages/node/src/indexer/ds-processor.service.ts
@@ -51,10 +51,8 @@ export class DsProcessorService {
   } = {};
   constructor(private project: SubqueryProject) {}
 
-  async validateCustomDs(): Promise<void> {
-    for (const ds of (this.project.dataSources as SubqlDatasource[]).filter(
-      isCustomDs,
-    )) {
+  async validateCustomDs(datasources: SubqlCustomDatasource[]): Promise<void> {
+    for (const ds of datasources) {
       const processor = this.getDsProcessor(ds);
       /* Standard validation applicable to all custom ds and processors */
       if (ds.kind !== processor.kind) {
@@ -82,6 +80,10 @@ export class DsProcessorService {
       /* Additional processor specific validation */
       processor.validate(ds, await this.getAssets(ds));
     }
+  }
+
+  async validateProjectCustomDatasources(): Promise<void> {
+    await this.validateCustomDs((this.project.dataSources as SubqlDatasource[]).filter(isCustomDs));
   }
 
   getDsProcessor<D extends string, T extends SubqlNetworkFilter>(

--- a/packages/node/src/indexer/dynamic-ds.service.ts
+++ b/packages/node/src/indexer/dynamic-ds.service.ts
@@ -3,13 +3,7 @@
 
 import assert from 'assert';
 import { Injectable } from '@nestjs/common';
-import {
-    CustomDataSourceV0_2_0Impl,
-  isCustomDs,
-  isRuntimeDs,
-  RuntimeDataSourceV0_2_0Impl,
-} from '@subql/common';
-import { plainToClass } from 'class-transformer';
+import { isCustomDs, isRuntimeDs } from '@subql/common';
 import { Transaction } from 'sequelize/types';
 import { SubqlProjectDs, SubqueryProject } from '../configure/SubqueryProject';
 import { getLogger } from '../utils/logger';
@@ -133,17 +127,8 @@ export class DynamicDsService {
           ...params.args,
         };
         await this.dsProcessorService.validateCustomDs([dsObj]);
-
-        const customDs: CustomDataSourceV0_2_0Impl = plainToClass(
-          CustomDataSourceV0_2_0Impl,
-          dsObj,
-        );
-        customDs.validate();
       } else if (isRuntimeDs(dsObj)) {
         // XXX add any modifications to the ds here
-
-        const runtimeDs = plainToClass(RuntimeDataSourceV0_2_0Impl, dsObj);
-        runtimeDs.validate();
       }
 
       return dsObj;

--- a/packages/node/src/indexer/dynamic-ds.service.ts
+++ b/packages/node/src/indexer/dynamic-ds.service.ts
@@ -1,0 +1,116 @@
+// Copyright 2020-2021 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { Injectable } from '@nestjs/common';
+import {
+  CustomDataSourceV0_2_0Impl,
+  isCustomDs,
+  isRuntimeDs,
+  manifestIsV0_2_1,
+  RuntimeDataSourceV0_2_0Impl,
+} from '@subql/common';
+import { SubqlDatasource, SubqlDatasourceKind } from '@subql/types';
+import { plainToClass } from 'class-transformer';
+import yaml from 'js-yaml';
+import { SubqlProjectDs, SubqueryProject } from '../configure/SubqueryProject';
+import { getLogger } from '../utils/logger';
+import { DsProcessorService } from './ds-processor.service';
+import { StoreService } from './store.service';
+
+const logger = getLogger('dynamic-ds');
+
+const METADATA_KEY = 'dynamicDatasources';
+
+function replacer(key: string, value: any): any {
+  if (value instanceof Map) {
+    const obj: Record<string, unknown> = {};
+    for (const key of value.keys()) {
+      obj[key] = value.get(key);
+    }
+
+    return obj;
+  } else {
+    return value;
+  }
+}
+
+@Injectable()
+export class DynamicDsService {
+  constructor(
+    private readonly storeService: StoreService,
+    private readonly dsProcessorService: DsProcessorService,
+    private readonly project: SubqueryProject,
+  ) {}
+
+  async createDynamicDatasource(
+    templateName: string,
+    args: Record<string, unknown>,
+    currentBlock: number,
+  ): Promise<void> {
+
+    const template = this.project.templates.find(
+      (t) => t.name === templateName,
+    );
+
+    if (!template) {
+      logger.error(
+        `Unable to find matching template in project for name: "${templateName}"`,
+      );
+      process.exit(1);
+    }
+
+    logger.info(`Creating new datasource from template: "${templateName}"`);
+
+    const ds: SubqlDatasource = { ...template, startBlock: currentBlock };
+    try {
+      if (isCustomDs(ds)) {
+        ds.processor.options = { ...ds.processor.options, ...args };
+        await this.dsProcessorService.validateCustomDs([ds]);
+      } else if (isRuntimeDs(ds)) {
+        // XXX add any modifications to the ds here
+
+        const runtimeDs = plainToClass(RuntimeDataSourceV0_2_0Impl, ds);
+        runtimeDs.validate();
+      }
+    } catch (e) {
+      logger.error(`Unable to create dynamic datasource.\n ${e.message}`);
+      process.exit(1);
+    }
+
+    await this.saveDynamicDatasource(ds);
+  }
+
+  async getDynamicDatasources(): Promise<SubqlProjectDs[]> {
+    const results = await this.storeService.getMetadata(METADATA_KEY);
+
+    if (!results) {
+      return [];
+    }
+
+    const jsonDs = yaml.load(results as unknown as string) as any[];
+
+    // Convert from objects to classes, this is needed for Map type in custom ds assets
+    return jsonDs.map((ds) => {
+      if (isRuntimeDs(ds)) {
+        return plainToClass(RuntimeDataSourceV0_2_0Impl, ds);
+      } else if (ds.kind !== SubqlDatasourceKind.Runtime) {
+        return plainToClass(CustomDataSourceV0_2_0Impl, ds);
+      }
+
+      logger.warn(`Unknown datasource kind (${ds.kind}), using plain object`);
+      return ds;
+    });
+  }
+
+  private async saveDynamicDatasource(ds: SubqlDatasource): Promise<void> {
+    const existing = await this.getDynamicDatasources();
+
+    // Need to convert Map objects to records
+    const dsObj = JSON.parse(JSON.stringify(ds, replacer));
+
+    await this.storeService.setMetadata(
+      METADATA_KEY,
+      yaml.dump([...existing, dsObj]),
+    );
+  }
+}

--- a/packages/node/src/indexer/dynamic-ds.service.ts
+++ b/packages/node/src/indexer/dynamic-ds.service.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import assert from 'assert';
 import { Injectable } from '@nestjs/common';
 import {
     CustomDataSourceV0_2_0Impl,
@@ -8,13 +9,12 @@ import {
   isRuntimeDs,
   RuntimeDataSourceV0_2_0Impl,
 } from '@subql/common';
-import { SubqlDatasource } from '@subql/types';
 import { plainToClass } from 'class-transformer';
 import { Transaction } from 'sequelize/types';
 import { SubqlProjectDs, SubqueryProject } from '../configure/SubqueryProject';
 import { getLogger } from '../utils/logger';
 import { DsProcessorService } from './ds-processor.service';
-import { StoreService } from './store.service';
+import { MetadataRepo } from './entities/Metadata.entity';
 
 const logger = getLogger('dynamic-ds');
 
@@ -28,11 +28,16 @@ interface DatasourceParams {
 
 @Injectable()
 export class DynamicDsService {
+  private metaDataRepo: MetadataRepo;
+
   constructor(
-    private readonly storeService: StoreService,
     private readonly dsProcessorService: DsProcessorService,
     private readonly project: SubqueryProject,
   ) {}
+
+  init(metaDataRepo: MetadataRepo): void {
+    this.metaDataRepo = metaDataRepo;
+  }
 
   private _datasources: SubqlProjectDs[];
 
@@ -44,6 +49,10 @@ export class DynamicDsService {
       const ds = await this.getDatasource(params);
 
       await this.saveDynamicDatasourceParams(params, tx);
+
+      logger.info(
+        `Created new dynamic datasource from template: "${params.templateName}"`,
+      );
 
       if (!this._datasources) this._datasources = [];
       this._datasources.push(ds);
@@ -71,7 +80,9 @@ export class DynamicDsService {
   }
 
   private async getDynamicDatasourceParams(): Promise<DatasourceParams[]> {
-    const results = await this.storeService.getMetadata(METADATA_KEY);
+    assert(this.metaDataRepo, `Model _metadata does not exist`);
+    const record = await this.metaDataRepo.findByPk(METADATA_KEY);
+    const results = record?.value;
 
     if (!results || typeof results !== 'string') {
       return [];
@@ -86,9 +97,9 @@ export class DynamicDsService {
   ): Promise<void> {
     const existing = await this.getDynamicDatasourceParams();
 
-    await this.storeService.setMetadata(
-      METADATA_KEY,
-      JSON.stringify([...existing, dsParams]),
+    assert(this.metaDataRepo, `Model _metadata does not exist`);
+    await this.metaDataRepo.upsert(
+      { key: METADATA_KEY, value: JSON.stringify([...existing, dsParams]) },
       { transaction: tx },
     );
   }
@@ -107,7 +118,7 @@ export class DynamicDsService {
     }
 
     logger.info(
-      `Creating new datasource from template: "${params.templateName}"`,
+      `Initialised dynamic datasource from template: "${params.templateName}"`,
     );
 
     const dsObj = {

--- a/packages/node/src/indexer/fetch.service.spec.ts
+++ b/packages/node/src/indexer/fetch.service.spec.ts
@@ -178,6 +178,7 @@ function testSubqueryProject(): SubqueryProject {
     id: 'test',
     root: './',
     schema: new GraphQLSchema({}),
+    templates: [],
   };
 }
 
@@ -208,6 +209,7 @@ function testSubqueryProjectV0_2_0(): SubqueryProject {
     id: 'test',
     schema: new GraphQLSchema({}),
     root: path.resolve(__dirname, '../../../'),
+    templates: [],
   };
 }
 

--- a/packages/node/src/indexer/fetch.service.test.ts
+++ b/packages/node/src/indexer/fetch.service.test.ts
@@ -35,6 +35,7 @@ function testSubqueryProject(): SubqueryProject {
     id: 'test',
     root: './',
     schema: new GraphQLSchema({}),
+    templates: [],
   };
 }
 

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -11,6 +11,7 @@ import { SubqueryFactory } from '../entities';
 import { ApiService } from './api.service';
 import { DictionaryService } from './dictionary.service';
 import { DsProcessorService } from './ds-processor.service';
+import { DynamicDsService } from './dynamic-ds.service';
 import { FetchService } from './fetch.service';
 import { IndexerManager } from './indexer.manager';
 import { MmrService } from './mmr.service';
@@ -80,6 +81,7 @@ function testSubqueryProject_1(): SubqueryProject {
     id: 'test',
     root: './',
     schema: new GraphQLSchema({}),
+    templates: [],
   };
 }
 
@@ -105,6 +107,7 @@ function testSubqueryProject_2(): SubqueryProject {
     id: 'test',
     root: './',
     schema: new GraphQLSchema({}),
+    templates: [],
   };
 }
 
@@ -134,6 +137,11 @@ function createIndexerManager(project: SubqueryProject): IndexerManager {
     nodeConfig,
     project,
   );
+  const dynamicDsService = new DynamicDsService(
+    storeService,
+    dsPluginService,
+    project,
+  );
 
   return new IndexerManager(
     storeService,
@@ -146,6 +154,7 @@ function createIndexerManager(project: SubqueryProject): IndexerManager {
     nodeConfig,
     sandboxService,
     dsPluginService,
+    dynamicDsService,
     subqueryRepo,
     eventEmitter,
   );

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -137,11 +137,7 @@ function createIndexerManager(project: SubqueryProject): IndexerManager {
     nodeConfig,
     project,
   );
-  const dynamicDsService = new DynamicDsService(
-    storeService,
-    dsPluginService,
-    project,
-  );
+  const dynamicDsService = new DynamicDsService(dsPluginService, project);
 
   return new IndexerManager(
     storeService,

--- a/packages/node/src/indexer/indexer.manager.test.ts
+++ b/packages/node/src/indexer/indexer.manager.test.ts
@@ -20,6 +20,7 @@ function testSubqueryProject(): SubqueryProject {
     id: 'test',
     root: './',
     schema: new GraphQLSchema({}),
+    templates: [],
   };
 }
 
@@ -45,6 +46,7 @@ const prepare = async (): Promise<IndexerManager> => {
             undefined,
             sequelize,
             project,
+            undefined,
             undefined,
             undefined,
             undefined,

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -87,11 +87,13 @@ export class IndexerManager {
 
     // Inject function to create ds into vm
     vm.freeze(
-      (name: string, args?: Record<string, unknown>) =>
+      (templateName: string, args?: Record<string, unknown>) =>
         this.dynamicDsService.createDynamicDatasource(
-          name,
-          args,
-          blockHeight,
+          {
+            templateName,
+            args,
+            startBlock: blockHeight,
+          },
           tx,
         ),
       'createDynamicDatasource',
@@ -132,6 +134,7 @@ export class IndexerManager {
       }
 
       // Run dynamic data sources, must be after predefined datasources
+      // FIXME if any new dynamic datasources are created here they wont be run in the current block
       for (const ds of await this.dynamicDsService.getDynamicDatasources()) {
         await this.indexBlockForDs(ds, blockContent, apiAt, blockHeight, tx);
       }
@@ -289,7 +292,7 @@ export class IndexerManager {
   }
 
   private async createProjectSchema(): Promise<string> {
-    let schema;
+    let schema: string;
     if (this.nodeConfig.localMode) {
       // create tables in default schema if local mode is enabled
       schema = DEFAULT_DB_SCHEMA;

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -134,7 +134,7 @@ export class IndexerManager {
       }
 
       // Run dynamic data sources, must be after predefined datasources
-      // FIXME if any new dynamic datasources are created here they wont be run in the current block
+      // FIXME if any new dynamic datasources are created here they wont be run for the current block
       for (const ds of await this.dynamicDsService.getDynamicDatasources()) {
         await this.indexBlockForDs(ds, blockContent, apiAt, blockHeight, tx);
       }
@@ -180,6 +180,7 @@ export class IndexerManager {
     const schema = await this.ensureProject();
     await this.initDbSchema(schema);
     this.metadataRepo = await this.ensureMetadata(schema);
+    this.dynamicDsService.init(this.metadataRepo);
 
     if (this.nodeConfig.proofOfIndex) {
       await Promise.all([

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -23,7 +23,7 @@ import {
   SubqlNetworkFilter,
   SubqlRuntimeHandler,
 } from '@subql/types';
-import { QueryTypes, Sequelize } from 'sequelize';
+import { QueryTypes, Sequelize, Transaction } from 'sequelize';
 import { NodeConfig } from '../configure/NodeConfig';
 import { SubqlProjectDs, SubqueryProject } from '../configure/SubqueryProject';
 import { SubqueryRepo } from '../entities';
@@ -81,13 +81,19 @@ export class IndexerManager {
     blockContent: BlockContent,
     apiAt: ApiAt,
     blockHeight: number,
+    tx: Transaction,
   ): Promise<void> {
     const vm = this.sandboxService.getDsProcessor(ds, apiAt);
 
     // Inject function to create ds into vm
     vm.freeze(
       (name: string, args?: Record<string, unknown>) =>
-        this.dynamicDsService.createDynamicDatasource(name, args, blockHeight),
+        this.dynamicDsService.createDynamicDatasource(
+          name,
+          args,
+          blockHeight,
+          tx,
+        ),
       'createDynamicDatasource',
     );
 
@@ -122,12 +128,12 @@ export class IndexerManager {
 
       // Run predefined data sources
       for (const ds of this.filteredDataSources) {
-        await this.indexBlockForDs(ds, blockContent, apiAt, blockHeight);
+        await this.indexBlockForDs(ds, blockContent, apiAt, blockHeight, tx);
       }
 
       // Run dynamic data sources, must be after predefined datasources
       for (const ds of await this.dynamicDsService.getDynamicDatasources()) {
-        await this.indexBlockForDs(ds, blockContent, apiAt, blockHeight);
+        await this.indexBlockForDs(ds, blockContent, apiAt, blockHeight, tx);
       }
 
       await this.storeService.setMetadataBatch(
@@ -179,7 +185,7 @@ export class IndexerManager {
       ]);
     }
 
-    let startHeight;
+    let startHeight: number;
     const lastProcessedHeight = await this.metadataRepo.findOne({
       where: { key: 'lastProcessedHeight' },
     });

--- a/packages/node/src/indexer/indexer.module.ts
+++ b/packages/node/src/indexer/indexer.module.ts
@@ -9,6 +9,7 @@ import { ApiService } from './api.service';
 import { BenchmarkService } from './benchmark.service';
 import { DictionaryService } from './dictionary.service';
 import { DsProcessorService } from './ds-processor.service';
+import { DynamicDsService } from './dynamic-ds.service';
 import { FetchService } from './fetch.service';
 import { IndexerManager } from './indexer.manager';
 import { MmrService } from './mmr.service';
@@ -38,6 +39,7 @@ import { StoreService } from './store.service';
     DictionaryService,
     SandboxService,
     DsProcessorService,
+    DynamicDsService,
     PoiService,
     MmrService,
   ],

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -286,15 +286,6 @@ export class StoreService {
     return flatten(fields);
   }
 
-  async getMetadata(
-    key: string,
-  ): Promise<string | number | boolean | undefined> {
-    assert(this.metaDataRepo, `Model _metadata does not exist`);
-    const record = await this.metaDataRepo.findOne({ where: { key } });
-
-    return record?.value;
-  }
-
   private async packEntityFields(
     schema: string,
     entity: string,

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -286,11 +286,13 @@ export class StoreService {
     return flatten(fields);
   }
 
-  async getMetadata(key: string): Promise<object | null> {
+  async getMetadata(
+    key: string,
+  ): Promise<string | number | boolean | undefined> {
     assert(this.metaDataRepo, `Model _metadata does not exist`);
     const record = await this.metaDataRepo.findOne({ where: { key } });
 
-    return (record?.toJSON() as any)?.value;
+    return record?.value;
   }
 
   private async packEntityFields(

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -226,7 +226,7 @@ export class StoreService {
     return blake2AsHex(enumName).substr(2, 10);
   }
 
-  setTransaction(tx: Transaction) {
+  setTransaction(tx: Transaction): void {
     this.tx = tx;
     tx.afterCommit(() => (this.tx = undefined));
     if (this.config.proofOfIndex) {
@@ -284,6 +284,13 @@ export class StoreService {
       fields.push(tableFields);
     }
     return flatten(fields);
+  }
+
+  async getMetadata(key: string): Promise<object | null> {
+    assert(this.metaDataRepo, `Model _metadata does not exist`);
+    const record = await this.metaDataRepo.findOne({ where: { key } });
+
+    return (record?.toJSON() as any)?.value;
   }
 
   private async packEntityFields(

--- a/packages/query/src/graphql/plugins/GetMetadataPlugin.ts
+++ b/packages/query/src/graphql/plugins/GetMetadataPlugin.ts
@@ -22,6 +22,7 @@ const METADATA_TYPES = {
   indexerHealthy: 'boolean',
   indexerNodeVersion: 'string',
   queryNodeVersion: 'string',
+  dynamicDatasources: 'string',
 };
 
 type MetaType = number | string | boolean;
@@ -126,6 +127,7 @@ export const GetMetadataPlugin = makeExtendSchemaPlugin((build, options) => {
         indexerNodeVersion: String
         queryNodeVersion: String
         rowCountEstimate: [TableEstimate]
+        dynamicDatasources: String
       }
       extend type Query {
         _metadata: _Metadata

--- a/packages/types/src/global.ts
+++ b/packages/types/src/global.ts
@@ -4,7 +4,7 @@
 import {ApiPromise} from '@polkadot/api';
 import {ApiDecoration} from '@polkadot/api/types';
 import Pino from 'pino';
-import {Store} from './interfaces';
+import {Store, DynamicDatasourceCreator} from './interfaces';
 
 type ApiAt = ApiDecoration<'promise'> & {rpc: ApiPromise['rpc']};
 
@@ -12,4 +12,5 @@ declare global {
   const api: ApiAt;
   const logger: Pino.Logger;
   const store: Store;
+  const createDynamicDatasource: DynamicDatasourceCreator;
 }

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -42,3 +42,5 @@ export interface SubstrateEvent extends EventRecord {
   extrinsic?: SubstrateExtrinsic;
   block: SubstrateBlock;
 }
+
+export type DynamicDatasourceCreator = (name: string, args: Record<string, unknown>) => Promise<void>;

--- a/packages/validator/src/rules/require-custom-ds-validation.ts
+++ b/packages/validator/src/rules/require-custom-ds-validation.ts
@@ -15,7 +15,7 @@ export class RequireCustomDsValidation implements Rule {
   validate(ctx: Context): boolean {
     const schema = ctx.data.schema;
 
-    if (schema.isV0_2_0) {
+    if (schema.isV0_2_0 || schema.isV0_2_1) {
       for (const customDs of schema.dataSources.filter(isCustomDs)) {
         const processor: SubqlDatasourceProcessor<string, SubqlNetworkFilter> = require(path.resolve(
           ctx.data.projectPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,24 +1652,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.15.3":
-  version: 7.15.3
-  resolution: "@babel/runtime@npm:7.15.3"
-  dependencies:
-    regenerator-runtime: ^0.13.4
-  checksum: 2f0b8d2d4e36035ab1d84af0ec26aafa098536870f27c8e07de0a0e398f7a394fdea68a88165535ffb52ded6a68912bdc3450bdf91f229eb132e1c89470789f5
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.15.4":
-  version: 7.15.4
-  resolution: "@babel/runtime@npm:7.15.4"
-  dependencies:
-    regenerator-runtime: ^0.13.4
-  checksum: c40825430400e47c19b97e4142d5315d2910305b9714d44a711472587ee2fd4521fdba5f02ddd9df3902f5e988d9854fa83f4da1e0c091f70f6983fa52480606
-  languageName: node
-  linkType: hard
-
 "@babel/runtime@npm:^7.16.3":
   version: 7.16.3
   resolution: "@babel/runtime@npm:7.16.3"
@@ -3091,17 +3073,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^7.3.1":
-  version: 7.7.1
-  resolution: "@polkadot/keyring@npm:7.7.1"
+"@polkadot/keyring@npm:^7.8.2":
+  version: 7.9.2
+  resolution: "@polkadot/keyring@npm:7.9.2"
   dependencies:
-    "@babel/runtime": ^7.15.4
-    "@polkadot/util": 7.7.1
-    "@polkadot/util-crypto": 7.7.1
+    "@babel/runtime": ^7.16.3
+    "@polkadot/util": 7.9.2
+    "@polkadot/util-crypto": 7.9.2
   peerDependencies:
-    "@polkadot/util": 7.7.1
-    "@polkadot/util-crypto": 7.7.1
-  checksum: 6de520361052196554454e830b25b66a01b93d1652b1ff843f56a40b9cee55237f5b70c493e1821f32e875ac0a584adede6b1253741e628c306d53b909c18f52
+    "@polkadot/util": 7.9.2
+    "@polkadot/util-crypto": 7.9.2
+  checksum: 68bcff9a29c46f5fdfb0f692c680401f5be97afb7ac85b6c43b889c712a5b5c4f548764856cf0d86ffe3fbf7e7a721665aef5cbcf91d3cbc6ee6de6413aeb381
   languageName: node
   linkType: hard
 
@@ -3116,15 +3098,6 @@ __metadata:
     "@polkadot/util": 8.3.2
     "@polkadot/util-crypto": 8.3.2
   checksum: a9b51fbe93e5f42eb73afdc120796409dc92cc0bb01563a4f9b5bddbb7f7e606b00d5e3fe4e7cb84bdc35bb04b4dcfa416426b30369c721c90c6b2af97a78b2d
-  languageName: node
-  linkType: hard
-
-"@polkadot/networks@npm:7.7.1":
-  version: 7.7.1
-  resolution: "@polkadot/networks@npm:7.7.1"
-  dependencies:
-    "@babel/runtime": ^7.15.4
-  checksum: c17a14c9c716436f71612cdba9aaae894bff58645124bd7664f2e37a7f2e75caa290fd6aecaaaedc1bc941cc483b8d7f3f554924ea88d82079b27566fea8e116
   languageName: node
   linkType: hard
 
@@ -3144,6 +3117,16 @@ __metadata:
     "@babel/runtime": ^7.16.7
     "@polkadot/util": 8.3.2
   checksum: 6eaf48b192da44f7a0014e5c50d45f9477080a98c1cf315e5e4181f9068ca3679989b8ecff07408f0798ea7c3c806f313eafe847ad1a6c8333d8f8e7d0ebee26
+  languageName: node
+  linkType: hard
+
+"@polkadot/networks@npm:8.3.3, @polkadot/networks@npm:^8.1.2":
+  version: 8.3.3
+  resolution: "@polkadot/networks@npm:8.3.3"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@polkadot/util": 8.3.3
+  checksum: 731772f55f9e19c7120319dd64e70baa584ec9fcca8af3b2abde0f71a38cae2296e8cfd971cdb2a37d35ea2fffb3907b628bb563b2cfe19b4131f9b071b3f627
   languageName: node
   linkType: hard
 
@@ -3227,6 +3210,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/types-known@npm:6.12.1":
+  version: 6.12.1
+  resolution: "@polkadot/types-known@npm:6.12.1"
+  dependencies:
+    "@babel/runtime": ^7.16.3
+    "@polkadot/networks": ^8.1.2
+    "@polkadot/types": 6.12.1
+    "@polkadot/util": ^8.1.2
+  checksum: a15ad68e9c19fefc70d74e216b5fa3c53410ef69494bf514a8128853354f1dd87bdf338fef303f1474adacff044eef24fb59f2a78f59b85134a7139d4f089eb2
+  languageName: node
+  linkType: hard
+
 "@polkadot/types-known@npm:7.4.1":
   version: 7.4.1
   resolution: "@polkadot/types-known@npm:7.4.1"
@@ -3251,6 +3246,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/types@npm:6.12.1, @polkadot/types@npm:^6.11.1":
+  version: 6.12.1
+  resolution: "@polkadot/types@npm:6.12.1"
+  dependencies:
+    "@babel/runtime": ^7.16.3
+    "@polkadot/types-known": 6.12.1
+    "@polkadot/util": ^8.1.2
+    "@polkadot/util-crypto": ^8.1.2
+    rxjs: ^7.4.0
+  checksum: 0c067505e175c31231d083ce06f693d043e4a937075402ff6a67c84a280c8c1526ec8845f3c75fbba193464d9790bb34d65027c5c627521989b892d6e5fcb9b2
+  languageName: node
+  linkType: hard
+
 "@polkadot/types@npm:7.4.1":
   version: 7.4.1
   resolution: "@polkadot/types@npm:7.4.1"
@@ -3267,67 +3275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:^5.9.1":
-  version: 5.9.1
-  resolution: "@polkadot/types@npm:5.9.1"
-  dependencies:
-    "@babel/runtime": ^7.15.4
-    "@polkadot/util": ^7.3.1
-    "@polkadot/util-crypto": ^7.3.1
-    rxjs: ^7.3.0
-  checksum: 6ff253dea99ac48422eba54d214161391161916338b74d60b594b53553e65e29e4f7b4cf3b4b1d72dadf4811ea066fc64a70e1251910f1569bbd7e8b870542c6
-  languageName: node
-  linkType: hard
-
-"@polkadot/util-crypto@npm:7.7.1":
-  version: 7.7.1
-  resolution: "@polkadot/util-crypto@npm:7.7.1"
-  dependencies:
-    "@babel/runtime": ^7.15.4
-    "@polkadot/networks": 7.7.1
-    "@polkadot/util": 7.7.1
-    "@polkadot/wasm-crypto": ^4.2.1
-    "@polkadot/x-randomvalues": 7.7.1
-    base-x: ^3.0.9
-    base64-js: ^1.5.1
-    blakejs: ^1.1.1
-    bn.js: ^4.12.0
-    create-hash: ^1.2.0
-    ed2curve: ^0.3.0
-    elliptic: ^6.5.4
-    hash.js: ^1.1.7
-    js-sha3: ^0.8.0
-    scryptsy: ^2.1.0
-    tweetnacl: ^1.0.3
-    xxhashjs: ^0.2.2
-  peerDependencies:
-    "@polkadot/util": 7.7.1
-  checksum: d40398269ed375e714d195fff8ecb4b3428b5479212dc83e04d82765a860cb60d087d9eff94f90b72dcd93dfa0df7763cbc79891b9643ab80f8bbcbf172093bb
-  languageName: node
-  linkType: hard
-
-"@polkadot/util-crypto@npm:8.3.2, @polkadot/util-crypto@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "@polkadot/util-crypto@npm:8.3.2"
-  dependencies:
-    "@babel/runtime": ^7.16.7
-    "@noble/hashes": 0.5.7
-    "@noble/secp256k1": 1.3.4
-    "@polkadot/networks": 8.3.2
-    "@polkadot/util": 8.3.2
-    "@polkadot/wasm-crypto": ^4.5.1
-    "@polkadot/x-bigint": 8.3.2
-    "@polkadot/x-randomvalues": 8.3.2
-    ed2curve: ^0.3.0
-    micro-base: ^0.10.2
-    tweetnacl: ^1.0.3
-  peerDependencies:
-    "@polkadot/util": 8.3.2
-  checksum: 2a15d51673c34338e61f479d59c7244abd09349b0e8fb06a98e6f0387e34c9cf3bb207876cf7d8da48204ba04434fb8f508be7c51feb27af2f905dfbced18ef0
-  languageName: node
-  linkType: hard
-
-"@polkadot/util-crypto@npm:^7.3.1":
+"@polkadot/util-crypto@npm:7.9.2":
   version: 7.9.2
   resolution: "@polkadot/util-crypto@npm:7.9.2"
   dependencies:
@@ -3353,6 +3301,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/util-crypto@npm:8.3.2, @polkadot/util-crypto@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "@polkadot/util-crypto@npm:8.3.2"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@noble/hashes": 0.5.7
+    "@noble/secp256k1": 1.3.4
+    "@polkadot/networks": 8.3.2
+    "@polkadot/util": 8.3.2
+    "@polkadot/wasm-crypto": ^4.5.1
+    "@polkadot/x-bigint": 8.3.2
+    "@polkadot/x-randomvalues": 8.3.2
+    ed2curve: ^0.3.0
+    micro-base: ^0.10.2
+    tweetnacl: ^1.0.3
+  peerDependencies:
+    "@polkadot/util": 8.3.2
+  checksum: 2a15d51673c34338e61f479d59c7244abd09349b0e8fb06a98e6f0387e34c9cf3bb207876cf7d8da48204ba04434fb8f508be7c51feb27af2f905dfbced18ef0
+  languageName: node
+  linkType: hard
+
+"@polkadot/util-crypto@npm:^8.1.2":
+  version: 8.3.3
+  resolution: "@polkadot/util-crypto@npm:8.3.3"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@noble/hashes": 0.5.7
+    "@noble/secp256k1": 1.3.4
+    "@polkadot/networks": 8.3.3
+    "@polkadot/util": 8.3.3
+    "@polkadot/wasm-crypto": ^4.5.1
+    "@polkadot/x-bigint": 8.3.3
+    "@polkadot/x-randomvalues": 8.3.3
+    ed2curve: ^0.3.0
+    micro-base: ^0.10.2
+    tweetnacl: ^1.0.3
+  peerDependencies:
+    "@polkadot/util": 8.3.3
+  checksum: 57c15a4b4ffac2fb037ef9f7d3f27d8c79e291352b73f85d2c54845d29fec4bf690fac43bda1e2e0b9fa56701c03393bc0fb6d3dcda56fd1142c85273f9c2220
+  languageName: node
+  linkType: hard
+
 "@polkadot/util@npm:8.3.2":
   version: 8.3.2
   resolution: "@polkadot/util@npm:8.3.2"
@@ -3369,15 +3359,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:4.2.1"
-  dependencies:
-    "@babel/runtime": ^7.15.3
-  checksum: f4c9fed22121eaedeebf7f7bbe3c28e1920f2b84e7a1aea1a9d3807e79d7c236cee71e008527ab2779b079a56d43d6638fe50efa348f918277c65fa083094499
-  languageName: node
-  linkType: hard
-
 "@polkadot/wasm-crypto-asmjs@npm:^4.5.1":
   version: 4.5.1
   resolution: "@polkadot/wasm-crypto-asmjs@npm:4.5.1"
@@ -3387,35 +3368,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-wasm@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "@polkadot/wasm-crypto-wasm@npm:4.2.1"
-  dependencies:
-    "@babel/runtime": ^7.15.3
-  checksum: 2eab39628f34dd64987c4109a7d3ca0376946ace322aa67c10119be36b9eebf0f7c68f2e4aea1510f1fbd469c70dc3e8f1d3bd58799c7dcbc3a1e6cb08a69b5d
-  languageName: node
-  linkType: hard
-
 "@polkadot/wasm-crypto-wasm@npm:^4.5.1":
   version: 4.5.1
   resolution: "@polkadot/wasm-crypto-wasm@npm:4.5.1"
   dependencies:
     "@babel/runtime": ^7.16.3
   checksum: b44833a47f87af19b8724d310e64a10c8a3a4499d6af247d48e76dfe0dbbf5c40a21681dbb97297f1ea31a0d66518093ed14509ace16087293cf93e97b28ee73
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "@polkadot/wasm-crypto@npm:4.2.1"
-  dependencies:
-    "@babel/runtime": ^7.15.3
-    "@polkadot/wasm-crypto-asmjs": ^4.2.1
-    "@polkadot/wasm-crypto-wasm": ^4.2.1
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: 2ef25ed7dd297c160fafef9198bd23a3ca5fc8c03fd94903fac4fa8fd11ecc74cea935039e61cebf5458e95f3b6a30f21ceb968d5ddf4a488f05e9cf6d093577
   languageName: node
   linkType: hard
 
@@ -3443,6 +3401,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/x-bigint@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-bigint@npm:8.3.3"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@polkadot/x-global": 8.3.3
+  checksum: 43cdb0572ab7dd4e77b3af5f4421ee804ad52fc6121415f09c851e1c431574bc7f5bf92cef9f1f0573ba8115ce4d1200273b23e15eb695781ad7dc54eb7970ab
+  languageName: node
+  linkType: hard
+
 "@polkadot/x-fetch@npm:^8.3.2":
   version: 8.3.2
   resolution: "@polkadot/x-fetch@npm:8.3.2"
@@ -3452,15 +3420,6 @@ __metadata:
     "@types/node-fetch": ^2.5.12
     node-fetch: ^2.6.6
   checksum: c68d15d30c6b343d06358940ec4add6e15188387a9a887916f329d11035b062bdae57d430ed097a75bd6a31888ff5cec16c8f6523ce2d5ed05cbb4af3f8c4506
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-global@npm:7.7.1":
-  version: 7.7.1
-  resolution: "@polkadot/x-global@npm:7.7.1"
-  dependencies:
-    "@babel/runtime": ^7.15.4
-  checksum: 85564b379a9cc55c35c6c573bbe33521e668300f8d55d7740ecc2d13076f0c931546007f4392ff8e12c72cfd480db08f5c501875d740971c472b0b86a73d8142
   languageName: node
   linkType: hard
 
@@ -3482,13 +3441,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:7.7.1":
-  version: 7.7.1
-  resolution: "@polkadot/x-randomvalues@npm:7.7.1"
+"@polkadot/x-global@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-global@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.15.4
-    "@polkadot/x-global": 7.7.1
-  checksum: cec8887d7f1f5be79c08c81bd2b4965a832a2b6c7324186dc7029876da6bd020239acd94a29bd82ac3c3ca74c5455853a73cee6b881fc11f6f19d897fe23e81e
+    "@babel/runtime": ^7.16.7
+  checksum: 992cea4d1e9442195648ae3aac9cd9afa657897e3e6d25f1870690e99bf687555e2296295c9b53ac0694c10ddbce20e158b659c510ae5e0688a5774c9bfac6e9
   languageName: node
   linkType: hard
 
@@ -3509,6 +3467,16 @@ __metadata:
     "@babel/runtime": ^7.16.7
     "@polkadot/x-global": 8.3.2
   checksum: 3b0210040111ce5d4ca38dd0a0f486dc3e92837c30f8772128096a29d50480305f3d1cd9b40b18d0a9954df67792bdc74fcfb7d51f36d8d097d2367a59301d09
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-randomvalues@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-randomvalues@npm:8.3.3"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@polkadot/x-global": 8.3.3
+  checksum: 54546db40525efaadf16035cf23a747229e0a308aac41af8c1852df94123ee6d1a5155bdb2c0cc0bb5599b58e31fbdc8a3d653d5ad34a57b51bd3581cdbd40ed
   languageName: node
   linkType: hard
 
@@ -3718,9 +3686,9 @@ __metadata:
     class-transformer: 0.4.0
     class-validator: ^0.13.1
     ethers: ^5.5.1
-    moonbeam-types-bundle: ^1.2.7
+    moonbeam-types-bundle: ^2.0.3
   peerDependencies:
-    "@polkadot/api": ^6
+    "@polkadot/api": ^7
   languageName: unknown
   linkType: soft
 
@@ -5829,16 +5797,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^3.0.9":
-  version: 3.0.9
-  resolution: "base-x@npm:3.0.9"
-  dependencies:
-    safe-buffer: ^5.0.1
-  checksum: 957101d6fd09e1903e846fd8f69fd7e5e3e50254383e61ab667c725866bec54e5ece5ba49ce385128ae48f9ec93a26567d1d5ebb91f4d56ef4a9cc0d5a5481e8
-  languageName: node
-  linkType: hard
-
-"base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
+"base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -11934,14 +11893,15 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"moonbeam-types-bundle@npm:^1.2.7":
-  version: 1.2.7
-  resolution: "moonbeam-types-bundle@npm:1.2.7"
+"moonbeam-types-bundle@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "moonbeam-types-bundle@npm:2.0.3"
   dependencies:
-    "@polkadot/keyring": ^7.3.1
-    "@polkadot/types": ^5.9.1
-    typescript: ^4.3.5
-  checksum: 23751f632d15fd328956e77d65a58237a07d3b8ba1328cc9a8d0c3e37c38ce6c96876bbf2a17a075e66c451fe1633f999d230af6dfc79b01b6e6b92d68940bc4
+    "@polkadot/api": ^6.11.1
+    "@polkadot/keyring": ^7.8.2
+    "@polkadot/types": ^6.11.1
+    typescript: ^4.5.2
+  checksum: 49ec1258d3512641b053ed33e7420d9fbaade1615dbbc2202bc8ca7d40cfa462afc90e9f624e549ec59774fcf11502412ebdf9e34e041cec7d780c5d535a28f5
   languageName: node
   linkType: hard
 
@@ -13904,7 +13864,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.1.0, rxjs@npm:^7.2.0, rxjs@npm:^7.3.0, rxjs@npm:^7.4.0":
+"rxjs@npm:^7.1.0, rxjs@npm:^7.2.0, rxjs@npm:^7.4.0":
   version: 7.4.0
   resolution: "rxjs@npm:7.4.0"
   dependencies:
@@ -15391,13 +15351,23 @@ typescript@4.3.5:
   languageName: node
   linkType: hard
 
-"typescript@^4.3.5, typescript@^4.4.4":
+typescript@^4.4.4:
   version: 4.4.4
   resolution: "typescript@npm:4.4.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 89ecb8436bb48ef5594d49289f5f89103071716b6e4844278f4fb3362856e31203e187a9c76d205c3f0b674d221a058fd28310dbcbcf5d95e9a57229bb5203f1
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.5.2":
+  version: 4.5.5
+  resolution: "typescript@npm:4.5.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
   languageName: node
   linkType: hard
 
@@ -15411,13 +15381,23 @@ typescript@4.3.5:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.3.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.4.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.4.4#~builtin<compat/typescript>":
   version: 4.4.4
   resolution: "typescript@patch:typescript@npm%3A4.4.4#~builtin<compat/typescript>::version=4.4.4&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: bd629ad0da4a15d79aaad56baf3ee7d96f6a181760d430ae77f8c5325df7bffd9edee57544a3970e3651e8b796fe03a5838a7eb39c6d46cc3866c0b23d36a0dd
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.5.2#~builtin<compat/typescript>":
+  version: 4.5.5
+  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=493e53"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: c05c318d79c690f101d7ffb34cd6c7d6bbd884d3af9cefe7749ad0cd6be43c7082f098280982ca945dcba23fde34a08fed9602bb26540936baf8c0520727d3ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Allows creating new datasources from templates within a handler

### Changes

* Introduces new v0.2.1 project manifest version which adds templates property
* Injects a function called `createDynamicDatasource` into the sandbox to allow creating a new datasource dynamically from a template datasource in the project manifest. These dynamic datasources are stored in the project metadata table


Example project and branch https://github.com/subquery/query-registry-subquery-project/tree/dynamic-ds

### TODO

- [x] Setup codegen to provide better types for creating a dynamic datasource so that `createDynamicDatasource` isn't called directly
- [x] Make sure that a database transaction is used for creating dynamic datasources
- [x] Docs https://github.com/subquery/documentation/pull/48

### Limitations
- If a dynamic DS creates another dynamic DS in the same block it will not get run that block
- With EVM the abis are static and cant easily be updated if the contract changes before its deployed
- Dynamic datasources cant be removed, this could end up slowing performance