### PR TITLE
Move POI logic under option check

### DIFF
--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -145,23 +145,23 @@ export class IndexerManager {
         ],
         { transaction: tx },
       );
-      // Need calculate operationHash to ensure correct offset insert all time
-      const operationHash = this.storeService.getOperationMerkleRoot();
-      if (
-        !u8aEq(operationHash, NULL_MERKEL_ROOT) &&
-        this.blockOffset === undefined
-      ) {
-        await this.metadataRepo.upsert(
-          {
-            key: 'blockOffset',
-            value: blockHeight - 1,
-          },
-          { transaction: tx },
-        );
-        this.setBlockOffset(blockHeight - 1);
-      }
 
       if (this.nodeConfig.proofOfIndex) {
+        // Need calculate operationHash to ensure correct offset insert all time
+        const operationHash = this.storeService.getOperationMerkleRoot();
+        if (
+          !u8aEq(operationHash, NULL_MERKEL_ROOT) &&
+          this.blockOffset === undefined
+        ) {
+          await this.metadataRepo.upsert(
+            {
+              key: 'blockOffset',
+              value: blockHeight - 1,
+            },
+            { transaction: tx },
+          );
+          this.setBlockOffset(blockHeight - 1);
+        }
         //check if operation is null, then poi will not be inserted
         if (!u8aEq(operationHash, NULL_MERKEL_ROOT)) {
           const poiBlock = PoiBlock.create(

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -145,23 +145,23 @@ export class IndexerManager {
         ],
         { transaction: tx },
       );
+      // Need calculate operationHash to ensure correct offset insert all time
+      const operationHash = this.storeService.getOperationMerkleRoot();
+      if (
+        !u8aEq(operationHash, NULL_MERKEL_ROOT) &&
+        this.blockOffset === undefined
+      ) {
+        await this.metadataRepo.upsert(
+          {
+            key: 'blockOffset',
+            value: blockHeight - 1,
+          },
+          { transaction: tx },
+        );
+        this.setBlockOffset(blockHeight - 1);
+      }
 
       if (this.nodeConfig.proofOfIndex) {
-        // Need calculate operationHash to ensure correct offset insert all time
-        const operationHash = this.storeService.getOperationMerkleRoot();
-        if (
-          !u8aEq(operationHash, NULL_MERKEL_ROOT) &&
-          this.blockOffset === undefined
-        ) {
-          await this.metadataRepo.upsert(
-            {
-              key: 'blockOffset',
-              value: blockHeight - 1,
-            },
-            { transaction: tx },
-          );
-          this.setBlockOffset(blockHeight - 1);
-        }
         //check if operation is null, then poi will not be inserted
         if (!u8aEq(operationHash, NULL_MERKEL_ROOT)) {
           const poiBlock = PoiBlock.create(

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -489,12 +489,15 @@ export class StoreService {
   }
 
   getOperationMerkleRoot(): Uint8Array {
-    this.operationStack.makeOperationMerkleTree();
-    const merkelRoot = this.operationStack.getOperationMerkleRoot();
-    if (merkelRoot === null) {
-      return NULL_MERKEL_ROOT;
+    if (this.config.proofOfIndex) {
+      this.operationStack.makeOperationMerkleTree();
+      const merkelRoot = this.operationStack.getOperationMerkleRoot();
+      if (merkelRoot === null) {
+        return NULL_MERKEL_ROOT;
+      }
+      return merkelRoot;
     }
-    return merkelRoot;
+    return NULL_MERKEL_ROOT;
   }
 
   private async getAllIndexFields(schema: string) {


### PR DESCRIPTION
Fixes `failed to index block at height 188  TypeError: Cannot read properties of undefined (reading 'makeOperationMerkleTree')` when POI is disabled