### PR TITLE
fix terra node require subql/common

### DIFF
--- a/packages/common-substrate/package.json
+++ b/packages/common-substrate/package.json
@@ -13,7 +13,7 @@
   "main": "dist/index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "@polkadot/util": "^7.9.2",
+    "@polkadot/util": "^8",
     "@subql/common": "workspace:*",
     "@subql/types": "workspace:*",
     "bn.js": "4.11.6",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,6 +13,7 @@
   "main": "dist/index.js",
   "license": "Apache-2.0",
   "dependencies": {
+    "@polkadot/util": "^8",
     "@subql/x-vm2": "^3.9.3-0.1.0",
     "ansi-styles": "^6.1.0",
     "bn.js": "5.2.0",


### PR DESCRIPTION
 but its util methods missing polkadot/util

Error stacks
```
Error: Cannot find module '@polkadot/util'
Require stack:
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/node_modules/@subql/common/dist/project/readers/ipfs-reader.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/node_modules/@subql/common/dist/project/readers/reader.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/node_modules/@subql/common/dist/project/readers/index.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/node_modules/@subql/common/dist/project/index.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/node_modules/@subql/common/dist/index.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/dist/main.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/bin/run
```