### PR TITLE
Update polkadot api to 7.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "^4.4.4"
   },
   "resolutions": {
-    "@polkadot/api": "7.8.1",
+    "@polkadot/api": "7.9.1",
     "@polkadot/util": "8.4.1"
   },
   "scripts": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -24,7 +24,7 @@
     "@nestjs/event-emitter": "^1.0.0",
     "@nestjs/platform-express": "^8.2.6",
     "@nestjs/schedule": "^1.0.2",
-    "@polkadot/api": "7.8.1",
+    "@polkadot/api": "7.9.1",
     "@subql/common": "workspace:*",
     "@subql/types": "workspace:*",
     "@subql/x-merkle-mountain-range": "2.0.0-0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3869,74 +3869,74 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/api-augment@npm:7.8.1"
+"@polkadot/api-augment@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/api-augment@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/api-base": 7.8.1
-    "@polkadot/rpc-augment": 7.8.1
-    "@polkadot/types": 7.8.1
-    "@polkadot/types-augment": 7.8.1
-    "@polkadot/types-codec": 7.8.1
+    "@polkadot/api-base": 7.9.1
+    "@polkadot/rpc-augment": 7.9.1
+    "@polkadot/types": 7.9.1
+    "@polkadot/types-augment": 7.9.1
+    "@polkadot/types-codec": 7.9.1
     "@polkadot/util": ^8.4.1
-  checksum: 3b13fce258bf93c95c9075e18a865e287da1909f27e68c8c63626fda5093bb050f75198d51820bbcfdd0bfb770fe4ea54b82e35876cbc83772de1ecc00f7e508
+  checksum: a3abec0a84c8476f1513615a1a8c45354a18531c4066a8e775009ebd737efa04a39833eaeca5f1a7422edc325c52d9175c9f5ce72dbffb5932a24b9054f5b31c
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/api-base@npm:7.8.1"
+"@polkadot/api-base@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/api-base@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/rpc-core": 7.8.1
-    "@polkadot/types": 7.8.1
+    "@polkadot/rpc-core": 7.9.1
+    "@polkadot/types": 7.9.1
     "@polkadot/util": ^8.4.1
     rxjs: ^7.5.4
-  checksum: 1098995294d7249e10f50059e106a9681740b17af2021db53771bc1951302fedc448f9c87f6d7edf62daa0653af0c8213d0a40b3dbc154f27b53094f36df533b
+  checksum: 299cea6eed65a6bbec5fa696d0d7fc4ca40405839e100ef1c2f38b14b36d060752195f6617d73df65e89805329c30fbbcdd6f774c0770a71a91392e52f88870b
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/api-derive@npm:7.8.1"
+"@polkadot/api-derive@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/api-derive@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/api": 7.8.1
-    "@polkadot/api-augment": 7.8.1
-    "@polkadot/api-base": 7.8.1
-    "@polkadot/rpc-core": 7.8.1
-    "@polkadot/types": 7.8.1
-    "@polkadot/types-codec": 7.8.1
+    "@polkadot/api": 7.9.1
+    "@polkadot/api-augment": 7.9.1
+    "@polkadot/api-base": 7.9.1
+    "@polkadot/rpc-core": 7.9.1
+    "@polkadot/types": 7.9.1
+    "@polkadot/types-codec": 7.9.1
     "@polkadot/util": ^8.4.1
     "@polkadot/util-crypto": ^8.4.1
     rxjs: ^7.5.4
-  checksum: ded3bc1a6e0690c16277978c4baeace14accd4a1e8a6e13ad8eb94fdf654c9b8c1058e735eca0614ed9f8da534b1484b08c41d3b32402ae86693d9dc182e8532
+  checksum: 0de8c30534e9147da21ed1a8b946b9041ed990ede388c220a3deb084a8364b36533e73c5076682e7e3ae7a41ac1d35e813494ec0408cdc13eed0a67c84b9c791
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/api@npm:7.8.1"
+"@polkadot/api@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/api@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/api-augment": 7.8.1
-    "@polkadot/api-base": 7.8.1
-    "@polkadot/api-derive": 7.8.1
+    "@polkadot/api-augment": 7.9.1
+    "@polkadot/api-base": 7.9.1
+    "@polkadot/api-derive": 7.9.1
     "@polkadot/keyring": ^8.4.1
