### PR TITLE
Add support for querying historical state

### DIFF
--- a/packages/query/src/graphql/plugins/PgBlockHeightPlugin.ts
+++ b/packages/query/src/graphql/plugins/PgBlockHeightPlugin.ts
@@ -1,0 +1,83 @@
+// Copyright 2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {Plugin} from 'graphile-build';
+import {QueryBuilder} from 'graphile-build-pg';
+import {GraphQLString} from 'graphql';
+
+export const PgBlockHeightPlugin: Plugin = (builder) => {
+  // Adds blockHeight condition to join clause when joining a table that has _$block_height column
+  builder.hook(
+    'GraphQLObjectType:fields:field',
+    (
+      field,
+      {pgSql: sql},
+      {
+        addArgDataGenerator,
+        scope: {
+          isPgBackwardRelationField,
+          isPgBackwardSingleRelationField,
+          isPgForwardRelationField,
+          pgFieldIntrospection,
+        },
+      }
+    ) => {
+      if (!isPgBackwardRelationField && !isPgForwardRelationField && !isPgBackwardSingleRelationField) {
+        return field;
+      }
+      if (
+        !pgFieldIntrospection?.attributes?.some(({name}) => name === '_$block_range') &&
+        !pgFieldIntrospection?.class?.attributes?.some(({name}) => name === '_$block_range')
+      ) {
+        return field;
+      }
+
+      addArgDataGenerator(() => ({
+        pgQuery: (queryBuilder: QueryBuilder) => {
+          queryBuilder.where(
+            sql.fragment`${queryBuilder.getTableAlias()}._$block_range @> ${queryBuilder.context.args.blockHeight}`
+          );
+        },
+      }));
+      return field;
+    }
+  );
+  // Adds blockHeight argument to single entity and connection queries for tables with _$block_height column
+  builder.hook(
+    'GraphQLObjectType:fields:field:args',
+    (
+      args,
+      {extend, pgSql: sql},
+      {addArgDataGenerator, scope: {isPgFieldConnection, isPgRowByUniqueConstraintField, pgFieldIntrospection}}
+    ) => {
+      if (!isPgRowByUniqueConstraintField && !isPgFieldConnection) {
+        return args;
+      }
+      if (
+        !pgFieldIntrospection?.attributes?.some(({name}) => name === '_$block_range') &&
+        !pgFieldIntrospection?.class?.attributes?.some(({name}) => name === '_$block_range')
+      ) {
+        return args;
+      }
+
+      addArgDataGenerator(({blockHeight}) => ({
+        pgQuery: (queryBuilder: QueryBuilder) => {
+          // Save blockHeight to context, so it gets passed down to children
+          if (!queryBuilder.context.args?.blockHeight) {
+            queryBuilder.context.args = {blockHeight: sql.fragment`${sql.value(blockHeight)}::bigint`};
+          }
+          queryBuilder.where(
+            sql.fragment`${queryBuilder.getTableAlias()}._$block_range @> ${queryBuilder.context.args.blockHeight}`
+          );
+        },
+      }));
+      return extend(args, {
+        blockHeight: {
+          description: 'Block height',
+          defaultValue: '9223372036854775807',
+          type: GraphQLString, // String because of int overflow
+        },
+      });
+    }
+  );
+};

