### PR TITLE
Fix mantlemint cli

### DIFF
--- a/packages/node-terra/src/configure/configure.module.ts
+++ b/packages/node-terra/src/configure/configure.module.ts
@@ -126,6 +126,7 @@ export class ConfigureModule {
           {
             endpoint: config.networkEndpoint,
             dictionary: config.networkDictionary,
+            mantlemint: config.networkMantlemint,
           },
           isNil,
         ),

--- a/packages/node-terra/src/yargs.ts
+++ b/packages/node-terra/src/yargs.ts
@@ -18,11 +18,6 @@ export function getYargsOption() {
       describe: 'Name of the subquery project',
       type: 'string',
     },
-    mantlemint: {
-      demandOption: false,
-      describe: 'Mantlemint endpoint URL',
-      type: 'string',
-    },
     config: {
       alias: 'c',
       demandOption: false,
@@ -77,6 +72,11 @@ export function getYargsOption() {
       type: 'array',
       describe:
         'Key value of api parameters passed to terra rpc. e.g. --network-endpoint-param "api_key: <your-api-key>"',
+    },
+    'network-mantlemint': {
+      demandOption: false,
+      describe: 'Mantlemint endpoint URL',
+      type: 'string',
     },
     'output-fmt': {
       demandOption: false,


### PR DESCRIPTION
- Rename `mantlemint` cli flag to `network-mantlemint` for consistency + fix naming bug
- Fix cli config not overriding project mantlemint endpoint