-    "@polkadot/rpc-augment": 7.8.1
-    "@polkadot/rpc-core": 7.8.1
-    "@polkadot/rpc-provider": 7.8.1
-    "@polkadot/types": 7.8.1
-    "@polkadot/types-augment": 7.8.1
-    "@polkadot/types-codec": 7.8.1
-    "@polkadot/types-create": 7.8.1
-    "@polkadot/types-known": 7.8.1
+    "@polkadot/rpc-augment": 7.9.1
+    "@polkadot/rpc-core": 7.9.1
+    "@polkadot/rpc-provider": 7.9.1
+    "@polkadot/types": 7.9.1
+    "@polkadot/types-augment": 7.9.1
+    "@polkadot/types-codec": 7.9.1
+    "@polkadot/types-create": 7.9.1
+    "@polkadot/types-known": 7.9.1
     "@polkadot/util": ^8.4.1
     "@polkadot/util-crypto": ^8.4.1
     eventemitter3: ^4.0.7
     rxjs: ^7.5.4
-  checksum: 5396f34e5876a60ad2a5b4f9fbeb027bba790d431645e146242a044a595d338ef85feecd16483602648c38a1e25649383583a78247149a8aee2fbfbc5d5ea021
+  checksum: 2e31f0c3e4d500a8b9f789fae445e2a00ca495b09f94c3c3a6de090a554c289786f5b229d321227809846238f37cb729dff36a3934ac2cae186bcaf1d4c3e924
   languageName: node
   linkType: hard
 
@@ -3998,41 +3998,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/rpc-augment@npm:7.8.1"
+"@polkadot/rpc-augment@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/rpc-augment@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/rpc-core": 7.8.1
-    "@polkadot/types": 7.8.1
-    "@polkadot/types-codec": 7.8.1
+    "@polkadot/rpc-core": 7.9.1
+    "@polkadot/types": 7.9.1
+    "@polkadot/types-codec": 7.9.1
     "@polkadot/util": ^8.4.1
-  checksum: 87e4fc27eb9c7a79c5c28519bd7840694b2309bc4286e2af161451df6b7f21e5950bd19e39e5b71ad3f7b544ca9bfdf6101f722e48297f93608c522d29c55032
+  checksum: ef2fc18a78cbb021b44409981d41babe39dec38230ccbef486c1ac1c3d144663004a8fdbe26fee3807d48e94144a88ec42d003f60831d7c36d3dccc562704170
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/rpc-core@npm:7.8.1"
+"@polkadot/rpc-core@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/rpc-core@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/rpc-augment": 7.8.1
-    "@polkadot/rpc-provider": 7.8.1
-    "@polkadot/types": 7.8.1
+    "@polkadot/rpc-augment": 7.9.1
+    "@polkadot/rpc-provider": 7.9.1
+    "@polkadot/types": 7.9.1
     "@polkadot/util": ^8.4.1
     rxjs: ^7.5.4
-  checksum: db2b986519c8397d220ac434bb7d8580a0e1153a2b1d1295ab0443cfae1fbee2570a47289a39ee803ef8990d8c935c984e9a89b1e781d444e801a16363c0af35
+  checksum: dd4f9718f0245171d35ec335cb070e34902fecb8c768f5033c7a4de3921e6b7339d0444e8b0d77a8651bc0b6081c55f3cebf8eb828facaeded10b157a5684d06
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/rpc-provider@npm:7.8.1"
+"@polkadot/rpc-provider@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/rpc-provider@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
     "@polkadot/keyring": ^8.4.1
-    "@polkadot/types": 7.8.1
-    "@polkadot/types-support": 7.8.1
+    "@polkadot/types": 7.9.1
+    "@polkadot/types-support": 7.9.1
     "@polkadot/util": ^8.4.1
     "@polkadot/util-crypto": ^8.4.1
     "@polkadot/x-fetch": ^8.4.1
@@ -4041,40 +4041,40 @@ __metadata:
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.2
     nock: ^13.2.4
-  checksum: 3d1dec9152affc5ec7ea02bb7713eb2ee7faae780e4aaa033998d203ba8c505e2b0b9b8ad457a731db7405658a1d89b3ac39a5fa5d41d5face20dec7587cf37e
+  checksum: 93d0c4bcc1b3329dc6273fd6323d338ffac64295a2725178876dee8200dbb2d189d134d5d8ab991e4c4557784a0db303ce228e582a1cd565b84b33bffd304668
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/types-augment@npm:7.8.1"
+"@polkadot/types-augment@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/types-augment@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/types": 7.8.1
-    "@polkadot/types-codec": 7.8.1
+    "@polkadot/types": 7.9.1
+    "@polkadot/types-codec": 7.9.1
     "@polkadot/util": ^8.4.1
-  checksum: 9a83042e860465a41736a82d7acb97eeac47f8ed5f3bd2f044c0e4a80dd94a969882004be00684a1e703245d7c71e2deb5b13fd51ad0d131563a876f41c82d42
+  checksum: 6ffcfe5677d5291e938ece27e611d8a33171cf236b12353110e8dcff3ae645bb127a3370158ff7446c5c228eec7bb8e83f5973679dc77bb672d0936171a9726d
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/types-codec@npm:7.8.1"
+"@polkadot/types-codec@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/types-codec@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
     "@polkadot/util": ^8.4.1
