### PR TITLE
Fix running project from IPFS with custom ds

### DIFF
--- a/packages/common-substrate/src/project/versioned/v0_2_0/types.ts
+++ b/packages/common-substrate/src/project/versioned/v0_2_0/types.ts
@@ -44,6 +44,12 @@ export interface ProjectManifestV0_2_0 extends ISubstrateProjectManifest {
   dataSources: (RuntimeDataSourceV0_2_0 | CustomDatasourceV0_2_0)[];
 }
 
+export function isDatasourceV0_2_0(
+  dataSource: SubqlDatasource
+): dataSource is RuntimeDataSourceV0_2_0 | CustomDatasourceV0_2_0 {
+  return !!(dataSource as RuntimeDataSourceV0_2_0).mapping.file;
+}
+
 export function isRuntimeDataSourceV0_2_0(dataSource: SubqlDatasource): dataSource is RuntimeDataSourceV0_2_0 {
-  return dataSource.kind === SubqlDatasourceKind.Runtime && !!(dataSource as RuntimeDataSourceV0_2_0).mapping.file;
+  return dataSource.kind === SubqlDatasourceKind.Runtime && isDatasourceV0_2_0(dataSource);
 }

--- a/packages/node-terra/src/utils/project.ts
+++ b/packages/node-terra/src/utils/project.ts
@@ -53,9 +53,7 @@ export function getProjectEntry(root: string): string {
 
     return projectEntryCache[pkgPath];
   } catch (err) {
-    throw new Error(
-      `can not find package.json within directory ${this.option.root}`,
-    );
+    throw new Error(`can not find package.json within directory ${root}`);
   }
 }
 

--- a/packages/node/src/indexer/sandbox.service.ts
+++ b/packages/node/src/indexer/sandbox.service.ts
@@ -4,7 +4,7 @@
 import path from 'path';
 import { Injectable } from '@nestjs/common';
 import { levelFilter } from '@subql/common';
-import { isRuntimeDataSourceV0_2_0 } from '@subql/common-substrate';
+import { isDatasourceV0_2_0 } from '@subql/common-substrate';
 import { Store, SubqlDatasource } from '@subql/types';
 import { NodeVM, NodeVMOptions, VMScript } from '@subql/x-vm2';
 import { merge } from 'lodash';
@@ -137,7 +137,7 @@ export class SandboxService {
   }
 
   private getDataSourceEntry(ds: SubqlDatasource): string {
-    if (isRuntimeDataSourceV0_2_0(ds)) {
+    if (isDatasourceV0_2_0(ds)) {
       return ds.mapping.file;
     } else {
       return getProjectEntry(this.project.root);

--- a/packages/node/src/utils/project.ts
+++ b/packages/node/src/utils/project.ts
@@ -58,9 +58,7 @@ export function getProjectEntry(root: string): string {
 
     return projectEntryCache[pkgPath];
   } catch (err) {
-    throw new Error(
-      `can not find package.json within directory ${this.option.root}`,
-    );
+    throw new Error(`can not find package.json within directory ${root}`);
   }
 }
 


### PR DESCRIPTION
Fixes a couple of issues:

- `getProjectEntry` when throwing an error using wrong `root` value. 
- Fix checking datasource entry in sandbox for custom datasources