### PR TITLE
Fix codegen importing jsonType interface multiple times

### DIFF
--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -18,7 +18,7 @@ import {
   isCustomDs,
 } from '@subql/common';
 import ejs from 'ejs';
-import {upperFirst} from 'lodash';
+import {upperFirst, uniq} from 'lodash';
 import rimraf from 'rimraf';
 
 const MODEL_TEMPLATE_PATH = path.resolve(__dirname, '../template/model.ts.ejs');
@@ -219,7 +219,7 @@ export async function generateModels(projectPath: string, schema: string): Promi
     const className = upperFirst(entity.name);
     const entityName = entity.name;
     const fields = processFields('entity', className, entity.fields, entity.indexes);
-    const importJsonInterfaces = fields.filter((field) => field.isJsonInterface).map((f) => f.type);
+    const importJsonInterfaces = uniq(fields.filter((field) => field.isJsonInterface).map((f) => f.type));
     const importEnums = fields.filter((field) => field.isEnum).map((f) => f.type);
     const indexedFields = fields.filter((field) => field.indexed && !field.isJsonInterface);
     const modelTemplate = {


### PR DESCRIPTION
If you had a jsonType for two properties in the same entity it would import it twice. The PR fixes the duplicate import.

Example:
```yaml
type EraValue @jsonField {
  era: Int!
  value: BigInt!
  valueAfter: BigInt!
}

type Indexer @entity {
  id: ID! # Indexers address

  commission: EraValue!
  totalStake: EraValue!
}
```

This would result in below causing a compiler error

```ts
import {
    EraValue,
    EraValue,
} from '../interfaces'
```