### PR TITLE
Rework handling spec versions

### DIFF
--- a/packages/node/src/indexer/SpecVersions.service.test.ts
+++ b/packages/node/src/indexer/SpecVersions.service.test.ts
@@ -1,0 +1,26 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { SpecVersionService } from './SpecVersions.service';
+
+describe('SpecVersions', () => {
+  let service: SpecVersionService;
+
+  beforeEach(() => {
+    service = new SpecVersionService();
+
+    service.addSpecVersions({
+      443964: 12,
+      528471: 13,
+      687752: 14,
+      746086: 15,
+    });
+  });
+
+  it('can find the correct spec versions', () => {
+    expect(service.getSpecVersion(1)).toBe(undefined);
+    expect(service.getSpecVersion(443964)).toBe(12);
+    expect(service.getSpecVersion(687752)).toBe(14);
+    expect(service.getSpecVersion(500000)).toBe(12);
+  });
+});

--- a/packages/node/src/indexer/SpecVersions.service.ts
+++ b/packages/node/src/indexer/SpecVersions.service.ts
@@ -1,0 +1,69 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { Injectable } from '@nestjs/common';
+import { ApiPromise } from '@polkadot/api';
+import { BlockHash, RuntimeVersion } from '@polkadot/types/interfaces';
+
+export type SpecVersionMap = { [blockNumber: number]: number }; // blockNumber => specVersion
+
+export function getSpecVersionBlockNumbers(
+  specVersions: SpecVersionMap,
+): number[] {
+  return Object.keys(specVersions).map((key) => parseInt(key, 10));
+}
+
+@Injectable()
+export class SpecVersionService {
+  private _specVersions: SpecVersionMap;
+
+  private _runtimeVersions: { [specVersion: number]: RuntimeVersion };
+  private _lastQueriedHeight = 0; // Keep track of the latest know block spec version
+
+  constructor() {
+    this._specVersions = {};
+    this._runtimeVersions = {};
+  }
+
+  addSpecVersions(
+    specVersions: SpecVersionMap,
+    lastQueriedHeight?: number,
+  ): void {
+    this._specVersions = { ...this.specVersions, ...specVersions };
+    this._lastQueriedHeight =
+      lastQueriedHeight ??
+      Math.max(...getSpecVersionBlockNumbers(specVersions));
+  }
+
+  get specVersions(): SpecVersionMap {
+    return this._specVersions;
+  }
+
+  get lastQueriedHeight(): number {
+    return this._lastQueriedHeight;
+  }
+
+  async getRuntimeVersion(
+    api: ApiPromise,
+    blockNumber: number,
+    blockHash: string | BlockHash,
+  ): Promise<RuntimeVersion | undefined> {
+    const specVersion = this.getSpecVersion(blockNumber);
+    if (!this._runtimeVersions[specVersion]) {
+      this._runtimeVersions[specVersion] =
+        await api.rpc.state.getRuntimeVersion(blockHash);
+    }
+
+    return this._runtimeVersions[specVersion];
+  }
+
+  getSpecVersion(blockNumber: number): number | undefined {
+    const specVersionBlock = Math.max(
+      ...getSpecVersionBlockNumbers(this.specVersions).filter(
+        (key) => key <= blockNumber,
+      ),
+    );
+
+    return this.specVersions[specVersionBlock];
+  }
+}

--- a/packages/node/src/indexer/api.service.spec.ts
+++ b/packages/node/src/indexer/api.service.spec.ts
@@ -8,6 +8,7 @@ import { GraphQLSchema } from 'graphql';
 import { omit } from 'lodash';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { ApiService } from './api.service';
