### PR TITLE
Add performance logger and use to keep track of processing a block

### DIFF
--- a/packages/node/src/utils/logger.ts
+++ b/packages/node/src/utils/logger.ts
@@ -43,3 +43,82 @@ export class NestLogger implements LoggerService {
     this.logger.warn(message);
   }
 }
+
+const scopes: Record<string, PerfScope> = {};
+export class PerfScope {
+  private readonly startTime: Date;
+  private endTime?: Date;
+  private children: Record<string, PerfScope> = {};
+
+  constructor(public name: string, private root = false) {
+    this.startTime = new Date();
+  }
+
+  start(name: string): PerfScope {
+    if (!this.children[name]) {
+      this.children[name] = new PerfScope(name);
+    }
+    return this.children[name];
+  }
+
+  stop(name: string): void {
+    const scope = this.children[name];
+
+    if (!scope) return;
+
+    scope.end();
+  }
+
+  async measure<T>(name: string, promise: Promise<T>): Promise<T> {
+    this.start(name);
+
+    try {
+      const res = await promise;
+
+      return res;
+    } finally {
+      this.stop(name);
+    }
+  }
+
+  end(prefix?: string): void {
+    // Only set end time once
+    if (!this.endTime) {
+      this.endTime = new Date();
+    }
+
+    // Stop any children
+    Object.values(this.children).map((c) => c.end());
+
+    if (this.root) {
+      this.print(0, prefix);
+      delete scopes[this.name];
+    }
+  }
+
+  print(depth = 0, prefix?: string): void {
+    const duration =
+      (this.endTime ?? new Date()).getTime() - this.startTime.getTime();
+
+    const logDepth = argv('perf');
+    if (depth >= logDepth && logDepth !== -1) return;
+
+    // TODO format time
+    console.log(
+      depth === 0 ? '\x1b[33m%s\x1b[0m' : '',
+      `${'  '.repeat(depth)}${prefix ?? ''}${this.name}: ${duration} ms`,
+    );
+
+    Object.values(this.children).map((c) => c.print(depth + 1));
+  }
+}
+
+export function perfLogger(name: string | number): PerfScope {
+  name = name.toString();
+
+  if (!scopes[name]) {
+    scopes[name] = new PerfScope(name, true);
+  }
+
+  return scopes[name];
+}

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -145,6 +145,13 @@ export function getYargsOption() {
       describe: 'Disable storing historical state entities',
       type: 'boolean',
     },
+    perf: {
+      demandOption: false,
+      describe:
+        'Performance logging, value is the depth of logging. -1 for everything',
+      type: 'number',
+      default: 0,
+    },
   });
 }
 


### PR DESCRIPTION
Adds a new option `perf` which is a number to set the amount of performance logging. Default is nothing

Example output:
```
Block 501: 6979 ms
   getBlockHeight(): 1012 ms
     getBlockHash(): 200 ms
     getBlockByHash(): 812 ms
   events/specVersion: 1356 ms
   wrapBlock: 1 ms
   in queue: 3696 ms
   indexBlock(): 445 ms
     getPatchedApi: 6 ms
     indexBlockData(): 425 ms
       block: 0 ms
       initialization events: 0 ms
       extrinsics and events: 424 ms
       finalization events: 0 ms
     poi/mmr: 0 ms
     commitTx: 6 ms
```