### PR TITLE
Fix missing terra.js

### DIFF
--- a/packages/node-terra/package.json
+++ b/packages/node-terra/package.json
@@ -29,6 +29,7 @@
     "@subql/types-terra": "workspace:*",
     "@subql/x-merkle-mountain-range": "2.0.0-0.1.1",
     "@subql/x-vm2": "^3.9.3-0.1.0",
+    "@terra-money/terra.js": "^3.0.1",
     "@willsoto/nestjs-prometheus": "^4.2.0",
     "app-module-path": "^2.2.0",
     "dayjs": "^1.10.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4798,6 +4798,7 @@ __metadata:
     "@subql/types-terra": "workspace:*"
     "@subql/x-merkle-mountain-range": 2.0.0-0.1.1
     "@subql/x-vm2": ^3.9.3-0.1.0
+    "@terra-money/terra.js": ^3.0.1
     "@types/app-module-path": ^2.2.0
     "@types/express": ^4.17.13
     "@types/jest": ^27.0.2


### PR DESCRIPTION
Error stacks:

  throw err;
  ^
Error: Cannot find module '@terra-money/terra.js'
Require stack:
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/dist/indexer/apiterra.service.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/dist/indexer/indexer.module.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/dist/app.module.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/dist/main.js
- /Users/jiatwork/.nvm/versions/node/v14.18.1/lib/node_modules/@subql/node-terra/bin/run
