### PR TITLE
Allow specifying terra api params, wrap api

### DIFF
--- a/packages/node-terra/src/configure/NodeConfig.ts
+++ b/packages/node-terra/src/configure/NodeConfig.ts
@@ -23,6 +23,7 @@ export interface IConfig {
   readonly preferRange: boolean;
   readonly networkEndpoint?: string;
   readonly networkDictionary?: string;
+  readonly networkEndpointParams?: Record<string, string>;
   readonly outputFmt?: 'json';
   readonly logLevel?: LevelWithSilent;
   readonly queryLimit: number;
@@ -106,6 +107,10 @@ export class NodeConfig implements IConfig {
 
   get networkDictionary(): string | undefined {
     return this._config.networkDictionary;
+  }
+
+  get networkEndpointParams(): Record<string, string> | undefined {
+    return this._config.networkEndpointParams;
   }
 
   get timeout(): number {

--- a/packages/node-terra/src/configure/configure.module.ts
+++ b/packages/node-terra/src/configure/configure.module.ts
@@ -14,6 +14,7 @@ import { SubqueryTerraProject } from './terraproject.model';
 
 const YargsNameMapping = {
   local: 'localMode',
+  'network-endpoint-param': 'networkEndpointParams',
 };
 
 type Args = ReturnType<typeof getYargsOption>['argv'];
@@ -28,6 +29,14 @@ function yargsToIConfig(yargs: Args): Partial<IConfig> {
       } catch (e) {
         throw new Error('Argument `network-registry` is not valid JSON');
       }
+    }
+    if (key === 'network-endpoint-param') {
+      value = (value as string[]).reduce((acc, header) => {
+        const [headerKey, headerValue] = header.split(':').map((v) => v.trim());
+        acc[headerKey] = headerValue;
+
+        return acc;
+      }, {});
     }
     acc[YargsNameMapping[key] ?? camelCase(key)] = value;
     return acc;

--- a/packages/node-terra/src/indexer/apiterra.service.ts
+++ b/packages/node-terra/src/indexer/apiterra.service.ts
@@ -77,10 +77,7 @@ export class TerraClient {
   }
 
   async txInfo(hash: string): Promise<TxInfo> {
-    return this.baseApi.tx.txInfo(hashToHex(hash), this.params).catch((e) => {
-      console.log('XXXXXX failed to get tx', e);
-      throw e;
-    });
+    return this.baseApi.tx.txInfo(hashToHex(hash), this.params);
   }
 
   get getLCDClient(): LCDClient {

--- a/packages/node-terra/src/indexer/fetchterra.service.test.ts
+++ b/packages/node-terra/src/indexer/fetchterra.service.test.ts
@@ -1,0 +1,92 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  SubqlTerraDatasourceKind,
+  SubqlTerraHandlerKind,
+} from '@subql/types-terra';
+import { GraphQLSchema } from 'graphql';
+import { NodeConfig } from '../configure/NodeConfig';
+import { SubqueryTerraProject } from '../configure/terraproject.model';
+import { ApiTerraService } from './apiterra.service';
+import { TerraDictionaryService } from './dictionaryterra.service';
+import { FetchTerraService } from './fetchterra.service';
+import { TerraDsProcessorService } from './terrads-processor.service';
+
+const ENDPOINT = 'https://terra.stakesystems.io';
+const CHAIN_ID = 'columbus-5';
+
+function testTerraProject(): SubqueryTerraProject {
+  return {
+    network: {
+      endpoint: ENDPOINT,
+      chainId: CHAIN_ID,
+    },
+    dataSources: [
+      {
+        name: 'runtime',
+        kind: SubqlTerraDatasourceKind.Runtime,
+        startBlock: 6000000,
+        mapping: {
+          file: '',
+          entryScript: '',
+          handlers: [
+            { handler: 'handleTest', kind: SubqlTerraHandlerKind.Block },
+          ],
+        },
+      },
+    ],
+    id: 'test',
+    root: './',
+    schema: new GraphQLSchema({}),
+    templates: [],
+  };
+}
+
+jest.setTimeout(200000);
+
+async function createFetchService(
+  project = testTerraProject(),
+  batchSize = 5,
+): Promise<FetchTerraService> {
+  const apiService = new ApiTerraService(project, {} as any);
+  await apiService.init();
+  const dsPluginService = new TerraDsProcessorService(project);
+  const dictionaryService = new TerraDictionaryService(project);
+  return new FetchTerraService(
+    apiService,
+    new NodeConfig({ subquery: '', subqueryName: '', batchSize }),
+    project,
+    dictionaryService,
+    dsPluginService,
+    new EventEmitter2(),
+  );
+}
+
+describe('FetchService', () => {
+  let fetchService: FetchTerraService;
+  //
+  // afterEach(() => {
+  //   return (
+  //     fetchService as unknown as any
+  //   )?.apiService?.onApplicationShutdown();
+  // });
+
+  it('fetch blocks', async () => {
+    const batchSize = 5;
+    const project = testTerraProject();
+
+    fetchService = await createFetchService(project, batchSize);
+    await fetchService.init();
+
+    const loopPromise = fetchService.startLoop(6684553);
+    // eslint-disable-next-line @typescript-eslint/require-await
+    fetchService.register(async (content) => {
+      if (Number(content.block.block.header.height) === 6684563) {
+        fetchService.onApplicationShutdown();
+      }
+    });
+    await loopPromise;
+  }, 500000);
+});

--- a/packages/node-terra/src/indexer/fetchterra.service.ts
+++ b/packages/node-terra/src/indexer/fetchterra.service.ts
@@ -28,7 +28,7 @@ import { isBaseTerraHandler, isCustomTerraHandler } from '../utils/project';
 import { delay } from '../utils/promise';
 import * as TerraUtil from '../utils/terra-helper';
 import { getYargsOption } from '../yargs';
-import { ApiTerraService } from './apiterra.service';
+import { ApiTerraService, TerraClient } from './apiterra.service';
 import { BlockedQueue } from './BlockedQueue';
 import {
   TerraDictionary,
@@ -129,7 +129,7 @@ export class FetchTerraService implements OnApplicationShutdown {
     this.isShutdown = true;
   }
 
-  get api(): LCDClient {
+  get api(): TerraClient {
     return this.apiService.getApi();
   }
 
@@ -236,7 +236,7 @@ export class FetchTerraService implements OnApplicationShutdown {
   }
 
   @Interval(CHECK_MEMORY_INTERVAL)
-  checkBatchScale() {
+  checkBatchScale(): void {
     if (argv['scale-batch-size']) {
       const scale = checkMemoryUsage(
         this.nodeConfig.batchSize,
@@ -250,13 +250,13 @@ export class FetchTerraService implements OnApplicationShutdown {
   }
 
   @Interval(BLOCK_TIME_VARIANCE * 1000)
-  async getLatestBlockHead() {
+  async getLatestBlockHead(): Promise<void> {
     if (!this.api) {
       logger.debug(`Skip fetch finalized block until API is ready`);
       return;
     }
     try {
-      const finalizedBlock = await this.api.tendermint.blockInfo();
+      const finalizedBlock = await this.api.blockInfo();
       const currentFinalizedHeight = parseInt(
         finalizedBlock.block.header.height,
       );
@@ -366,7 +366,8 @@ export class FetchTerraService implements OnApplicationShutdown {
     { _metadata: metaData }: TerraDictionary,
     startBlockHeight: number,
   ): Promise<boolean> {
-    const nodeInfo: any = await this.api.tendermint.nodeInfo();
+    const nodeInfo = await this.api.nodeInfo();
+
     if (metaData.chainId !== nodeInfo.default_node_info.network) {
       logger.warn(`Dictionary is disabled since now`);
       this.useDictionary = false;
@@ -394,28 +395,33 @@ export class FetchTerraService implements OnApplicationShutdown {
   }
 
   async fillBlockBuffer(): Promise<void> {
-    while (!this.isShutdown) {
-      const takeCount = Math.min(
-        this.blockBuffer.freeSize,
-        Math.round(this.batchSizeScale * this.nodeConfig.batchSize),
-      );
+    try {
+      while (!this.isShutdown) {
+        const takeCount = Math.min(
+          this.blockBuffer.freeSize,
+          Math.round(this.batchSizeScale * this.nodeConfig.batchSize),
+        );
 
-      if (this.blockNumberBuffer.size === 0 || takeCount === 0) {
-        await delay(1);
-        continue;
+        if (this.blockNumberBuffer.size === 0 || takeCount === 0) {
+          await delay(1);
+          continue;
+        }
+
+        const bufferBlocks = await this.blockNumberBuffer.takeAll(takeCount);
+        const blocks = await fetchBlocksBatches(this.api, bufferBlocks);
+        logger.info(
+          `fetch block [${bufferBlocks[0]},${
+            bufferBlocks[bufferBlocks.length - 1]
+          }], total ${bufferBlocks.length} blocks`,
+        );
+        this.blockBuffer.putAll(blocks);
+        this.eventEmitter.emit(IndexerEvent.BlockQueueSize, {
+          value: this.blockBuffer.size,
+        });
       }
-
-      const bufferBlocks = await this.blockNumberBuffer.takeAll(takeCount);
-      const blocks = await fetchBlocksBatches(this.api, bufferBlocks);
-      logger.info(
-        `fetch block [${bufferBlocks[0]},${
-          bufferBlocks[bufferBlocks.length - 1]
-        }], total ${bufferBlocks.length} blocks`,
-      );
-      this.blockBuffer.putAll(blocks);
-      this.eventEmitter.emit(IndexerEvent.BlockQueueSize, {
-        value: this.blockBuffer.size,
-      });
+    } catch (e) {
+      console.log('XXXXXX fillBlockBuffer');
+      throw e;
     }
   }
 

--- a/packages/node-terra/src/indexer/fetchterra.service.ts
+++ b/packages/node-terra/src/indexer/fetchterra.service.ts
@@ -395,33 +395,28 @@ export class FetchTerraService implements OnApplicationShutdown {
   }
 
   async fillBlockBuffer(): Promise<void> {
-    try {
-      while (!this.isShutdown) {
-        const takeCount = Math.min(
-          this.blockBuffer.freeSize,
-          Math.round(this.batchSizeScale * this.nodeConfig.batchSize),
-        );
+    while (!this.isShutdown) {
+      const takeCount = Math.min(
+        this.blockBuffer.freeSize,
+        Math.round(this.batchSizeScale * this.nodeConfig.batchSize),
+      );
 
-        if (this.blockNumberBuffer.size === 0 || takeCount === 0) {
-          await delay(1);
-          continue;
-        }
-
-        const bufferBlocks = await this.blockNumberBuffer.takeAll(takeCount);
-        const blocks = await fetchBlocksBatches(this.api, bufferBlocks);
-        logger.info(
-          `fetch block [${bufferBlocks[0]},${
-            bufferBlocks[bufferBlocks.length - 1]
-          }], total ${bufferBlocks.length} blocks`,
-        );
-        this.blockBuffer.putAll(blocks);
-        this.eventEmitter.emit(IndexerEvent.BlockQueueSize, {
-          value: this.blockBuffer.size,
-        });
+      if (this.blockNumberBuffer.size === 0 || takeCount === 0) {
+        await delay(1);
+        continue;
       }
-    } catch (e) {
-      console.log('XXXXXX fillBlockBuffer');
-      throw e;
+
+      const bufferBlocks = await this.blockNumberBuffer.takeAll(takeCount);
+      const blocks = await fetchBlocksBatches(this.api, bufferBlocks);
+      logger.info(
+        `fetch block [${bufferBlocks[0]},${
+          bufferBlocks[bufferBlocks.length - 1]
+        }], total ${bufferBlocks.length} blocks`,
+      );
+      this.blockBuffer.putAll(blocks);
+      this.eventEmitter.emit(IndexerEvent.BlockQueueSize, {
+        value: this.blockBuffer.size,
+      });
     }
   }
 

--- a/packages/node-terra/src/indexer/indexer.module.ts
+++ b/packages/node-terra/src/indexer/indexer.module.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Module } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { NodeConfig } from '../configure/NodeConfig';
 import { SubqueryTerraProject } from '../configure/terraproject.model';
 import { DbModule } from '../db/db.module';
 import { ApiTerraService } from './apiterra.service';
@@ -25,13 +25,13 @@ import { DynamicDsService } from './terradynamic-ds.service';
       provide: ApiTerraService,
       useFactory: async (
         project: SubqueryTerraProject,
-        eventEmitter: EventEmitter2,
+        nodeConfig: NodeConfig,
       ) => {
-        const apiService = new ApiTerraService(project, eventEmitter);
+        const apiService = new ApiTerraService(project, nodeConfig);
         await apiService.init();
         return apiService;
       },
-      inject: [SubqueryTerraProject, EventEmitter2],
+      inject: [SubqueryTerraProject, NodeConfig],
     },
     FetchTerraService,
     BenchmarkService,

--- a/packages/node-terra/src/utils/terra-helper.ts
+++ b/packages/node-terra/src/utils/terra-helper.ts
@@ -91,7 +91,6 @@ export async function fetchTerraBlocksBatches(
   blockArray: number[],
 ): Promise<TerraBlockContent[]> {
   const blocks = await fetchTerraBlocksArray(api, blockArray);
-  console.log('XXXXX have raw blocks');
   return Promise.all(
     blocks.map(
       async (blockInfo) =>

--- a/packages/node-terra/src/utils/terra-helper.ts
+++ b/packages/node-terra/src/utils/terra-helper.ts
@@ -6,10 +6,10 @@ import {
   BlockInfo,
   EventsByType,
   hashToHex,
-  LCDClient,
   TxInfo,
   TxLog,
 } from '@terra-money/terra.js';
+import { TerraClient } from '../indexer/apiterra.service';
 import { TerraBlockContent } from '../indexer/types';
 import { getLogger } from './logger';
 
@@ -44,15 +44,15 @@ export function filterEvents(
   return filteredEvents;
 }
 
-async function getBlockByHeight(api: LCDClient, height: number) {
-  return api.tendermint.blockInfo(height).catch((e) => {
+async function getBlockByHeight(api: TerraClient, height: number) {
+  return api.blockInfo(height).catch((e) => {
     logger.error(`failed to fetch Block ${height}`);
     throw e;
   });
 }
 
 export async function fetchTerraBlocksArray(
-  api: LCDClient,
+  api: TerraClient,
   blockArray: number[],
 ): Promise<BlockInfo[]> {
   return Promise.all(
@@ -61,18 +61,18 @@ export async function fetchTerraBlocksArray(
 }
 
 export async function getTxInfobyHashes(
-  api: LCDClient,
+  api: TerraClient,
   txHashes: string[],
 ): Promise<TxInfo[]> {
   return Promise.all(
     txHashes.map(async (hash) => {
-      return api.tx.txInfo(hashToHex(hash));
+      return api.txInfo(hash);
     }),
   );
 }
 
 export async function getEventsByTypeFromBlock(
-  api: LCDClient,
+  api: TerraClient,
   blockInfo: BlockInfo,
 ): Promise<EventsByType[]> {
   const txHashes = blockInfo.block.data.txs;
@@ -87,10 +87,11 @@ export async function getEventsByTypeFromBlock(
 }
 
 export async function fetchTerraBlocksBatches(
-  api: LCDClient,
+  api: TerraClient,
   blockArray: number[],
 ): Promise<TerraBlockContent[]> {
   const blocks = await fetchTerraBlocksArray(api, blockArray);
+  console.log('XXXXX have raw blocks');
   return Promise.all(
     blocks.map(
       async (blockInfo) =>

--- a/packages/node-terra/src/yargs.ts
+++ b/packages/node-terra/src/yargs.ts
@@ -67,6 +67,12 @@ export function getYargsOption() {
       type: 'string',
       describe: 'Blockchain network endpoint to connect',
     },
+    'network-endpoint-param': {
+      demandOption: false,
+      type: 'array',
+      describe:
+        'Key value of api parameters passed to terra rpc. e.g. --network-endpoint-param "api_key: <your-api-key>"',
+    },
     'output-fmt': {
       demandOption: false,
       describe: 'Print log as json or plain text',


### PR DESCRIPTION
New cli option for terra node: `network-endpoint-param`.
Usage: `--network-endpoint-param "api_key: <your-api-key>"`

Wraps the consumed api methods to insert api params