-  checksum: 63f41356a2f598444df38f25320ae65d9569c50983d03fb07e2910943b6831fa57cb92a910118b93047a0326c0663ed1811d14186a67d90003a2e36bed8d93bd
+  checksum: 0142c30b3738df11920ff9e97be8be7f9dafda340cc6fcdb67358193b299a3bd0eea09f291d3c8a9190086059367dba95a718b1a64510bfe10e26a9a4a537b26
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/types-create@npm:7.8.1"
+"@polkadot/types-create@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/types-create@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/types-codec": 7.8.1
+    "@polkadot/types-codec": 7.9.1
     "@polkadot/util": ^8.4.1
-  checksum: 80f464cb90b9b09bf48600d4663b01982a196847b091b0375c1275c2d413ec6f970290ed4f413e0aa0ab892a6aa00e6a7c2b26ddc31be45cfd60c35434d260ed
+  checksum: 6f457bee00aa7898e87e0af92fc01ff55d50ab94b8baefd0ca06841faf7048f3d6447cfb5a133fc34631762d6befa9666278bbc0fdaf4e82fb54704b1b3d30a8
   languageName: node
   linkType: hard
 
@@ -4090,27 +4090,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/types-known@npm:7.8.1"
+"@polkadot/types-known@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/types-known@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
     "@polkadot/networks": ^8.4.1
-    "@polkadot/types": 7.8.1
-    "@polkadot/types-codec": 7.8.1
-    "@polkadot/types-create": 7.8.1
+    "@polkadot/types": 7.9.1
+    "@polkadot/types-codec": 7.9.1
+    "@polkadot/types-create": 7.9.1
     "@polkadot/util": ^8.4.1
-  checksum: 9d0809aa2f94f5dcf8dd3b6a965d3991a93014f85926f33168c92cb204bed73bd81207041ae8f7ff6e6f3e36d0c48c46985272bf2c927be3ac7888ef33dd0b28
+  checksum: 6b335e74ab199eaa0fd510b27eaaeac75ba4cc8bea13b551e3b5100288f39e5369ab4c6cc3cb36ce0d7958cade37f52f552f2c28555acd8fefe206da8f255885
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/types-support@npm:7.8.1"
+"@polkadot/types-support@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/types-support@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
     "@polkadot/util": ^8.4.1
-  checksum: 1295f6725ca7fb5d2b1957bec68993df6b2b4d37e4c1540d1802a4dd6ea80d5051d4764e4a0c6a2e0be0d6728fcb7d64367ac8e9a6f571f511f594e6a4bc8719
+  checksum: 992e0cb63c6cfe6c84772c4f08cfd63ffa69db78aba5a86bc93b5a6f6ecf41590287d5c28d1812e8105dc2ca4c1e49ec88c394633e95ff005b6bc9fc08894948
   languageName: node
   linkType: hard
 
@@ -4127,19 +4127,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:7.8.1":
-  version: 7.8.1
-  resolution: "@polkadot/types@npm:7.8.1"
+"@polkadot/types@npm:7.9.1":
+  version: 7.9.1
+  resolution: "@polkadot/types@npm:7.9.1"
   dependencies:
     "@babel/runtime": ^7.17.2
     "@polkadot/keyring": ^8.4.1
-    "@polkadot/types-augment": 7.8.1
-    "@polkadot/types-codec": 7.8.1
-    "@polkadot/types-create": 7.8.1
+    "@polkadot/types-augment": 7.9.1
+    "@polkadot/types-codec": 7.9.1
+    "@polkadot/types-create": 7.9.1
     "@polkadot/util": ^8.4.1
     "@polkadot/util-crypto": ^8.4.1
     rxjs: ^7.5.4
-  checksum: 7eaad9dc2059b80534c255cd338c9e609372edcac7e6dc1798f83c89a5d4ab999dd44410e5c81b5b4cae219783d46c650d4a899a45339abab433181033e6ef71
+  checksum: 0f6008b4ad7f563283dffa84124d60bfd8d85caccf39a9f9e321279fe5deaecd995ac98fdf935f5c9760cec512100753554bcd9fe895c36da7896c8db40c68c8
   languageName: node
   linkType: hard
 
@@ -4582,7 +4582,7 @@ __metadata:
     "@nestjs/schedule": ^1.0.2
     "@nestjs/schematics": ^8.0.5
     "@nestjs/testing": ^8.2.6
-    "@polkadot/api": 7.8.1
+    "@polkadot/api": 7.9.1
     "@subql/common": "workspace:*"
     "@subql/types": "workspace:*"
     "@subql/x-merkle-mountain-range": 2.0.0-0.1.1


### PR DESCRIPTION
Contains a fix for eth historical rpc methods with blocknumber
https://github.com/polkadot-js/api/releases/tag/v7.9.1