--- a/packages/query/src/graphql/plugins/PgRowByVirtualIdPlugin.ts
+++ b/packages/query/src/graphql/plugins/PgRowByVirtualIdPlugin.ts
@@ -1,0 +1,126 @@
+// Copyright 2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {Plugin} from 'graphile-build';
+
+// Copied from graphile-build-pg/node8plus/plugins/PgRowByUniqueConstraint.ts
+// Modified to overwrite hidden column _$id primary key with id column
+export const PgRowByVirtualIdPlugin: Plugin = (builder) => {
+  builder.hook('GraphQLObjectType:fields', (fields, build, context) => {
+    const {
+      extend,
+      gql2pg,
+      graphql: {GraphQLNonNull},
+      inflection,
+      parseResolveInfo,
+      pgGetGqlInputTypeByTypeIdAndModifier,
+      pgGetGqlTypeByTypeIdAndModifier,
+      pgIntrospectionResultsByKind: introspectionResultsByKind,
+      pgOmit: omit,
+      pgPrepareAndRun,
+      pgQueryFromResolveData: queryFromResolveData,
+      pgSql: sql,
+    } = build;
+    const {
+      fieldWithHooks,
+      scope: {isRootQuery},
+    } = context;
+
+    if (!isRootQuery) {
+      return fields;
+    }
+
+    return extend(
+      fields,
+      introspectionResultsByKind.class.reduce((memo, table) => {
+        if (!table.namespace) return memo;
+        if (omit(table, 'read')) return memo;
+
+        const TableType = pgGetGqlTypeByTypeIdAndModifier(table.type.id, null);
+        const sqlFullTableName = sql.identifier(table.namespace.name, table.name);
+        if (TableType) {
+          const uniqueConstraints = table.constraints.filter((con) => con.type === 'u' || con.type === 'p');
+          uniqueConstraints.forEach((constraint) => {
+            if (omit(constraint, 'read')) {
+              return;
+            }
+            const keys = constraint.keyAttributes;
+            // Only for _$id primary key
+            if (keys.length !== 1 || keys[0].name !== '_$id') {
+              return;
+            }
+            const fieldName = inflection.rowByUniqueKeys(keys, table, constraint);
+            // Find id column
+            const idColumn = table.attributes.find(({name}) => name === 'id');
+            if (!idColumn) {
+              return;
+            }
+            // Overwrite with id column
+            const keysIncludingMeta = [
+              {
+                ...idColumn,
+                sqlIdentifier: sql.identifier(idColumn.name),
+                columnName: inflection.column(idColumn),
+              },
+            ];
+            const queryFromResolveDataOptions = {
+              useAsterisk: false,
+            };
+            const queryFromResolveDataCallback = (queryBuilder, args) => {
+              const sqlTableAlias = queryBuilder.getTableAlias();
+              keysIncludingMeta.forEach(({columnName, sqlIdentifier, type, typeModifier}) => {
+                queryBuilder.where(
+                  sql.fragment`${sqlTableAlias}.${sqlIdentifier} = ${gql2pg(args[columnName], type, typeModifier)}`
+                );
+              });
+            };
+
+            memo[fieldName] = fieldWithHooks(
+              fieldName,
+              ({getDataFromParsedResolveInfoFragment}) => {
+                return {
+                  type: TableType,
+                  args: keysIncludingMeta.reduce((memo, {columnName, name, typeId, typeModifier}) => {
+                    const InputType = pgGetGqlInputTypeByTypeIdAndModifier(typeId, typeModifier);
+                    if (!InputType) {
+                      throw new Error(`Could not find input type for key '${name}' on type '${TableType.name}'`);
+                    }
+                    memo[columnName] = {
+                      type: new GraphQLNonNull(InputType),
+                    };
+                    return memo;
+                  }, {}),
+                  async resolve(parent, args, resolveContext, resolveInfo) {
+                    const {pgClient} = resolveContext;
+                    const parsedResolveInfoFragment = parseResolveInfo(resolveInfo);
+                    parsedResolveInfoFragment.args = args; // Allow overriding via makeWrapResolversPlugin
+                    const resolveData = getDataFromParsedResolveInfoFragment(parsedResolveInfoFragment, TableType);
+                    const query = queryFromResolveData(
+                      sqlFullTableName,
+                      undefined,
+                      resolveData,
+                      queryFromResolveDataOptions,
+                      (queryBuilder) => queryFromResolveDataCallback(queryBuilder, args),
+                      resolveContext,
+                      resolveInfo.rootValue
+                    );
+                    const {text, values} = sql.compile(query);
+                    const {
+                      rows: [row],
+                    } = await pgPrepareAndRun(pgClient, text, values);
+                    return row;
+                  },
+                };
+              },
+              {
+                isPgRowByUniqueConstraintField: true,
+                pgFieldIntrospection: constraint,
+              }
+            );
+          });
+        }
+        return memo;
+      }, {})
+    );
+  });
+};

--- a/packages/query/src/graphql/plugins/index.ts
+++ b/packages/query/src/graphql/plugins/index.ts
@@ -50,6 +50,8 @@ import {GetMetadataPlugin} from './GetMetadataPlugin';
 import {smartTagsPlugin} from './smartTagsPlugin';
 import {makeAddInflectorsPlugin} from 'graphile-utils';
 import PgAggregationPlugin from './PgAggregationPlugin';
+import {PgBlockHeightPlugin} from './PgBlockHeightPlugin';
+import {PgRowByVirtualIdPlugin} from './PgRowByVirtualIdPlugin';
 
 /* eslint-enable */
 
