### PR TITLE
Fix toDeployment with ds processor assets

### DIFF
--- a/packages/common-substrate/src/project/project.spec.ts
+++ b/packages/common-substrate/src/project/project.spec.ts
@@ -92,4 +92,10 @@ describe('project.yaml', () => {
       loadSubstrateProjectManifest(path.join(projectsDir, 'project_0.2.0_invalid_custom_ds.yaml'))
     ).toThrow();
   });
+
+  it('can convert project with assets to deployment', () => {
+    const manifest = loadSubstrateProjectManifest(path.join(projectsDir, 'project_1.0.0.yaml'));
+    expect(manifest.isV1_0_0).toBeTruthy();
+    expect(() => manifest.toDeployment()).not.toThrow();
+  });
 });

--- a/packages/common/src/project/versioned/base.ts
+++ b/packages/common/src/project/versioned/base.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import {classToPlain} from 'class-transformer';
 import {Allow, IsString, validateSync} from 'class-validator';
 import yaml from 'js-yaml';
 
@@ -17,7 +18,8 @@ export abstract class ProjectManifestBaseImpl<D extends object> {
   abstract readonly deployment: D;
 
   toDeployment(): string {
-    return yaml.dump(this.deployment, {
+    // classToPlain fixes Map type with assets fields
+    return yaml.dump(classToPlain(this.deployment), {
       sortKeys: true,
       condenseFlow: true,
     });


### PR DESCRIPTION
`yaml.dump` doesn't have support for js Map type, `classToPlain` converts Map to object.


<details>
<summary>Error before fix</summary>

```
ERROR YAMLException: unacceptable kind of an object to dump [object Map]
    at writeNode (/Users/scotttwiname/Projects/subql/node_modules/js-yaml/lib/dumper.js:868:13)
    at writeBlockMapping (/Users/scotttwiname/Projects/subql/node_modules/js-yaml/lib/dumper.js:731:10)
    at writeNode (/Users/scotttwiname/Projects/subql/node_modules/js-yaml/lib/dumper.js:834:9)
    at writeBlockSequence (/Users/scotttwiname/Projects/subql/node_modules/js-yaml/lib/dumper.js:605:9)
    at writeNode (/Users/scotttwiname/Projects/subql/node_modules/js-yaml/lib/dumper.js:849:11)
    at writeBlockMapping (/Users/scotttwiname/Projects/subql/node_modules/js-yaml/lib/dumper.js:731:10)
    at writeNode (/Users/scotttwiname/Projects/subql/node_modules/js-yaml/lib/dumper.js:834:9)
    at Object.dump (/Users/scotttwiname/Projects/subql/node_modules/js-yaml/lib/dumper.js:960:7)
    at ProjectManifestV1_0_0Impl.toDeployment (/Users/scotttwiname/Projects/subql/packages/common/src/project/versioned/base.ts:20:17)
    at SubstrateProjectManifestVersioned.toDeployment (/Users/scotttwiname/Projects/subql/packages/common-substrate/src/project/versioned/ProjectManifestVersioned.ts:101:23) {
  reason: 'unacceptable kind of an object to dump [object Map]',
  mark: undefined
}
```
</details>