+import { SpecVersionService } from './SpecVersions.service';
 
 jest.mock('@polkadot/api', () => {
   const ApiPromise = jest.fn();
@@ -69,9 +70,19 @@ function testSubqueryProject(): SubqueryProject {
 }
 
 describe('ApiService', () => {
+  let specVersionService: SpecVersionService;
+
+  beforeEach(() => {
+    specVersionService = new SpecVersionService();
+  });
+
   it('read custom types from project manifest', async () => {
     const project = testSubqueryProject();
-    const apiService = new ApiService(project, new EventEmitter2());
+    const apiService = new ApiService(
+      project,
+      specVersionService,
+      new EventEmitter2(),
+    );
     await apiService.init();
     expect(WsProvider).toHaveBeenCalledWith(testNetwork.endpoint);
     expect(ApiPromise.create).toHaveBeenCalledWith({
@@ -87,7 +98,11 @@ describe('ApiService', () => {
     // Now after manifest 1.0.0, will use chainId instead of genesisHash
     (project.network as any).chainId = '0x';
 
-    const apiService = new ApiService(project, new EventEmitter2());
+    const apiService = new ApiService(
+      project,
+      specVersionService,
+      new EventEmitter2(),
+    );
 
     await expect(apiService.init()).rejects.toThrow();
   });

--- a/packages/node/src/indexer/dictionary.service.test.ts
+++ b/packages/node/src/indexer/dictionary.service.test.ts
@@ -62,6 +62,7 @@ describe('DictionaryService', () => {
     const dic = await dictionaryService.getDictionary(
       startBlock,
       endBlock,
+      startBlock,
       batchSize,
       HAPPY_PATH_CONDITIONS,
     );
@@ -80,6 +81,7 @@ describe('DictionaryService', () => {
     const dic = await dictionaryService.getDictionary(
       startBlock,
       endBlock,
+      startBlock,
       batchSize,
       HAPPY_PATH_CONDITIONS,
     );
@@ -95,6 +97,7 @@ describe('DictionaryService', () => {
     const dic = await dictionaryService.getDictionary(
       startBlock,
       endBlock,
+      1,
       batchSize,
       HAPPY_PATH_CONDITIONS,
     );
@@ -111,6 +114,7 @@ describe('DictionaryService', () => {
     const dic = await dictionaryService.getDictionary(
       startBlock,
       endBlock,
+      startBlock,
       batchSize,
       [
         {
@@ -134,6 +138,7 @@ describe('DictionaryService', () => {
     const dic = await dictionaryService.getDictionary(
       startBlock,
       endBlock,
+      1,
       batchSize,
       [
         {

--- a/packages/node/src/indexer/fetch.service.spec.ts
+++ b/packages/node/src/indexer/fetch.service.spec.ts
@@ -15,6 +15,7 @@ import { ApiService } from './api.service';
 import { Dictionary, DictionaryService } from './dictionary.service';
 import { DsProcessorService } from './ds-processor.service';
 import { FetchService } from './fetch.service';
+import { SpecVersionService } from './SpecVersions.service';
 
 jest.mock('../utils/substrate', () =>
   jest.createMockFromModule('../utils/substrate'),
@@ -98,6 +99,7 @@ const mockDictionaryRet: Dictionary = {
   },
   //simulate after last process height update to 1000
   batchBlocks: [1000],
+  specVersions: {},
 };
 
 const mockDictionaryNoBatches: Dictionary = {
@@ -114,6 +116,7 @@ const mockDictionaryNoBatches: Dictionary = {
     rowCountEstimate: [{ table: '', estimate: 0 }],
   },
   batchBlocks: [],
+  specVersions: {},
 };
 
 const mockDictionaryBatches: Dictionary = {
@@ -130,6 +133,7 @@ const mockDictionaryBatches: Dictionary = {
     rowCountEstimate: [{ table: '', estimate: 0 }],
   },
   batchBlocks: [14000, 14200, 14300, 14500, 14600, 14700, 14800, 14900],
+  specVersions: {},
 };
 
 function mockDictionaryService(
@@ -224,6 +228,7 @@ function createFetchService(
     project,
     dictionaryService,
     new DsProcessorService(project),
+    new SpecVersionService(),
     new EventEmitter2(),
   );
 }
@@ -342,6 +347,7 @@ describe('FetchService', () => {
       project,
       dictionaryService,
       dsPluginService,
+      new SpecVersionService(),
       eventEmitter,
     );
 
@@ -405,6 +411,7 @@ describe('FetchService', () => {
       project,
       dictionaryService,
       dsPluginService,
+      new SpecVersionService(),
       eventEmitter,
     );
     await fetchService.init();
@@ -462,6 +469,7 @@ describe('FetchService', () => {
       project,
       dictionaryService,
       dsPluginService,
+      new SpecVersionService(),
       eventEmitter,
     );
     const nextEndBlockHeightSpy = jest.spyOn(

--- a/packages/node/src/indexer/fetch.service.test.ts
+++ b/packages/node/src/indexer/fetch.service.test.ts
@@ -14,6 +14,7 @@ import { ApiService } from './api.service';
 import { DictionaryService } from './dictionary.service';
 import { DsProcessorService } from './ds-processor.service';
 import { FetchService } from './fetch.service';
+import { SpecVersionService } from './SpecVersions.service';
 
 function testSubqueryProject(): SubqueryProject {
   return {
@@ -52,7 +53,12 @@ async function createFetchService(
   project = testSubqueryProject(),
   batchSize = 5,
 ): Promise<FetchService> {
-  const apiService = new ApiService(project, new EventEmitter2());
+  const specVersionService = new SpecVersionService();
+  const apiService = new ApiService(
+    project,
+    specVersionService,
+    new EventEmitter2(),
+  );
   await apiService.init();
   const dictionaryService = new DictionaryService(project);
   const dsPluginService = new DsProcessorService(project);
@@ -62,6 +68,7 @@ async function createFetchService(
     project,
     dictionaryService,
     dsPluginService,
+    specVersionService,
     new EventEmitter2(),
   );
 }

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -266,7 +266,7 @@ export class FetchService implements OnApplicationShutdown {
   }
 
   @Interval(CHECK_MEMORY_INTERVAL)
-  checkBatchScale() {
+  checkBatchScale(): void {
     if (argv['scale-batch-size']) {
       const scale = checkMemoryUsage(
         this.nodeConfig.batchSize,
@@ -280,7 +280,7 @@ export class FetchService implements OnApplicationShutdown {
   }
 
   @Interval(BLOCK_TIME_VARIANCE * 1000)
-  async getFinalizedBlockHead() {
+  async getFinalizedBlockHead(): Promise<void> {
     if (!this.api) {
       logger.debug(`Skip fetch finalized block until API is ready`);
       return;
@@ -302,7 +302,7 @@ export class FetchService implements OnApplicationShutdown {
   }
 
   @Interval(BLOCK_TIME_VARIANCE * 1000)
-  async getBestBlockHead() {
+  async getBestBlockHead(): Promise<void> {
     if (!this.api) {
       logger.debug(`Skip fetch best block until API is ready`);
       return;

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -20,6 +20,7 @@ import { IndexerManager } from './indexer.manager';
 import { MmrService } from './mmr.service';
 import { PoiService } from './poi.service';
 import { SandboxService } from './sandbox.service';
+import { SpecVersionService } from './SpecVersions.service';
 import { StoreService } from './store.service';
 
 jest.mock('sequelize', () => {
@@ -126,8 +127,9 @@ function testSubqueryProject_2(): SubqueryProject {
 function createIndexerManager(project: SubqueryProject): IndexerManager {
   const sequilize = new Sequelize();
   const eventEmitter = new EventEmitter2();
+  const specVersionService = new SpecVersionService();
 
-  const apiService = new ApiService(project, eventEmitter);
+  const apiService = new ApiService(project, specVersionService, eventEmitter);
   const dictionaryService = new DictionaryService(project);
 
   const dsPluginService = new DsProcessorService(project);
@@ -137,6 +139,7 @@ function createIndexerManager(project: SubqueryProject): IndexerManager {
     project,
     dictionaryService,
     dsPluginService,
+    specVersionService,
     eventEmitter,
   );
   const poiService = new PoiService(nodeConfig, project, sequilize);

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -56,7 +56,7 @@ const { argv } = getYargsOption();
 @Injectable()
 export class IndexerManager {
   private api: ApiPromise;
-  private prevSpecVersion?: number;
+  // private prevSpecVersion?: number;
   protected metadataRepo: MetadataRepo;
   private filteredDataSources: SubqlProjectDs[];
 
@@ -121,12 +121,10 @@ export class IndexerManager {
 
     let poiBlockHash: Uint8Array;
     try {
-      const isUpgraded = block.specVersion !== this.prevSpecVersion;
       // if parentBlockHash injected, which means we need to check runtime upgrade
       const apiAt = await this.apiService.getPatchedApi(
         block.block.hash,
         block.block.header.number.unwrap().toNumber(),
-        isUpgraded ? block.block.header.parentHash : undefined,
       );
 
       // Run predefined data sources
@@ -168,7 +166,6 @@ export class IndexerManager {
     }
     await tx.commit();
     this.fetchService.latestProcessed(block.block.header.number.toNumber());
-    this.prevSpecVersion = block.specVersion;
     if (this.nodeConfig.proofOfIndex) {
       this.poiService.setLatestPoiBlockHash(poiBlockHash);
     }

--- a/packages/node/src/indexer/indexer.module.ts
+++ b/packages/node/src/indexer/indexer.module.ts
@@ -15,6 +15,7 @@ import { IndexerManager } from './indexer.manager';
 import { MmrService } from './mmr.service';
 import { PoiService } from './poi.service';
 import { SandboxService } from './sandbox.service';
+import { SpecVersionService } from './SpecVersions.service';
 import { StoreService } from './store.service';
 
 @Module({
@@ -26,13 +27,18 @@ import { StoreService } from './store.service';
       provide: ApiService,
       useFactory: async (
         project: SubqueryProject,
+        specVersionService: SpecVersionService,
         eventEmitter: EventEmitter2,
       ) => {
-        const apiService = new ApiService(project, eventEmitter);
+        const apiService = new ApiService(
+          project,
+          specVersionService,
+          eventEmitter,
+        );
         await apiService.init();
         return apiService;
       },
-      inject: [SubqueryProject, EventEmitter2],
+      inject: [SubqueryProject, SpecVersionService, EventEmitter2],
     },
     FetchService,
     BenchmarkService,
@@ -42,6 +48,7 @@ import { StoreService } from './store.service';
     DynamicDsService,
     PoiService,
     MmrService,
+    SpecVersionService,
   ],
   exports: [StoreService],
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "declaration": true,
     "sourceMap": true,
     "inlineSources": true,
+    "noImplicitThis": true,
     "composite": true,
     "paths": {
       "@subql/common": ["packages/common/src"],


### PR DESCRIPTION
I'm not super happy with this approach, its quite hard to work with data with the blockbuffer queue. It also might make more sense to separate the spec version dictionary query into another request separate of block numbers

- Introduce SpecVersion service to keep track of spec version data
- Update dictinary query to filter spec versions
- When dictionary isn't used, be smarter about fetching spec versions