### PR TITLE
Lowercase moonbeam dictionary query fields

### DIFF
--- a/packages/contract-processors/src/moonbeam.ts
+++ b/packages/contract-processors/src/moonbeam.ts
@@ -281,7 +281,10 @@ const EventProcessor: SecondLayerHandlerProcessor<
       conditions: [],
     };
     if (ds.processor?.options?.address) {
-      queryEntry.conditions.push({field: 'address', value: ds.processor?.options?.address});
+      queryEntry.conditions.push({
+        field: 'address',
+        value: ds.processor.options.address.toLowerCase(),
+      });
     } else {
       return;
     }
@@ -403,10 +406,10 @@ const CallProcessor: SecondLayerHandlerProcessor<
       conditions: [],
     };
     if (ds.processor?.options?.address) {
-      queryEntry.conditions.push({field: 'to', value: ds.processor?.options?.address});
+      queryEntry.conditions.push({field: 'to', value: ds.processor.options.address.toLowerCase()});
     }
     if (filter?.from) {
-      queryEntry.conditions.push({field: 'from', value: filter?.from});
+      queryEntry.conditions.push({field: 'from', value: filter.from.toLowerCase()});
     }
 
     if (filter?.function) {


### PR DESCRIPTION
If addresses used in a project that uses moonbeam datasources are not lower case then the dictionary will not find the correct results. 

It is common for ethereum addresses to be in [checksum](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md) format which will cause issues. 

Example fix on another project https://github.com/solarbeamio/solarbeam-vaults-subquery/pull/1. This PR will guard against projects that use checksum addresses