### PR TITLE
Split setup code from indexer manager to another service

### DIFF
--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -481,7 +481,7 @@ export class FetchService implements OnApplicationShutdown {
     let currentSpecVersion: number;
     // we want to keep the specVersionMap in memory, and use it even useDictionary been disabled
     // therefore instead of check .useDictionary, we check it length before use it.
-    if (this.specVersionMap.length !== 0) {
+    if (this.specVersionMap && this.specVersionMap.length !== 0) {
       currentSpecVersion = this.getSpecFromMap(
         blockHeight,
         this.specVersionMap,

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -19,6 +19,7 @@ import { FetchService } from './fetch.service';
 import { IndexerManager } from './indexer.manager';
 import { MmrService } from './mmr.service';
 import { PoiService } from './poi.service';
+import { ProjectService } from './project.service';
 import { SandboxService } from './sandbox.service';
 import { StoreService } from './store.service';
 
@@ -150,6 +151,19 @@ function createIndexerManager(project: SubqueryProject): IndexerManager {
     project,
   );
   const dynamicDsService = new DynamicDsService(dsPluginService, project);
+  const projectService = new ProjectService(
+    dsPluginService,
+    apiService,
+    poiService,
+    mmrService,
+    sequilize,
+    project,
+    storeService,
+    nodeConfig,
+    dynamicDsService,
+    subqueryRepo,
+    eventEmitter,
+  );
 
   return new IndexerManager(
     storeService,
@@ -165,6 +179,7 @@ function createIndexerManager(project: SubqueryProject): IndexerManager {
     dynamicDsService,
     subqueryRepo,
     eventEmitter,
+    projectService,
   );
 }
 

--- a/packages/node/src/indexer/indexer.manager.test.ts
+++ b/packages/node/src/indexer/indexer.manager.test.ts
@@ -9,6 +9,7 @@ import { SubqueryProject } from '../configure/SubqueryProject';
 import { DbModule } from '../db/db.module';
 import { SubqueryRepo } from '../entities';
 import { IndexerManager } from './indexer.manager';
+import { ProjectService } from './project.service';
 
 function testSubqueryProject(): SubqueryProject {
   return {
@@ -36,6 +37,7 @@ const prepare = async (): Promise<IndexerManager> => {
         useFactory: (
           sequelize: Sequelize,
           project: SubqueryProject,
+          projectService: ProjectService,
           subqueryRepo: SubqueryRepo,
         ) => {
           const indexerManager = new IndexerManager(
@@ -52,10 +54,11 @@ const prepare = async (): Promise<IndexerManager> => {
             undefined,
             subqueryRepo,
             undefined,
+            projectService,
           );
           return indexerManager;
         },
-        inject: [Sequelize, SubqueryProject, 'Subquery'],
+        inject: [Sequelize, SubqueryProject, ProjectService, 'Subquery'],
       },
     ],
     imports: [

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -1,8 +1,6 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import assert from 'assert';
-import fs from 'fs';
 import { Inject, Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApiPromise } from '@polkadot/api';
@@ -25,8 +23,7 @@ import {
   SubstrateEvent,
   SubstrateExtrinsic,
 } from '@subql/types';
-import { getAllEntitiesRelations } from '@subql/utils';
-import { QueryTypes, Sequelize } from 'sequelize';
+import { Sequelize } from 'sequelize';
 import { NodeConfig } from '../configure/NodeConfig';
 import { SubqlProjectDs, SubqueryProject } from '../configure/SubqueryProject';
 import { SubqueryRepo } from '../entities';
@@ -38,23 +35,18 @@ import { ApiService } from './api.service';
 import {
   asSecondLayerHandlerProcessor_1_0_0,
   DsProcessorService,
-  isSecondLayerHandlerProcessor_0_0_0,
 } from './ds-processor.service';
 import { DynamicDsService } from './dynamic-ds.service';
-import { MetadataFactory, MetadataRepo } from './entities/Metadata.entity';
 import { IndexerEvent } from './events';
 import { FetchService } from './fetch.service';
 import { MmrService } from './mmr.service';
 import { PoiService } from './poi.service';
 import { PoiBlock } from './PoiBlock';
+import { ProjectService } from './project.service';
 import { IndexerSandbox, SandboxService } from './sandbox.service';
 import { StoreService } from './store.service';
 import { BlockContent } from './types';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { version: packageVersion } = require('../../package.json');
-
-const DEFAULT_DB_SCHEMA = 'public';
 const NULL_MERKEL_ROOT = hexToU8a('0x00');
 
 const logger = getLogger('indexer');
@@ -63,10 +55,8 @@ const { argv } = getYargsOption();
 @Injectable()
 export class IndexerManager {
   private api: ApiPromise;
-  protected metadataRepo: MetadataRepo;
   private filteredDataSources: SubqlProjectDs[];
   private blockOffset: number;
-  private schema: string;
 
   constructor(
     private storeService: StoreService,
@@ -82,6 +72,7 @@ export class IndexerManager {
     private dynamicDsService: DynamicDsService,
     @Inject('Subquery') protected subqueryRepo: SubqueryRepo,
     private eventEmitter: EventEmitter2,
+    private projectService: ProjectService,
   ) {}
 
   @profiler(argv.profiler)
@@ -152,14 +143,11 @@ export class IndexerManager {
         !u8aEq(operationHash, NULL_MERKEL_ROOT) &&
         this.blockOffset === undefined
       ) {
-        await this.metadataRepo.upsert(
-          {
-            key: 'blockOffset',
-            value: blockHeight - 1,
-          },
-          { transaction: tx },
+        await this.projectService.upsertMetadataBlockOffset(
+          blockHeight - 1,
+          tx,
         );
-        this.setBlockOffset(blockHeight - 1);
+        this.projectService.setBlockOffset(blockHeight - 1);
       }
 
       if (this.nodeConfig.proofOfIndex) {
@@ -190,40 +178,10 @@ export class IndexerManager {
   }
 
   async start(): Promise<void> {
-    await this.dsProcessorService.validateProjectCustomDatasources();
-    await this.fetchService.init();
+    await this.projectService.init();
+
     this.api = this.apiService.getApi();
-    this.schema = await this.ensureProject();
-    await this.initDbSchema();
-    this.metadataRepo = await this.ensureMetadata();
-    this.dynamicDsService.init(this.metadataRepo);
-
-    if (this.nodeConfig.proofOfIndex) {
-      const blockOffset = await this.metadataRepo.findOne({
-        where: { key: 'blockOffset' },
-      });
-      if (blockOffset !== null && blockOffset.value !== null) {
-        this.setBlockOffset(Number(blockOffset.value));
-      }
-      await Promise.all([this.poiService.init(this.schema)]);
-    }
-
-    let startHeight: number;
-    const lastProcessedHeight = await this.metadataRepo.findOne({
-      where: { key: 'lastProcessedHeight' },
-    });
-    if (lastProcessedHeight !== null && lastProcessedHeight.value !== null) {
-      startHeight = Number(lastProcessedHeight.value) + 1;
-    } else {
-      const project = await this.subqueryRepo.findOne({
-        where: { name: this.nodeConfig.subqueryName },
-      });
-      if (project !== null) {
-        startHeight = project.nextBlockHeight;
-      } else {
-        startHeight = this.getStartBlockFromDataSources();
-      }
-    }
+    const startHeight = this.projectService.startHeight;
 
     void this.fetchService.startLoop(startHeight).catch((err) => {
       logger.error(err, 'failed to fetch block');
@@ -231,205 +189,6 @@ export class IndexerManager {
       process.exit(1);
     });
     this.fetchService.register((block) => this.indexBlock(block));
-  }
-
-  private setBlockOffset(offset: number): void {
-    this.blockOffset = offset;
-    logger.info(`set blockoffset to ${offset}`);
-    void this.mmrService
-      .syncFileBaseFromPoi(this.schema, this.blockOffset)
-      .catch((err) => {
-        logger.error(err, 'failed to sync poi to mmr');
-        process.exit(1);
-      });
-  }
-
-  private async ensureProject(): Promise<string> {
-    let schema = await this.getExistingProjectSchema();
-    if (!schema) {
-      schema = await this.createProjectSchema();
-    } else {
-      if (argv['force-clean']) {
-        try {
-          // drop existing project schema and metadata table
-          await this.sequelize.dropSchema(`"${schema}"`, {
-            logging: false,
-            benchmark: false,
-          });
-
-          // remove schema from subquery table (might not exist)
-          await this.sequelize.query(
-            ` DELETE
-              FROM public.subqueries
-              WHERE name = :name`,
-            {
-              replacements: { name: this.nodeConfig.subqueryName },
-              type: QueryTypes.DELETE,
-            },
-          );
-
-          logger.info('force cleaned schema and tables');
-
-          if (fs.existsSync(this.nodeConfig.mmrPath)) {
-            await fs.promises.unlink(this.nodeConfig.mmrPath);
-            logger.info('force cleaned file based mmr');
-          }
-        } catch (err) {
-          logger.error(err, 'failed to force clean');
-        }
-        schema = await this.createProjectSchema();
-      }
-    }
-
-    this.eventEmitter.emit(IndexerEvent.Ready, {
-      value: true,
-    });
-
-    return schema;
-  }
-
-  // Get existing project schema, undefined when doesn't exist
-  private async getExistingProjectSchema(): Promise<string> {
-    let schema = this.nodeConfig.localMode
-      ? DEFAULT_DB_SCHEMA
-      : this.nodeConfig.dbSchema;
-
-    // Note that sequelize.fetchAllSchemas does not include public schema, we cannot assume that public schema exists so we must make a raw query
-    const schemas = (await this.sequelize
-      .query(`SELECT schema_name FROM information_schema.schemata`, {
-        type: QueryTypes.SELECT,
-      })
-      .then((xs) => xs.map((x: any) => x.schema_name))
-      .catch((err) => {
-        logger.error(`Unable to fetch all schemas: ${err}`);
-        process.exit(1);
-      })) as [string];
-
-    if (!schemas.includes(schema)) {
-      // fallback to subqueries table
-      const subqueryModel = await this.subqueryRepo.findOne({
-        where: { name: this.nodeConfig.subqueryName },
-      });
-      if (subqueryModel) {
-        schema = subqueryModel.dbSchema;
-      } else {
-        schema = undefined;
-      }
-    }
-    return schema;
-  }
-
-  private async createProjectSchema(): Promise<string> {
-    let schema: string;
-    if (this.nodeConfig.localMode) {
-      // create tables in default schema if local mode is enabled
-      schema = DEFAULT_DB_SCHEMA;
-    } else {
-      schema = this.nodeConfig.dbSchema;
-      const schemas = await this.sequelize.showAllSchemas(undefined);
-      if (!(schemas as unknown as string[]).includes(schema)) {
-        await this.sequelize.createSchema(`"${schema}"`, undefined);
-      }
-    }
-
-    return schema;
-  }
-
-  private async initDbSchema(): Promise<void> {
-    const graphqlSchema = this.project.schema;
-    const modelsRelations = getAllEntitiesRelations(graphqlSchema);
-    await this.storeService.init(modelsRelations, this.schema);
-  }
-
-  private async ensureMetadata(): Promise<MetadataRepo> {
-    const metadataRepo = MetadataFactory(this.sequelize, this.schema);
-
-    const project = await this.subqueryRepo.findOne({
-      where: { name: this.nodeConfig.subqueryName },
-    });
-
-    this.eventEmitter.emit(
-      IndexerEvent.NetworkMetadata,
-      this.apiService.networkMeta,
-    );
-
-    const keys = [
-      'lastProcessedHeight',
-      'blockOffset',
-      'indexerNodeVersion',
-      'chain',
-      'specName',
-      'genesisHash',
-      'chainId',
-    ] as const;
-
-    const entries = await metadataRepo.findAll({
-      where: {
-        key: keys,
-      },
-    });
-
-    const keyValue = entries.reduce((arr, curr) => {
-      arr[curr.key] = curr.value;
-      return arr;
-    }, {} as { [key in typeof keys[number]]: string | boolean | number });
-
-    const { chain, genesisHash, specName } = this.apiService.networkMeta;
-
-    if (this.project.runner) {
-      await Promise.all([
-        metadataRepo.upsert({
-          key: 'runnerNode',
-          value: this.project.runner.node.name,
-        }),
-        metadataRepo.upsert({
-          key: 'runnerNodeVersion',
-          value: this.project.runner.node.version,
-        }),
-        metadataRepo.upsert({
-          key: 'runnerQuery',
-          value: this.project.runner.query.name,
-        }),
-        metadataRepo.upsert({
-          key: 'runnerQueryVersion',
-          value: this.project.runner.query.version,
-        }),
-      ]);
-    }
-    if (!keyValue.genesisHash) {
-      if (project) {
-        await metadataRepo.upsert({
-          key: 'genesisHash',
-          value: project.networkGenesis,
-        });
-      } else {
-        await metadataRepo.upsert({ key: 'genesisHash', value: genesisHash });
-      }
-    } else {
-      // Check if the configured genesisHash matches the currently stored genesisHash
-      assert(
-        // Configured project yaml genesisHash only exists in specVersion v0.2.0, fallback to api fetched genesisHash on v0.0.1
-        (this.project.network.chainId ?? genesisHash) === keyValue.genesisHash,
-        'Specified project manifest chain id / genesis hash does not match database stored genesis hash, consider cleaning project schema using --force-clean',
-      );
-    }
-
-    if (keyValue.chain !== chain) {
-      await metadataRepo.upsert({ key: 'chain', value: chain });
-    }
-
-    if (keyValue.specName !== specName) {
-      await metadataRepo.upsert({ key: 'specName', value: specName });
-    }
-
-    if (keyValue.indexerNodeVersion !== packageVersion) {
-      await metadataRepo.upsert({
-        key: 'indexerNodeVersion',
-        value: packageVersion,
-      });
-    }
-
-    return metadataRepo;
   }
 
   private filterDataSources(nextProcessingHeight: number): SubqlProjectDs[] {
@@ -457,20 +216,6 @@ export class IndexerManager {
       process.exit(1);
     }
     return filteredDs;
-  }
-
-  private getStartBlockFromDataSources() {
-    const startBlocksList = this.project.dataSources.map(
-      (item) => item.startBlock ?? 1,
-    );
-    if (startBlocksList.length === 0) {
-      logger.error(
-        `Failed to find a valid datasource, Please check your endpoint if specName filter is used.`,
-      );
-      process.exit(1);
-    } else {
-      return Math.min(...startBlocksList);
-    }
   }
 
   private async indexBlockData(

--- a/packages/node/src/indexer/indexer.module.ts
+++ b/packages/node/src/indexer/indexer.module.ts
@@ -14,6 +14,7 @@ import { FetchService } from './fetch.service';
 import { IndexerManager } from './indexer.manager';
 import { MmrService } from './mmr.service';
 import { PoiService } from './poi.service';
+import { ProjectService } from './project.service';
 import { SandboxService } from './sandbox.service';
 import { StoreService } from './store.service';
 
@@ -42,6 +43,7 @@ import { StoreService } from './store.service';
     DynamicDsService,
     PoiService,
     MmrService,
+    ProjectService,
   ],
   exports: [StoreService, MmrService],
 })

--- a/packages/node/src/indexer/project.service.test.ts
+++ b/packages/node/src/indexer/project.service.test.ts
@@ -25,7 +25,7 @@ function testSubqueryProject(): SubqueryProject {
   };
 }
 
-const prepare = async (): Promise<IndexerManager> => {
+const prepare = async (): Promise<ProjectService> => {
   const module = await Test.createTestingModule({
     providers: [
       {
@@ -33,15 +33,13 @@ const prepare = async (): Promise<IndexerManager> => {
         useFactory: () => testSubqueryProject(),
       },
       {
-        provide: IndexerManager,
+        provide: ProjectService,
         useFactory: (
           sequelize: Sequelize,
           project: SubqueryProject,
-          projectService: ProjectService,
           subqueryRepo: SubqueryRepo,
         ) => {
-          const indexerManager = new IndexerManager(
-            undefined,
+          const projectService = new ProjectService(
             undefined,
             undefined,
             undefined,
@@ -51,15 +49,42 @@ const prepare = async (): Promise<IndexerManager> => {
             undefined,
             undefined,
             undefined,
-            undefined,
             subqueryRepo,
             undefined,
-            projectService,
           );
-          return indexerManager;
+
+          return projectService;
         },
-        inject: [Sequelize, SubqueryProject, ProjectService, 'Subquery'],
+        inject: [Sequelize, SubqueryProject, 'Subquery'],
       },
+      // {
+      //   provide: IndexerManager,
+      //   useFactory: (
+      //     sequelize: Sequelize,
+      //     project: SubqueryProject,
+      //     projectService: ProjectService,
+      //     subqueryRepo: SubqueryRepo,
+      //   ) => {
+      //     const indexerManager = new IndexerManager(
+      //       undefined,
+      //       undefined,
+      //       undefined,
+      //       undefined,
+      //       undefined,
+      //       sequelize,
+      //       project,
+      //       undefined,
+      //       undefined,
+      //       undefined,
+      //       undefined,
+      //       subqueryRepo,
+      //       undefined,
+      //       projectService,
+      //     );
+      //     return indexerManager;
+      //   },
+      //   inject: [Sequelize, SubqueryProject, ProjectService, 'Subquery'],
+      // },
     ],
     imports: [
       DbModule.forRoot({
@@ -75,7 +100,7 @@ const prepare = async (): Promise<IndexerManager> => {
 
   const app = module.createNestApplication();
   await app.init();
-  return app.get(IndexerManager);
+  return app.get(ProjectService);
 };
 
 function prepareProject(
@@ -95,8 +120,8 @@ function prepareProject(
 
 const TEST_PROJECT = 'test-user/TEST_PROJECT';
 
-describe('IndexerManager Integration Tests', () => {
-  let indexerManager: IndexerManager;
+describe('ProjectService Integration Tests', () => {
+  let projectService: ProjectService;
   let subqueryRepo: SubqueryRepo;
 
   async function createSchema(name: string): Promise<void> {
@@ -109,19 +134,19 @@ describe('IndexerManager Integration Tests', () => {
   }
 
   beforeAll(async () => {
-    indexerManager = await prepare();
-    subqueryRepo = (indexerManager as any).subqueryRepo;
+    projectService = await prepare();
+    subqueryRepo = (projectService as any).subqueryRepo;
   });
 
   beforeEach(async () => {
-    delete (indexerManager as any).nodeConfig;
+    delete (projectService as any).nodeConfig;
     await subqueryRepo.destroy({ where: { name: TEST_PROJECT } });
     await subqueryRepo.sequelize.dropSchema(`"${TEST_PROJECT}"`, undefined);
   });
 
   it("read existing project's schema from subqueries table", async () => {
     const schemaName = 'subql_99999';
-    (indexerManager as any).nodeConfig = new NodeConfig({
+    (projectService as any).nodeConfig = new NodeConfig({
       subquery: '/test/dir/test-query-project',
       subqueryName: TEST_PROJECT,
     });
@@ -129,12 +154,12 @@ describe('IndexerManager Integration Tests', () => {
     await subqueryRepo.create(prepareProject(TEST_PROJECT, schemaName, 1));
 
     await expect(
-      (indexerManager as any).getExistingProjectSchema(),
+      (projectService as any).getExistingProjectSchema(),
     ).resolves.toBe(schemaName);
   });
 
   it("read existing project's schema from nodeConfig", async () => {
-    (indexerManager as any).nodeConfig = new NodeConfig({
+    (projectService as any).nodeConfig = new NodeConfig({
       subquery: '/test/dir/test-query-project',
       subqueryName: TEST_PROJECT,
     });
@@ -143,12 +168,12 @@ describe('IndexerManager Integration Tests', () => {
     await subqueryRepo.create(prepareProject(TEST_PROJECT, 'subql_99999', 1));
 
     await expect(
-      (indexerManager as any).getExistingProjectSchema(),
+      (projectService as any).getExistingProjectSchema(),
     ).resolves.toBe(TEST_PROJECT);
   });
 
   it("read existing project's schema when --local", async () => {
-    (indexerManager as any).nodeConfig = new NodeConfig({
+    (projectService as any).nodeConfig = new NodeConfig({
       subquery: '/test/dir/test-query-project',
       subqueryName: TEST_PROJECT,
       localMode: true,
@@ -157,16 +182,16 @@ describe('IndexerManager Integration Tests', () => {
     await subqueryRepo.create(prepareProject(TEST_PROJECT, 'subql_99999', 1));
 
     await expect(
-      (indexerManager as any).getExistingProjectSchema(),
+      (projectService as any).getExistingProjectSchema(),
     ).resolves.toBe('public');
   });
 
   it('create project schema', async () => {
-    (indexerManager as any).nodeConfig = new NodeConfig({
+    (projectService as any).nodeConfig = new NodeConfig({
       subquery: '/test/dir/test-query-project',
       subqueryName: TEST_PROJECT,
     });
-    await expect((indexerManager as any).createProjectSchema()).resolves.toBe(
+    await expect((projectService as any).createProjectSchema()).resolves.toBe(
       TEST_PROJECT,
     );
     await expect(checkSchemaExist(TEST_PROJECT)).resolves.toBe(true);

--- a/packages/node/src/indexer/project.service.ts
+++ b/packages/node/src/indexer/project.service.ts
@@ -1,0 +1,349 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'assert';
+import fs from 'fs';
+import { Inject, Injectable } from '@nestjs/common';
+import { getAllEntitiesRelations } from '@subql/utils';
+import { EventEmitter2 } from 'eventemitter2';
+import { QueryTypes, Sequelize, Transaction } from 'sequelize';
+import { NodeConfig } from '../configure/NodeConfig';
+import { SubqlProjectDs, SubqueryProject } from '../configure/SubqueryProject';
+import { SubqueryRepo } from '../entities';
+import { getLogger } from '../utils/logger';
+import { getYargsOption } from '../yargs';
+import { ApiService } from './api.service';
+import { DsProcessorService } from './ds-processor.service';
+import { DynamicDsService } from './dynamic-ds.service';
+import { MetadataFactory, MetadataRepo } from './entities/Metadata.entity';
+import { IndexerEvent } from './events';
+import { MmrService } from './mmr.service';
+import { PoiService } from './poi.service';
+import { StoreService } from './store.service';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { version: packageVersion } = require('../../package.json');
+
+const DEFAULT_DB_SCHEMA = 'public';
+
+const logger = getLogger('Project');
+const { argv } = getYargsOption();
+
+@Injectable()
+export class ProjectService {
+  private _schema: string;
+  private metadataRepo: MetadataRepo;
+  private _startHeight: number;
+
+  constructor(
+    private readonly dsProcessorService: DsProcessorService,
+    private readonly apiService: ApiService,
+    private readonly poiService: PoiService,
+    protected readonly mmrService: MmrService,
+    private readonly sequelize: Sequelize,
+    private readonly project: SubqueryProject,
+    private readonly storeService: StoreService,
+    private readonly nodeConfig: NodeConfig,
+    private readonly dynamicDsService: DynamicDsService,
+    @Inject('Subquery') protected subqueryRepo: SubqueryRepo,
+    private eventEmitter: EventEmitter2,
+  ) {}
+
+  get schema(): string {
+    return this._schema;
+  }
+
+  get startHeight(): number {
+    return this._startHeight;
+  }
+
+  async init(): Promise<void> {
+    await this.dsProcessorService.validateProjectCustomDatasources();
+
+    this._schema = await this.ensureProject();
+    await this.initDbSchema();
+    this.metadataRepo = await this.ensureMetadata();
+    this.dynamicDsService.init(this.metadataRepo);
+
+    if (this.nodeConfig.proofOfIndex) {
+      const blockOffset = await this.getMetadataBlockOffset();
+      if (blockOffset !== null && blockOffset !== undefined) {
+        this.setBlockOffset(Number(blockOffset));
+      }
+      await this.poiService.init(this.schema);
+    }
+
+    // TODO parse this to fetch service
+    this._startHeight = await this.getStartHeight();
+  }
+
+  private async ensureProject(): Promise<string> {
+    let schema = await this.getExistingProjectSchema();
+    if (!schema) {
+      schema = await this.createProjectSchema();
+    } else {
+      if (argv['force-clean']) {
+        try {
+          // drop existing project schema and metadata table
+          await this.sequelize.dropSchema(`"${schema}"`, {
+            logging: false,
+            benchmark: false,
+          });
+
+          // remove schema from subquery table (might not exist)
+          await this.sequelize.query(
+            ` DELETE
+              FROM public.subqueries
+              WHERE name = :name`,
+            {
+              replacements: { name: this.nodeConfig.subqueryName },
+              type: QueryTypes.DELETE,
+            },
+          );
+
+          logger.info('force cleaned schema and tables');
+
+          if (fs.existsSync(this.nodeConfig.mmrPath)) {
+            await fs.promises.unlink(this.nodeConfig.mmrPath);
+            logger.info('force cleaned file based mmr');
+          }
+        } catch (err) {
+          logger.error(err, 'failed to force clean');
+        }
+        schema = await this.createProjectSchema();
+      }
+    }
+
+    this.eventEmitter.emit(IndexerEvent.Ready, {
+      value: true,
+    });
+
+    return schema;
+  }
+
+  // Get existing project schema, undefined when doesn't exist
+  private async getExistingProjectSchema(): Promise<string> {
+    let schema = this.nodeConfig.localMode
+      ? DEFAULT_DB_SCHEMA
+      : this.nodeConfig.dbSchema;
+
+    // Note that sequelize.fetchAllSchemas does not include public schema, we cannot assume that public schema exists so we must make a raw query
+    const schemas = (await this.sequelize
+      .query(`SELECT schema_name FROM information_schema.schemata`, {
+        type: QueryTypes.SELECT,
+      })
+      .then((xs) => xs.map((x: any) => x.schema_name))
+      .catch((err) => {
+        logger.error(`Unable to fetch all schemas: ${err}`);
+        process.exit(1);
+      })) as [string];
+
+    if (!schemas.includes(schema)) {
+      // fallback to subqueries table
+      const subqueryModel = await this.subqueryRepo.findOne({
+        where: { name: this.nodeConfig.subqueryName },
+      });
+      if (subqueryModel) {
+        schema = subqueryModel.dbSchema;
+      } else {
+        schema = undefined;
+      }
+    }
+    return schema;
+  }
+
+  private async createProjectSchema(): Promise<string> {
+    let schema: string;
+    if (this.nodeConfig.localMode) {
+      // create tables in default schema if local mode is enabled
+      schema = DEFAULT_DB_SCHEMA;
+    } else {
+      schema = this.nodeConfig.dbSchema;
+      const schemas = await this.sequelize.showAllSchemas(undefined);
+      if (!(schemas as unknown as string[]).includes(schema)) {
+        await this.sequelize.createSchema(`"${schema}"`, undefined);
+      }
+    }
+
+    return schema;
+  }
+
+  private async initDbSchema(): Promise<void> {
+    const graphqlSchema = this.project.schema;
+    const modelsRelations = getAllEntitiesRelations(graphqlSchema);
+    await this.storeService.init(modelsRelations, this.schema);
+  }
+
+  private async ensureMetadata(): Promise<MetadataRepo> {
+    const metadataRepo = MetadataFactory(this.sequelize, this.schema);
+
+    const project = await this.subqueryRepo.findOne({
+      where: { name: this.nodeConfig.subqueryName },
+    });
+
+    this.eventEmitter.emit(
+      IndexerEvent.NetworkMetadata,
+      this.apiService.networkMeta,
+    );
+
+    const keys = [
+      'lastProcessedHeight',
+      'blockOffset',
+      'indexerNodeVersion',
+      'chain',
+      'specName',
+      'genesisHash',
+      'chainId',
+    ] as const;
+
+    const entries = await metadataRepo.findAll({
+      where: {
+        key: keys,
+      },
+    });
+
+    const keyValue = entries.reduce((arr, curr) => {
+      arr[curr.key] = curr.value;
+      return arr;
+    }, {} as { [key in typeof keys[number]]: string | boolean | number });
+
+    const { chain, genesisHash, specName } = this.apiService.networkMeta;
+
+    if (this.project.runner) {
+      await Promise.all([
+        metadataRepo.upsert({
+          key: 'runnerNode',
+          value: this.project.runner.node.name,
+        }),
+        metadataRepo.upsert({
+          key: 'runnerNodeVersion',
+          value: this.project.runner.node.version,
+        }),
+        metadataRepo.upsert({
+          key: 'runnerQuery',
+          value: this.project.runner.query.name,
+        }),
+        metadataRepo.upsert({
+          key: 'runnerQueryVersion',
+          value: this.project.runner.query.version,
+        }),
+      ]);
+    }
+    if (!keyValue.genesisHash) {
+      if (project) {
+        await metadataRepo.upsert({
+          key: 'genesisHash',
+          value: project.networkGenesis,
+        });
+      } else {
+        await metadataRepo.upsert({ key: 'genesisHash', value: genesisHash });
+      }
+    } else {
+      // Check if the configured genesisHash matches the currently stored genesisHash
+      assert(
+        // Configured project yaml genesisHash only exists in specVersion v0.2.0, fallback to api fetched genesisHash on v0.0.1
+        (this.project.network.chainId ?? genesisHash) === keyValue.genesisHash,
+        'Specified project manifest chain id / genesis hash does not match database stored genesis hash, consider cleaning project schema using --force-clean',
+      );
+    }
+
+    if (keyValue.chain !== chain) {
+      await metadataRepo.upsert({ key: 'chain', value: chain });
+    }
+
+    if (keyValue.specName !== specName) {
+      await metadataRepo.upsert({ key: 'specName', value: specName });
+    }
+
+    if (keyValue.indexerNodeVersion !== packageVersion) {
+      await metadataRepo.upsert({
+        key: 'indexerNodeVersion',
+        value: packageVersion,
+      });
+    }
+
+    return metadataRepo;
+  }
+
+  async upsertMetadataBlockOffset(
+    height: number,
+    tx: Transaction,
+  ): Promise<void> {
+    await this.metadataRepo.upsert(
+      {
+        key: 'blockOffset',
+        value: height - 1,
+      },
+      { transaction: tx },
+    );
+  }
+
+  async getMetadataBlockOffset(): Promise<number> {
+    const res = await this.metadataRepo.findOne({
+      where: { key: 'blockOffset' },
+    });
+
+    return res?.value as number;
+  }
+
+  async getLastProcessedHeight(): Promise<number> {
+    const res = await this.metadataRepo.findOne({
+      where: { key: 'lastProcessedHeight' },
+    });
+
+    return res?.value as number;
+  }
+
+  private async getStartHeight(): Promise<number> {
+    let startHeight: number;
+    const lastProcessedHeight = await this.getLastProcessedHeight();
+    if (lastProcessedHeight !== null && lastProcessedHeight !== undefined) {
+      startHeight = Number(lastProcessedHeight) + 1;
+    } else {
+      const project = await this.subqueryRepo.findOne({
+        where: { name: this.nodeConfig.subqueryName },
+      });
+      if (project !== null) {
+        startHeight = project.nextBlockHeight;
+      } else {
+        startHeight = this.getStartBlockFromDataSources();
+      }
+    }
+
+    return startHeight;
+  }
+
+  // FIXME Dedupe with indexermanager
+  setBlockOffset(offset: number): void {
+    logger.info(`set blockoffset to ${offset}`);
+    void this.mmrService
+      .syncFileBaseFromPoi(this.schema, offset)
+      .catch((err) => {
+        logger.error(err, 'failed to sync poi to mmr');
+        process.exit(1);
+      });
+  }
+
+  private getStartBlockFromDataSources() {
+    const startBlocksList = this.getDataSourcesForSpecName().map(
+      (item) => item.startBlock ?? 1,
+    );
+    if (startBlocksList.length === 0) {
+      logger.error(
+        `Failed to find a valid datasource, Please check your endpoint if specName filter is used.`,
+      );
+      process.exit(1);
+    } else {
+      return Math.min(...startBlocksList);
+    }
+  }
+
+  private getDataSourcesForSpecName(): SubqlProjectDs[] {
+    return this.project.dataSources.filter(
+      (ds) =>
+        !ds.filter?.specName ||
+        ds.filter.specName ===
+          this.apiService.getApi().runtimeVersion.specName.toString(),
+    );
+  }
+}


### PR DESCRIPTION
Moves all the setup related logic into ProjectService and leaves IndexerManager with only functionality for indexing blocks. 

Reason for doing this is that worker threads only want this setup logic to run once and not for each worker thread

Will wait until https://github.com/subquery/subql/pull/1046 is merged before completing