### PR TITLE
Fix failing test because of updated example project

### DIFF
--- a/packages/validator/src/validator.spec.ts
+++ b/packages/validator/src/validator.spec.ts
@@ -15,8 +15,7 @@ describe('Validator', () => {
 
   it('should validate get reports', async () => {
     const result = await v.getValidateReports();
-    expect(result.length).toBe(8);
-    expect(result.filter((r) => r.valid).length).toBe(8);
+    expect(result.filter((r) => r.valid).length).toBe(result.length);
   });
 
   it('should return validate result', async () => {


### PR DESCRIPTION
The example project used by a validator test was updated to new manifest spec version https://github.com/subquery/tutorials-block-timestamp/commit/e1ad5f9f3aaa551b4ab1db71516f8b8096a6d94f breaking the number of validations run on it.

Updates the test to check that all validations pass rather than the correct number of validations are run.