@@ -105,6 +107,8 @@ const plugins = [
   smartTagsPlugin,
   GetMetadataPlugin,
   PgAggregationPlugin,
+  PgBlockHeightPlugin,
+  PgRowByVirtualIdPlugin,
   makeAddInflectorsPlugin((inflectors) => {
     const {constantCase: oldConstantCase} = inflectors;
     const enumValues = new Set();

--- a/packages/query/src/graphql/plugins/index.ts
+++ b/packages/query/src/graphql/plugins/index.ts
@@ -53,6 +53,9 @@ import PgAggregationPlugin from './PgAggregationPlugin';
 import {PgBlockHeightPlugin} from './PgBlockHeightPlugin';
 import {PgRowByVirtualIdPlugin} from './PgRowByVirtualIdPlugin';
 
+import {getYargsOption} from '../../yargs';
+const {argv} = getYargsOption();
+
 /* eslint-enable */
 
 export const defaultPlugins = [
@@ -107,8 +110,6 @@ const plugins = [
   smartTagsPlugin,
   GetMetadataPlugin,
   PgAggregationPlugin,
-  PgBlockHeightPlugin,
-  PgRowByVirtualIdPlugin,
   makeAddInflectorsPlugin((inflectors) => {
     const {constantCase: oldConstantCase} = inflectors;
     const enumValues = new Set();
@@ -129,5 +130,9 @@ const plugins = [
     };
   }, true),
 ];
+
+if (argv['experimental-historical']) {
+  plugins.push(PgBlockHeightPlugin, PgRowByVirtualIdPlugin);
+}
 
 export {plugins};

--- a/packages/query/src/graphql/plugins/smartTagsPlugin.ts
+++ b/packages/query/src/graphql/plugins/smartTagsPlugin.ts
@@ -4,11 +4,29 @@
 import {PgEntity, PgEntityKind} from 'graphile-build-pg';
 import {makePgSmartTagsPlugin} from 'graphile-utils';
 
-export const smartTagsPlugin = makePgSmartTagsPlugin({
-  //Rule 1, omit `_metadata` from node
-  kind: PgEntityKind.CLASS,
-  match: ({name}: PgEntity) => /_metadata/.test(name),
-  tags: {
-    omit: true,
+export const smartTagsPlugin = makePgSmartTagsPlugin([
+  {
+    //Rule 1, omit `_metadata` from node
+    kind: PgEntityKind.CLASS,
+    match: ({name}: PgEntity) => /_metadata/.test(name),
+    tags: {
+      omit: true,
+    },
   },
-});
+  // Omit _$block_range column
+  {
+    kind: PgEntityKind.ATTRIBUTE,
+    match: ({name}) => /_\$block_range/.test(name),
+    tags: {
+      omit: true,
+    },
+  },
+  // Omit _$id column
+  {
+    kind: PgEntityKind.ATTRIBUTE,
+    match: ({name}) => /_\$id/.test(name),
+    tags: {
+      omit: true,
+    },
+  },
+]);

--- a/packages/query/src/graphql/plugins/smartTagsPlugin.ts
+++ b/packages/query/src/graphql/plugins/smartTagsPlugin.ts
@@ -8,7 +8,7 @@ export const smartTagsPlugin = makePgSmartTagsPlugin([
   {
     //Rule 1, omit `_metadata` from node
     kind: PgEntityKind.CLASS,
-    match: ({name}: PgEntity) => /_metadata/.test(name),
+    match: ({name}: PgEntity) => /^_metadata$/.test(name),
     tags: {
       omit: true,
     },
@@ -16,7 +16,7 @@ export const smartTagsPlugin = makePgSmartTagsPlugin([
   // Omit _$block_range column
   {
     kind: PgEntityKind.ATTRIBUTE,
-    match: ({name}) => /_\$block_range/.test(name),
+    match: ({name}) => /^_\$block_range$/.test(name),
     tags: {
       omit: true,
     },
@@ -24,7 +24,7 @@ export const smartTagsPlugin = makePgSmartTagsPlugin([
   // Omit _$id column
   {
     kind: PgEntityKind.ATTRIBUTE,
-    match: ({name}) => /_\$id/.test(name),
+    match: ({name}) => /^_\$id$/.test(name),
     tags: {
       omit: true,
     },

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -60,6 +60,11 @@ export function getYargsOption() {
       describe: 'The port the service will bind to',
       type: 'number',
     },
+    'experimental-historical': {
+      demandOption: false,
+      describe: 'Add block height argument to queries for fetching historical state of entities',
+      type: 'boolean',
+    },
   });
 }
 


### PR DESCRIPTION
Resolve #415

- Created a plugin which adds blockHeight as an input argument when underlying table contains column with name "_$block_range".
  - Default value for blockHeight is max bigint
  - blockHeight is then used to filter and return only entities with (_$block_range @> blockHeight)
  - For nested queries, if joining a table that also has "_$block_range" column, same filter is also applied to join
- Hid _$id and _$block_range columns from schema
- Copied and modified PgRowByUniqueConstraint plugin to handle tables with hidden _$id primary key (replace with normal id column)

Relationships between two history tables can be defined using [@foreignKey](https://www.graphile.org/postgraphile/smart-tags/#foreignkey) smart comments to create fake foreign keys (even to non-unique columns), for example: `@foreignKey (table2_id) references table2 (id)`
The join clause is then later modified by PgBlockHeightPlugin to join the two tables using both the foreign key and the blockHeight provided in input