### PR TITLE
Allow specifying 'ipfs-headers' option to node

### DIFF
--- a/packages/common/src/project/readers/ipfs-reader.ts
+++ b/packages/common/src/project/readers/ipfs-reader.ts
@@ -16,11 +16,14 @@ const CIDv1 = new RegExp(
 export class IPFSReader implements Reader {
   private ipfs: IPFS.IPFSHTTPClient;
 
-  constructor(private readonly cid: string, gateway?: string) {
+  constructor(private readonly cid: string, gateway?: string, headers?: Record<string, string>) {
     if (!CIDv0.test(cid) && !CIDv1.test(cid)) {
       throw new Error('IPFS project path CID is not valid');
     }
-    this.ipfs = IPFS.create({url: gateway ?? IPFS_NODE_ENDPOINT});
+    this.ipfs = IPFS.create({
+      url: gateway ?? IPFS_NODE_ENDPOINT,
+      headers,
+    });
   }
 
   get root(): undefined {

--- a/packages/common/src/project/readers/reader.ts
+++ b/packages/common/src/project/readers/reader.ts
@@ -11,6 +11,7 @@ import {LocalReader} from './local-reader';
 
 export type ReaderOptions = {
   ipfs?: string;
+  ipfsHeaders?: Record<string, string>;
 };
 
 export interface Reader {
@@ -31,7 +32,7 @@ export class ReaderFactory {
 
     const ipfsMatch = location.match(IPFS_REGEX);
     if (ipfsMatch) {
-      return new IPFSReader(location.replace('ipfs://', ''), options.ipfs);
+      return new IPFSReader(location.replace('ipfs://', ''), options.ipfs, options.ipfsHeaders);
     }
 
     //local mode

--- a/packages/node/src/configure/NodeConfig.ts
+++ b/packages/node/src/configure/NodeConfig.ts
@@ -31,6 +31,7 @@ export interface IConfig {
   readonly proofOfIndex: boolean;
   readonly mmrPath?: string;
   readonly ipfs?: string;
+  readonly ipfsHeaders?: Record<string, string>;
 }
 
 export type MinConfig = Partial<Omit<IConfig, 'subquery'>> &
@@ -140,6 +141,10 @@ export class NodeConfig implements IConfig {
   }
   get ipfs(): string {
     return this._config.ipfs;
+  }
+
+  get ipfsHeaders(): Record<string, string> {
+    return this._config.ipfsHeaders;
   }
 
   get dbSchema(): string {

--- a/packages/node/src/configure/configure.module.ts
+++ b/packages/node/src/configure/configure.module.ts
@@ -26,11 +26,15 @@ function yargsToIConfig(yargs: Args): Partial<IConfig> {
   return Object.entries(yargs).reduce((acc, [key, value]) => {
     if (['_', '$0'].includes(key)) return acc;
 
-    if (key === 'network-registry') {
+    if (
+      key === 'network-registry' ||
+      key === 'ipfs-headers' ||
+      key === 'ipfsHeaders'
+    ) {
       try {
         value = JSON.parse(value as string);
       } catch (e) {
-        throw new Error('Argument `network-registry` is not valid JSON');
+        throw new Error(`Argument "${key}" is not valid JSON`);
       }
     }
     acc[YargsNameMapping[key] ?? camelCase(key)] = value;
@@ -129,6 +133,7 @@ export class ConfigureModule {
         ),
         {
           ipfs: config.ipfs,
+          ipfsHeaders: config.ipfsHeaders,
         },
       ).catch((err) => {
         logger.error(err, 'Create Subquery project from given path failed!');

--- a/packages/node/src/configure/configure.module.ts
+++ b/packages/node/src/configure/configure.module.ts
@@ -18,6 +18,7 @@ const logger = getLogger('configure');
 
 const YargsNameMapping = {
   local: 'localMode',
+  'ipfs-header': 'ipfsHeaders',
 };
 
 type Args = ReturnType<typeof getYargsOption>['argv'];
@@ -26,16 +27,21 @@ function yargsToIConfig(yargs: Args): Partial<IConfig> {
   return Object.entries(yargs).reduce((acc, [key, value]) => {
     if (['_', '$0'].includes(key)) return acc;
 
-    if (
-      key === 'network-registry' ||
-      key === 'ipfs-headers' ||
-      key === 'ipfsHeaders'
-    ) {
+    if (key === 'network-registry') {
       try {
         value = JSON.parse(value as string);
       } catch (e) {
         throw new Error(`Argument "${key}" is not valid JSON`);
       }
+    }
+
+    if (key === 'ipfs-header') {
+      value = (value as string[]).reduce((acc, header) => {
+        const [headerKey, headerValue] = header.split(':').map((v) => v.trim());
+        acc[headerKey] = headerValue;
+
+        return acc;
+      }, {});
     }
     acc[YargsNameMapping[key] ?? camelCase(key)] = value;
     return acc;

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -128,6 +128,11 @@ export function getYargsOption() {
       describe: 'IPFS gateway endpoint',
       type: 'string',
     },
+    'ipfs-headers': {
+      demandOption: false,
+      describe: 'JSON object providing headers to IPFS requests',
+      type: 'string',
+    },
     port: {
       alias: 'p',
       demandOption: false,

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -128,10 +128,10 @@ export function getYargsOption() {
       describe: 'IPFS gateway endpoint',
       type: 'string',
     },
-    'ipfs-headers': {
+    'ipfs-header': {
       demandOption: false,
-      describe: 'JSON object providing headers to IPFS requests',
-      type: 'string',
+      describe: `Headers to provide with IPFS requests. e.g --ipfs-header "X-Custom-Header: value"`,
+      type: 'array',
     },
     port: {
       alias: 'p',


### PR DESCRIPTION
Effectively allows authorization for IPFS

Example flags:
*  ~~`--ipfs-headers "{ \"Authorization\": \"Bearer <Your-Auth-Token-Here>\"}"`~~
* `--ipfs-header "Authorization: Bearer <Your-Auth-Token-Here>" "X-Custom-Header: value"`
* `--ipfs-header "Authorization: Bearer <Your-Auth-Token-Here>"  --ipfs-header "X-Custom-Header: value"`