### PR TITLE
validate deployment, validate multi network

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -89,11 +89,8 @@ module.exports = {
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   // moduleNameMapper: {},
   moduleNameMapper: {
-    '^@subql/common-substrate': '<rootDir>/packages/common-substrate/src',
     '^@subql/common-substrate/(.*)$': '<rootDir>/packages/common-substrate/src/$1',
-    '^@subql/common': '<rootDir>/packages/common/src',
     '^@subql/common/(.*)$': '<rootDir>/packages/common/src/$1',
-    '^@subql/utils': '<rootDir>/packages/utils/src',
     '^@subql/utils/(.*)$': '<rootDir>/packages/utils/src/$1',
   },
 

--- a/packages/cli/src/controller/deploy-controller.spec.ts
+++ b/packages/cli/src/controller/deploy-controller.spec.ts
@@ -28,10 +28,13 @@ const projectSpec: deploymentSpec = {
   apiVersion: '2',
 };
 
+const describeIf = (condition: boolean, ...args: Parameters<typeof describe>) =>
+  condition ? describe(...args) : describe.skip(...args);
+
 // Replace/Update your access token when test locally
 const testAuth = process.env.SUBQL_ACCESS_TOKEN_TEST;
 // const testAuth = 'process.env.SUBQL_ACCESS_TOKEN_TEST';
-describe('CLI deploy, delete, promote', () => {
+describeIf(!!testAuth, 'CLI deploy, delete, promote', () => {
   beforeAll(async () => {
     const {apiVersion, description, logoURl, org, project_name, repository, subtitle} = projectSpec;
     try {

--- a/packages/cli/src/controller/project-controller.spec.ts
+++ b/packages/cli/src/controller/project-controller.spec.ts
@@ -19,9 +19,11 @@ const projectSpec = {
 // Replace/Update your access token when test locally
 const testAuth = process.env.SUBQL_ACCESS_TOKEN_TEST;
 
+const testIf = (condition: boolean, ...args: Parameters<typeof it>) => (condition ? it(...args) : it.skip(...args));
+
 jest.setTimeout(120000);
 describe('CLI create project and delete project', () => {
-  it('Create project and delete', async () => {
+  testIf(!!testAuth, 'Create project and delete', async () => {
     const {apiVersion, description, logoURl, org, project_name, repository, subtitle} = projectSpec;
     const create_project = await createProject(
       org,

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -15,3 +15,19 @@ export const RUNNER_REGEX = /(\^?)(\d|x|\*)+\.(\d|x|\*)+\.(\d|x|\*)+/;
 export const DEFAULT_WORD_SIZE = 32;
 export const DEFAULT_LEAF = Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex');
 export const MMR_AWAIT_TIME = 2;
+
+// NETWORK
+export enum NETWORK_FAMILY {
+  substrate = 'Substrate',
+  avalanche = 'Avalanche',
+  terra = 'Terra',
+  cosmos = 'Cosmos',
+}
+
+export const runnerMapping = {
+  '@subql/node': NETWORK_FAMILY.substrate,
+  '@subql/node-substrate': NETWORK_FAMILY.substrate,
+  '@subql/node-avalanche': NETWORK_FAMILY.avalanche,
+  '@subql/node-terra': NETWORK_FAMILY.terra,
+  '@subql/node-cosmos': NETWORK_FAMILY.cosmos,
+};

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@subql/common": "workspace:*",
     "@subql/common-avalanche": "latest",
-    "@subql/common-cosmos": "^0.0.5",
+    "@subql/common-cosmos": "^0.0.6",
     "@subql/common-substrate": "workspace:*",
     "@subql/common-terra": "latest",
     "axios": "^0.24.0",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -17,7 +17,10 @@
   ],
   "dependencies": {
     "@subql/common": "workspace:*",
+    "@subql/common-avalanche": "latest",
+    "@subql/common-cosmos": "^0.0.5",
     "@subql/common-substrate": "workspace:*",
+    "@subql/common-terra": "latest",
     "axios": "^0.24.0",
     "ipfs-http-client": "^52.0.3",
     "js-yaml": "^4.1.0",

--- a/packages/validator/src/context.ts
+++ b/packages/validator/src/context.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {Reader} from '@subql/common';
+import {SubstrateProjectManifestVersioned as AvalancheProjectManifestVersioned} from '@subql/common-avalanche';
+import {CosmosProjectManifestVersioned} from '@subql/common-cosmos';
 import {SubstrateProjectManifestVersioned} from '@subql/common-substrate';
 import {TerraProjectManifestVersioned} from '@subql/common-terra';
 import {IPackageJson} from 'package-json-type';
@@ -9,7 +11,11 @@ import {IPackageJson} from 'package-json-type';
 export interface ContextData {
   projectPath: string;
   pkg: IPackageJson;
-  schema?: SubstrateProjectManifestVersioned | TerraProjectManifestVersioned;
+  schema?:
+    | SubstrateProjectManifestVersioned
+    | TerraProjectManifestVersioned
+    | CosmosProjectManifestVersioned
+    | AvalancheProjectManifestVersioned;
 }
 
 export interface Context {

--- a/packages/validator/src/rules/rule.ts
+++ b/packages/validator/src/rules/rule.ts
@@ -23,12 +23,16 @@ export interface Rule {
   validate(ctx: Context): boolean | Promise<boolean>;
 }
 
-export const commonRules: Rule[] = [
-  new RequireBuildScript(),
-  new RequireCodegenScript(),
-  new RequireCliDep(),
+export const deploymentRules: Rule[] = [
   new RequireValidManifest(),
   new RequireValidChainTypes(),
   new RequireCustomDsValidation(),
   new RequireValidRunner(),
+];
+
+export const commonRules: Rule[] = [
+  new RequireBuildScript(),
+  new RequireCodegenScript(),
+  new RequireCliDep(),
+  ...deploymentRules,
 ];

--- a/packages/validator/src/validator.spec.ts
+++ b/packages/validator/src/validator.spec.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import {NETWORK_FAMILY} from '@subql/common';
 import {commonRules} from './rules';
 import {Validator} from './validator';
 
@@ -9,7 +10,7 @@ describe('Validator', () => {
 
   beforeAll(async () => {
     const url = 'https://github.com/subquery/tutorials-block-timestamp';
-    v = await Validator.create(url);
+    v = await Validator.create(url, null, NETWORK_FAMILY.substrate);
     v.addRule(...commonRules);
   });
 

--- a/packages/validator/src/validator.spec.ts
+++ b/packages/validator/src/validator.spec.ts
@@ -1,17 +1,23 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {NETWORK_FAMILY} from '@subql/common';
-import {commonRules} from './rules';
+import {IPFS_NODE_ENDPOINT, NETWORK_FAMILY} from '@subql/common';
+import {commonRules, deploymentRules} from './rules';
 import {Validator} from './validator';
 
-describe('Validator', () => {
+describe('Validate project below manifest spec 1.0.0', () => {
   let v: Validator;
+  const url = 'https://github.com/subquery/tutorials-block-timestamp';
 
   beforeAll(async () => {
-    const url = 'https://github.com/subquery/tutorials-block-timestamp';
     v = await Validator.create(url, null, NETWORK_FAMILY.substrate);
     v.addRule(...commonRules);
+  });
+
+  it('should throw error if manifest is below 1.0.0 and network is not provided', async () => {
+    const v1 = await Validator.create(url);
+    v1.addRule(...commonRules);
+    await expect(v1.getValidateReports()).rejects.toThrow(/Can not identify project network under spec version 1.0.0/);
   });
 
   it('should validate get reports', async () => {
@@ -22,5 +28,23 @@ describe('Validator', () => {
   it('should return validate result', async () => {
     const result = await v.validate();
     expect(result).toBeTruthy();
+  });
+});
+
+describe('Validate project with manifest spec 1.0.0, auto identify network', () => {
+  it('should validate IPFS deployment', async () => {
+    const cid = 'ipfs://QmVX1aaJRL9f5Vgjr8VJ9MWAcFHzAya9omnQ534JYCigCQ';
+    const v = await Validator.create(cid, {ipfs: IPFS_NODE_ENDPOINT});
+    v.addRule(...deploymentRules);
+    const result = await v.getValidateReports();
+    expect(result.filter((r) => r.valid).length).toBe(result.length);
+  });
+
+  it('should validate get reports', async () => {
+    const url = 'https://github.com/subquery/juno-subql-dictionary';
+    const v = await Validator.create(url);
+    v.addRule(...commonRules);
+    const result = await v.getValidateReports();
+    expect(result.filter((r) => r.valid).length).toBe(result.length);
   });
 });

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,9 +1,12 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {Reader, ReaderFactory, ReaderOptions} from '@subql/common';
+import {getProjectNetwork, NETWORK_FAMILY, Reader, ReaderFactory, ReaderOptions} from '@subql/common';
+import {parseSubstrateProjectManifest as parseAvalancheProjectManifest} from '@subql/common-avalanche';
+import {parseCosmosProjectManifest} from '@subql/common-cosmos';
 import {parseSubstrateProjectManifest} from '@subql/common-substrate';
 import {parseTerraProjectManifest} from '@subql/common-terra';
+
 import {Context} from './context';
 import {Rule, RuleType} from './rules';
 
@@ -17,10 +20,14 @@ export interface Report {
 export class Validator {
   private readonly rules: Rule[] = [];
 
-  static async create(location: string, opts?: ReaderOptions): Promise<Validator> {
-    return new Validator(await ReaderFactory.create(location, opts), location);
+  static async create(location: string, opts?: ReaderOptions, networkFamily?: NETWORK_FAMILY): Promise<Validator> {
+    return new Validator(await ReaderFactory.create(location, opts), location, networkFamily);
   }
-  constructor(private readonly reader: Reader, private readonly location: string) {}
+  constructor(
+    private readonly reader: Reader,
+    private readonly location: string,
+    private readonly networkFamily?: NETWORK_FAMILY
+  ) {}
 
   addRule(...rules: Rule[]): void {
     this.rules.push(...rules);
@@ -42,24 +49,32 @@ export class Validator {
     });
 
     let schema;
-    try {
-      schema = parseSubstrateProjectManifest(rawSchema);
-      if (schema.isV0_0_1) {
-        reports.push({
-          name: 'package-json-file',
-          description: 'A valid `package.json` file must exist in the root directory of the project',
-          valid: !!pkg,
-          skipped: false,
-        });
-      }
-    } catch (e) {
-      console.warn(`Try to load as Substrate project failed, will try to load as Terra project.`);
-      try {
+
+    const networkFamily = this.networkFamily ?? getProjectNetwork(rawSchema);
+    switch (networkFamily) {
+      case NETWORK_FAMILY.substrate:
+        schema = parseSubstrateProjectManifest(rawSchema);
+        if (schema.isV0_0_1) {
+          reports.push({
+            name: 'package-json-file',
+            description: 'A valid `package.json` file must exist in the root directory of the project',
+            valid: !!pkg,
+            skipped: false,
+          });
+        }
+        break;
+      case NETWORK_FAMILY.terra:
         schema = parseTerraProjectManifest(rawSchema);
-      } catch (e) {
-        console.error(`Load Terra project failed, please check the manifest file.`);
-        throw e;
-      }
+        break;
+      case NETWORK_FAMILY.avalanche:
+        schema = parseAvalancheProjectManifest(rawSchema);
+        break;
+      case NETWORK_FAMILY.cosmos:
+        schema = parseCosmosProjectManifest(rawSchema);
+        break;
+      default:
+        console.error(`Load project failed, please check the manifest file.`);
+        break;
     }
 
     const ctx: Context = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3311,7 +3311,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/common-cosmos@npm:latest":
+"@subql/common-avalanche@npm:latest":
+  version: 0.0.2-0
+  resolution: "@subql/common-avalanche@npm:0.0.2-0"
+  dependencies:
+    "@polkadot/util": ^8
+    "@subql/common": 0.22.0
+    "@subql/types-avalanche": 0.0.2-0
+    bn.js: 4.11.6
+    class-transformer: 0.4.0
+    class-validator: ^0.13.2
+    flatted: ^3.2.2
+    graphql: ^15.7.2
+    graphql-tag: ^2.12.5
+    js-yaml: ^4.1.0
+    pino: ^6.13.3
+    reflect-metadata: ^0.1.13
+    sequelize: ^6.6.2
+    vm2: ^3.9.9
+  checksum: 99493bdfb2b06af583f382584c06e583b6874740a683971d45cdd58ceff86fc0ef068659b26ac64c0205767d8ce65035aab6d588a496fdf915a3dc92c9c6646f
+  languageName: node
+  linkType: hard
+
+"@subql/common-cosmos@npm:^0.0.5, @subql/common-cosmos@npm:latest":
   version: 0.0.5
   resolution: "@subql/common-cosmos@npm:0.0.5"
   dependencies:
@@ -3341,7 +3363,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@subql/common-terra@npm:^0.6.0":
+"@subql/common-terra@npm:^0.6.0, @subql/common-terra@npm:latest":
   version: 0.6.0
   resolution: "@subql/common-terra@npm:0.6.0"
   dependencies:
@@ -3351,6 +3373,20 @@ __metadata:
     js-yaml: ^4.1.0
     reflect-metadata: ^0.1.13
   checksum: 90e45b4dcac1f624d18395a3db928a7a7a86dd199d0a8f7594862ab62256dc39170b1488b0490a46139f25563178beb103eee2c8450c342bf49d7553399d5729
+  languageName: node
+  linkType: hard
+
+"@subql/common@npm:0.22.0":
+  version: 0.22.0
+  resolution: "@subql/common@npm:0.22.0"
+  dependencies:
+    axios: ^0.27.2
+    class-transformer: 0.5.1
+    class-validator: ^0.13.2
+    js-yaml: ^4.1.0
+    reflect-metadata: ^0.1.13
+    semver: ^7.3.5
+  checksum: 58259f15f19cae5f3a2aab3de8d8a6eba54c681960e32c9e83bfe7dcede185734ddd28e71518939fad35df83c9ef18b426ac7b224331b9468918ad401926f698
   languageName: node
   linkType: hard
 
@@ -3498,6 +3534,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@subql/types-avalanche@npm:0.0.2-0":
+  version: 0.0.2-0
+  resolution: "@subql/types-avalanche@npm:0.0.2-0"
+  peerDependencies:
+    "@polkadot/api": ^8
+  checksum: 3144caabcea3049a302e515ce966e32be5cc7f68dd313418424c1d825c324d66e271d881c8efff14b6106d71d1f134e8ca63862163547ae43956a893ed228538
+  languageName: node
+  linkType: hard
+
 "@subql/types-avalanche@npm:0.0.3-4":
   version: 0.0.3-4
   resolution: "@subql/types-avalanche@npm:0.0.3-4"
@@ -3565,7 +3610,10 @@ __metadata:
   resolution: "@subql/validator@workspace:packages/validator"
   dependencies:
     "@subql/common": "workspace:*"
+    "@subql/common-avalanche": latest
+    "@subql/common-cosmos": ^0.0.5
     "@subql/common-substrate": "workspace:*"
+    "@subql/common-terra": latest
     "@types/js-yaml": ^4.0.5
     axios: ^0.24.0
     ipfs-http-client: ^52.0.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -3333,7 +3333,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/common-cosmos@npm:^0.0.5, @subql/common-cosmos@npm:latest":
+"@subql/common-cosmos@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "@subql/common-cosmos@npm:0.0.6"
+  dependencies:
+    "@subql/common": latest
+    "@subql/types-cosmos": 0.0.6
+    class-transformer: 0.4.0
+    class-validator: ^0.13.2
+    js-yaml: ^4.1.0
+    reflect-metadata: ^0.1.13
+  checksum: 93d113560cad2202d08a51ef9e3d8e8d3dac349cb63e6ccb9744ff5ae3b728d985cec422226119219be4622e02cad1597010b0d0d5179519bc76bf1d26f4c028
+  languageName: node
+  linkType: hard
+
+"@subql/common-cosmos@npm:latest":
   version: 0.0.5
   resolution: "@subql/common-cosmos@npm:0.0.5"
   dependencies:
@@ -3563,6 +3577,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@subql/types-cosmos@npm:0.0.6":
+  version: 0.0.6
+  resolution: "@subql/types-cosmos@npm:0.0.6"
+  peerDependencies:
+    "@cosmjs/cosmwasm-stargate": 0.28.7
+    "@cosmjs/proto-signing": 0.28.7
+    "@cosmjs/stargate": 0.28.7
+  checksum: 7b86b60e0bccdbb4cd65567049a719a453036a1dc46fecfd13112d71e725e5d72395ed9ad8ce6471cb7d41859387c0f82c0c8d460a6e743c7428382518638471
+  languageName: node
+  linkType: hard
+
 "@subql/types-terra@npm:0.4.0":
   version: 0.4.0
   resolution: "@subql/types-terra@npm:0.4.0"
@@ -3611,7 +3636,7 @@ __metadata:
   dependencies:
     "@subql/common": "workspace:*"
     "@subql/common-avalanche": latest
-    "@subql/common-cosmos": ^0.0.5
+    "@subql/common-cosmos": ^0.0.6
     "@subql/common-substrate": "workspace:*"
     "@subql/common-terra": latest
     "@types/js-yaml": ^4.0.5


### PR DESCRIPTION
Closes #1035 

**It will validate multi network**

```

jiatwork@MacBook-Pro-4 cli % node bin/run validate -l https://github.com/subquery/juno-subql-dictionary
 PASS  project-yaml-file
 PASS  require-build-script
 PASS  require-codegen-script
 PASS  require-cli-dep
 PASS  require-valid-manifest
 PASS  require-valid-chaintypes
 PASS  require-custom-ds-validation
 PASS  require-valid-runner

Result: 8 passed, 0 failed, 0 skipped

```

**It will validate IPFS deployment**

```

jiatwork@MacBook-Pro-4 cli % node bin/run validate -l ipfs://QmVX1aaJRL9f5Vgjr8VJ9MWAcFHzAya9omnQ534JYCigCQ
 PASS  project-yaml-file
 PASS  require-valid-manifest
 PASS  require-valid-chaintypes
 PASS  require-custom-ds-validation
 PASS  require-valid-runner

Result: 5 passed, 0 failed, 0 skipped

```

_______________________

**Project under 1.0.0 , It will reject validate if no `network-family` provided**

```
jiatwork@MacBook-Pro-4 cli % node bin/run validate -l https://github.com/subquery/polkadot-gift-subql      
    Error: Can not identify project network under spec version 1.0.0
```
**It continue validate if `network-family` provided**
```
jiatwork@MacBook-Pro-4 cli % node bin/run validate -l https://github.com/subquery/polkadot-gift-subql --network-family=Substrate
 PASS  project-yaml-file
 PASS  require-build-script
 PASS  require-codegen-script
 PASS  require-cli-dep
 PASS  require-valid-manifest
 PASS  require-valid-chaintypes
 PASS  require-custom-ds-validation
 PASS  require-valid-runner

Result: 8 passed, 0 failed, 0 skipped
```




