### PR TITLE
Keep alive terra LCD connections

### DIFF
--- a/packages/node-terra/src/utils/terra-helper.ts
+++ b/packages/node-terra/src/utils/terra-helper.ts
@@ -135,7 +135,9 @@ export async function getTxInfobyHashes(
     txHashes.map(async (hash) => {
       return api.txInfo(hash);
     }),
-  );
+  ).catch((e) => {
+    throw new Error(`Failed to fetch block transactions: ${e.message}`);
+  });
 }
 
 export function wrapBlock(block: BlockInfo, txs: TxInfo[]): TerraBlock {

--- a/packages/node-terra/src/yargs.ts
+++ b/packages/node-terra/src/yargs.ts
@@ -136,7 +136,7 @@ export function getYargsOption() {
       demandOption: false,
       describe: 'The timeout value for API requests',
       type: 'number',
-      default: 30000,
+      default: 300000,
     },
   });
 }


### PR DESCRIPTION
- Use http keep alive for connections
- Take advantage of axios features
- Fix not passing params to lcd requests
- Increase default lcd timeout from 30 to 300s
- Improve logging