### PR TITLE
Add Eth provider to query contracts and other changes

### DIFF
--- a/packages/node-avalanche/src/avalanche/block.avalanche.ts
+++ b/packages/node-avalanche/src/avalanche/block.avalanche.ts
@@ -27,7 +27,7 @@ export class AvalancheBlockWrapped implements AvalancheBlockWrapper {
   private _logs: AvalancheLog[];
   constructor(private _block: AvalancheBlock) {
     this._logs = flatten(_block.transactions.map((tx) => tx.receipt.logs)).map(
-      (log) => formatLog(log),
+      (log) => formatLog(log, _block),
     ) as AvalancheLog<AvalancheResult>[];
     this.block.logs = this._logs;
   }

--- a/packages/node-avalanche/src/avalanche/index.ts
+++ b/packages/node-avalanche/src/avalanche/index.ts
@@ -3,3 +3,4 @@
 
 export * from './api.avalanche';
 export * from './api.service.avalanche';
+export * from './provider';

--- a/packages/node-avalanche/src/avalanche/provider.ts
+++ b/packages/node-avalanche/src/avalanche/provider.ts
@@ -1,0 +1,235 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  Block,
+  BlockTag,
+  BlockWithTransactions,
+  EventType,
+  FeeData,
+  Filter,
+  Listener,
+  Log,
+  Provider,
+  TransactionReceipt,
+  TransactionRequest,
+  TransactionResponse,
+} from '@ethersproject/abstract-provider';
+import { Network } from '@ethersproject/networks';
+import { Deferrable, resolveProperties } from '@ethersproject/properties';
+import Avalanche from 'avalanche';
+import { EVMAPI } from 'avalanche/dist/apis/evm';
+import { BigNumber, BigNumberish } from 'ethers';
+
+function BNishToHex(value: BigNumberish): string {
+  return BigNumber.from(value).toHexString();
+}
+
+export class CChainProvider implements Provider {
+  private api: EVMAPI;
+
+  constructor(
+    avalanche: Avalanche,
+    private readonly blockHeight: number,
+    readonly path = '/ext/bc/C/rpc',
+  ) {
+    this.api = avalanche.CChain();
+  }
+
+  private async resolveHeight(
+    blockTag?: BlockTag | Promise<BlockTag>,
+  ): Promise<BlockTag> {
+    if (!blockTag) return this.blockHeight;
+
+    const resolvedBlockTag = await blockTag;
+
+    if (resolvedBlockTag === 'latest') return this.blockHeight;
+    if (typeof resolvedBlockTag === 'number') {
+      return Math.min(resolvedBlockTag, this.blockHeight);
+    }
+
+    // Will be 'earliest'
+    return resolvedBlockTag;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  getNetwork(): Promise<Network> {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async getBlockNumber(): Promise<number> {
+    return this.blockHeight;
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  getGasPrice(): Promise<BigNumber> {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  getFeeData(): Promise<FeeData> {
+    throw new Error('Method not available at specific block heights');
+  }
+
+  async getBalance(
+    addressOrName: string | Promise<string>,
+    blockTag?: BlockTag | Promise<BlockTag>,
+  ): Promise<BigNumber> {
+    const {
+      data: { result },
+    } = await this.api.callMethod(
+      'eth_getBalance',
+      [await addressOrName, await this.resolveHeight(blockTag)],
+      this.path,
+    );
+
+    return BigNumber.from(result);
+  }
+
+  async getTransactionCount(
+    addressOrName: string | Promise<string>,
+    blockTag?: BlockTag | Promise<BlockTag>,
+  ): Promise<number> {
+    const {
+      data: { result },
+    } = await this.api.callMethod(
+      'eth_getTransactionCount',
+      [await addressOrName, await this.resolveHeight(blockTag)],
+      this.path,
+    );
+
+    return result;
+  }
+  async getCode(
+    addressOrName: string | Promise<string>,
+    blockTag?: BlockTag | Promise<BlockTag>,
+  ): Promise<string> {
+    const {
+      data: { result },
+    } = await this.api.callMethod(
+      'eth_getCode',
+      [await addressOrName, await this.resolveHeight(blockTag)],
+      this.path,
+    );
+
+    return result;
+  }
+
+  async getStorageAt(
+    addressOrName: string | Promise<string>,
+    position: BigNumberish | Promise<BigNumberish>,
+    blockTag?: BlockTag | Promise<BlockTag>,
+  ): Promise<string> {
+    const {
+      data: { result },
+    } = await this.api.callMethod(
+      'eth_getStorageAt',
+      [await addressOrName, await position, await this.resolveHeight(blockTag)],
+      this.path,
+    );
+
+    return result;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  sendTransaction(
+    signedTransaction: string | Promise<string>,
+  ): Promise<TransactionResponse> {
+    throw new Error('Method not available at specific block heights');
+  }
+
+  async call(
+    transaction: Deferrable<TransactionRequest>,
+    blockTag?: BlockTag | Promise<BlockTag>,
+  ): Promise<string> {
+    const tx = await resolveProperties(transaction);
+
+    const {
+      data: { result },
+    } = await this.api.callMethod(
+      'eth_getStorageAt',
+      [
+        {
+          ...tx,
+          nonce: tx.nonce && BNishToHex(tx.nonce),
+          gas: tx.gasLimit && BNishToHex(tx.gasLimit),
+          gasPrice: tx.gasPrice && BNishToHex(tx.gasPrice),
+          value: tx.value && BNishToHex(tx.value),
+          data: tx.data,
+        },
+        await this.resolveHeight(blockTag),
+      ],
+      this.path,
+    );
+
+    return result;
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  estimateGas(transaction: Deferrable<TransactionRequest>): Promise<BigNumber> {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  getBlock(blockHashOrBlockTag: BlockTag | Promise<BlockTag>): Promise<Block> {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  getBlockWithTransactions(
+    blockHashOrBlockTag: BlockTag | Promise<BlockTag>,
+  ): Promise<BlockWithTransactions> {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  getTransaction(transactionHash: string): Promise<TransactionResponse> {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  getTransactionReceipt(transactionHash: string): Promise<TransactionReceipt> {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  getLogs(filter: Filter): Promise<Log[]> {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  resolveName(name: string | Promise<string>): Promise<string> {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  lookupAddress(address: string | Promise<string>): Promise<string> {
+    throw new Error('Method not available at specific block heights');
+  }
+  on(eventName: EventType, listener: Listener): Provider {
+    throw new Error('Method not available at specific block heights');
+  }
+  once(eventName: EventType, listener: Listener): Provider {
+    throw new Error('Method not available at specific block heights');
+  }
+  emit(eventName: EventType, ...args: any[]): boolean {
+    throw new Error('Method not available at specific block heights');
+  }
+  listenerCount(eventName?: EventType): number {
+    throw new Error('Method not available at specific block heights');
+  }
+  listeners(eventName?: EventType): Listener[] {
+    throw new Error('Method not available at specific block heights');
+  }
+  off(eventName: EventType, listener?: Listener): Provider {
+    throw new Error('Method not available at specific block heights');
+  }
+  removeAllListeners(eventName?: EventType): Provider {
+    throw new Error('Method not available at specific block heights');
+  }
+  addListener(eventName: EventType, listener: Listener): Provider {
+    throw new Error('Method not available at specific block heights');
+  }
+  removeListener(eventName: EventType, listener: Listener): Provider {
+    throw new Error('Method not available at specific block heights');
+  }
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  waitForTransaction(
+    transactionHash: string,
+    confirmations?: number,
+    timeout?: number,
+  ): Promise<TransactionReceipt> {
+    throw new Error('Method not available at specific block heights');
+  }
+  _isProvider: boolean;
+}

--- a/packages/node-avalanche/src/avalanche/utils.avalanche.ts
+++ b/packages/node-avalanche/src/avalanche/utils.avalanche.ts
@@ -11,111 +11,111 @@ import {
 import { BigNumber } from 'ethers';
 
 export function formatBlock(block: Record<string, any>): AvalancheBlock {
-  const newBlock = {} as AvalancheBlock;
-  if (block.baseFeePerGas) {
-    newBlock.baseFeePerGas = BigNumber.from(block.baseFeePerGas).toBigInt();
-  }
-  newBlock.blockExtraData = block.extraData;
-  if (block.blockGasCost) {
-    newBlock.blockGasCost = BigNumber.from(block.blockGasCost).toBigInt();
-  }
-  newBlock.difficulty = BigNumber.from(block.difficulty).toBigInt();
-  newBlock.extDataGasUsed = block.extDataGasUsed;
-  newBlock.extDataHash = block.extDataHash;
-  newBlock.gasLimit = BigNumber.from(block.gasLimit).toBigInt();
-  newBlock.gasUsed = BigNumber.from(block.gasUsed).toBigInt();
-  newBlock.hash = block.hash;
-  newBlock.logsBloom = block.logsBloom;
-  newBlock.miner = block.miner;
-  newBlock.mixHash = block.mixHash;
-  newBlock.nonce = block.nonce;
-  newBlock.number = BigNumber.from(block.number).toNumber();
-  newBlock.parentHash = block.parentHash;
-  newBlock.receiptsRoot = block.receiptsRoot;
-  newBlock.sha3Uncles = block.sha3Uncles;
-  newBlock.size = BigNumber.from(block.size).toBigInt();
-  newBlock.stateRoot = block.stateRoot;
-  newBlock.timestamp = BigNumber.from(block.timestamp).toBigInt();
-  newBlock.totalDifficulty = BigNumber.from(block.totalDifficulty).toBigInt();
-  newBlock.transactions = block.transactions;
-  newBlock.transactionsRoot = block.transactionsRoot;
-  newBlock.uncles = block.uncles;
+  const newBlock: AvalancheBlock = {
+    difficulty: BigNumber.from(block.difficulty).toBigInt(),
+    extDataGasUsed: block.extDataGasUsed,
+    extDataHash: block.extDataHash,
+    gasLimit: BigNumber.from(block.gasLimit).toBigInt(),
+    gasUsed: BigNumber.from(block.gasUsed).toBigInt(),
+    hash: block.hash,
+    logsBloom: block.logsBloom,
+    miner: block.miner,
+    mixHash: block.mixHash,
+    nonce: block.nonce,
+    number: BigNumber.from(block.number).toNumber(),
+    parentHash: block.parentHash,
+    receiptsRoot: block.receiptsRoot,
+    sha3Uncles: block.sha3Uncles,
+    size: BigNumber.from(block.size).toBigInt(),
+    stateRoot: block.stateRoot,
+    timestamp: BigNumber.from(block.timestamp).toBigInt(),
+    totalDifficulty: BigNumber.from(block.totalDifficulty).toBigInt(),
+    transactions: block.transactions,
+    transactionsRoot: block.transactionsRoot,
+    uncles: block.uncles,
+    baseFeePerGas: block.baseFeePerGas
+      ? BigNumber.from(block.baseFeePerGas).toBigInt()
+      : undefined,
+    blockGasCost: block.blockGasCost
+      ? BigNumber.from(block.blockGasCost).toBigInt()
+      : undefined,
+    blockExtraData: block.blockExtraData,
+    logs: [], // Filled in at AvalancheBlockWrapped constructor
+  };
+
   return newBlock;
 }
 export function formatLog(
   log: AvalancheLog<AvalancheResult> | AvalancheLog,
+  block: AvalancheBlock,
 ): AvalancheLog<AvalancheResult> | AvalancheLog {
-  const newLog = {} as AvalancheLog<AvalancheResult>;
-  newLog.address = log.address;
-  newLog.topics = log.topics;
-  newLog.data = log.data;
-  newLog.blockNumber = BigNumber.from(log.blockNumber).toNumber();
-  newLog.transactionHash = log.transactionHash;
-  newLog.transactionIndex = BigNumber.from(log.transactionIndex).toNumber();
-  newLog.blockHash = log.blockHash;
-  newLog.logIndex = BigNumber.from(log.logIndex).toNumber();
-  newLog.removed = log.removed;
-  newLog.args = log.args;
+  const newLog: AvalancheLog<AvalancheResult> = {
+    address: log.address,
+    topics: log.topics,
+    data: log.data,
+    blockNumber: BigNumber.from(log.blockNumber).toNumber(),
+    transactionHash: log.transactionHash,
+    transactionIndex: BigNumber.from(log.transactionIndex).toNumber(),
+    blockHash: log.blockHash,
+    logIndex: BigNumber.from(log.logIndex).toNumber(),
+    removed: log.removed,
+    args: log.args,
+    block,
+  };
   return newLog;
 }
 
 export function formatTransaction(
   tx: Record<string, any>,
 ): AvalancheTransaction {
-  const transaction = {} as AvalancheTransaction;
-  transaction.blockHash = tx.blockHash;
-  transaction.blockNumber = BigNumber.from(tx.blockNumber).toNumber();
-  transaction.from = tx.from;
-  transaction.gas = BigNumber.from(tx.gas).toBigInt();
-  transaction.gasPrice = BigNumber.from(tx.gasPrice).toBigInt();
-  transaction.hash = tx.hash;
-  transaction.input = tx.input;
-  transaction.nonce = BigNumber.from(tx.nonce).toBigInt();
-  transaction.to = tx.to;
-  transaction.transactionIndex = BigNumber.from(tx.transactionIndex).toBigInt();
-  transaction.value = BigNumber.from(tx.value).toBigInt();
-  transaction.type = tx.type;
-  transaction.v = BigNumber.from(tx.v).toBigInt();
-  transaction.r = tx.r;
-  transaction.s = tx.s;
-  if (tx.accessList) {
-    transaction.accessList = tx.accessList;
-  }
-  if (tx.chainId) {
-    transaction.chainId = tx.chainId;
-  }
-  if (tx.maxFeePerGas) {
-    transaction.maxFeePerGas = BigNumber.from(tx.maxFeePerGas).toBigInt();
-  }
-  if (tx.maxPriorityFeePerGas) {
-    transaction.maxPriorityFeePerGas = BigNumber.from(
-      tx.maxPriorityFeePerGas,
-    ).toBigInt();
-  }
+  const transaction: AvalancheTransaction = {
+    blockHash: tx.blockHash,
+    blockNumber: BigNumber.from(tx.blockNumber).toNumber(),
+    from: tx.from,
+    gas: BigNumber.from(tx.gas).toBigInt(),
+    gasPrice: BigNumber.from(tx.gasPrice).toBigInt(),
+    hash: tx.hash,
+    input: tx.input,
+    nonce: BigNumber.from(tx.nonce).toBigInt(),
+    to: tx.to,
+    transactionIndex: BigNumber.from(tx.transactionIndex).toBigInt(),
+    value: BigNumber.from(tx.value).toBigInt(),
+    type: tx.type,
+    v: BigNumber.from(tx.v).toBigInt(),
+    r: tx.r,
+    s: tx.s,
+    accessList: tx.accessList,
+    chainId: tx.chainId,
+    maxFeePerGas: tx.maxFeePerGas
+      ? BigNumber.from(tx.maxFeePerGas).toBigInt()
+      : undefined,
+    maxPriorityFeePerGas: tx.maxPriorityFeePerGas
+      ? BigNumber.from(tx.maxPriorityFeePerGas).toBigInt()
+      : undefined,
+    receipt: undefined, // Filled in at AvalancheApi.fetchBlocks
+  };
   return transaction;
 }
 
-export function formatReceipt(receipt: Record<string, any>): AvalancheReceipt {
-  const newReceipt = {} as AvalancheReceipt;
-  newReceipt.blockHash = receipt.blockHash;
-  newReceipt.blockNumber = BigNumber.from(receipt.blockNumber).toNumber();
-  newReceipt.contractAddress = receipt.contractAddress;
-  newReceipt.cumulativeGasUsed = BigNumber.from(
-    receipt.cumulativeGasUsed,
-  ).toBigInt();
-  newReceipt.effectiveGasPrice = BigNumber.from(
-    receipt.effectiveGasPrice,
-  ).toBigInt();
-  newReceipt.from = receipt.from;
-  newReceipt.gasUsed = BigNumber.from(receipt.gasUsed).toBigInt();
-  newReceipt.logs = receipt.logs.map((log) => formatLog(log));
-  newReceipt.logsBloom = receipt.logsBloom;
-  newReceipt.status = Boolean(BigNumber.from(receipt.status).toNumber());
-  newReceipt.to = receipt.to;
-  newReceipt.transactionHash = receipt.transactionHash;
-  newReceipt.transactionIndex = BigNumber.from(
-    receipt.transactionIndex,
-  ).toNumber();
-  newReceipt.type = receipt.type;
+export function formatReceipt(
+  receipt: Record<string, any>,
+  block: AvalancheBlock,
+): AvalancheReceipt {
+  const newReceipt: AvalancheReceipt = {
+    blockHash: receipt.blockHash,
+    blockNumber: BigNumber.from(receipt.blockNumber).toNumber(),
+    contractAddress: receipt.contractAddress,
+    cumulativeGasUsed: BigNumber.from(receipt.cumulativeGasUsed).toBigInt(),
+    effectiveGasPrice: BigNumber.from(receipt.effectiveGasPrice).toBigInt(),
+    from: receipt.from,
+    gasUsed: BigNumber.from(receipt.gasUsed).toBigInt(),
+    logs: receipt.logs.map((log) => formatLog(log, block)),
+    logsBloom: receipt.logsBloom,
+    status: Boolean(BigNumber.from(receipt.status).toNumber()),
+    to: receipt.to,
+    transactionHash: receipt.transactionHash,
+    transactionIndex: BigNumber.from(receipt.transactionIndex).toNumber(),
+    type: receipt.type,
+  };
   return newReceipt;
 }

--- a/packages/node-avalanche/src/indexer/sandbox.service.ts
+++ b/packages/node-avalanche/src/indexer/sandbox.service.ts
@@ -8,7 +8,7 @@ import {
   SubstrateDataSource,
 } from '@subql/common-avalanche';
 import { ApiService, getYargsOption, getLogger } from '@subql/common-node';
-import { ApiAt, ApiWrapper, BlockWrapper, Store } from '@subql/types-avalanche';
+import { ApiWrapper, BlockWrapper, Store } from '@subql/types-avalanche';
 import { levelFilter } from '@subql/utils';
 import { NodeVM, NodeVMOptions, VMScript } from '@subql/x-vm2';
 import { merge } from 'lodash';
@@ -112,29 +112,6 @@ export class SandboxService {
     private readonly nodeConfig: NodeConfig,
     private readonly project: SubqueryProject,
   ) {}
-
-  getDsProcessor(ds: SubqlProjectDs, api: ApiAt): IndexerSandbox {
-    const entry = this.getDataSourceEntry(ds);
-    let processor = this.processorCache[entry];
-    if (!processor) {
-      processor = new IndexerSandbox(
-        {
-          // api: await this.apiService.getPatchedApi(),
-          store: this.storeService.getStore(),
-          root: this.project.root,
-          script: ds.mapping.entryScript,
-          entry,
-        },
-        this.nodeConfig,
-      );
-      this.processorCache[entry] = processor;
-    }
-    processor.freeze(api, 'api');
-    if (argv.unsafe) {
-      processor.freeze(this.apiService.api, 'unsafeApi');
-    }
-    return processor;
-  }
 
   getDsProcessorWrapper(
     ds: SubqlProjectDs,

--- a/packages/types-avalanche/package.json
+++ b/packages/types-avalanche/package.json
@@ -21,5 +21,8 @@
   "devDependencies": {
     "@polkadot/api": "^8",
     "@types/app-module-path": "^2.2.0"
+  },
+  "dependencies": {
+    "@ethersproject/abstract-provider": "^5.6.1"
   }
 }

--- a/packages/types-avalanche/src/avalanche/interfaces.ts
+++ b/packages/types-avalanche/src/avalanche/interfaces.ts
@@ -74,13 +74,14 @@ export type AvalancheLog<T extends AvalancheResult = AvalancheResult> = {
   address: string;
   topics: string[];
   data: string;
+  blockHash: string;
   blockNumber: number;
   transactionHash: string;
   transactionIndex: number;
-  blockHash: string;
   logIndex: number;
   removed: boolean;
   args?: T;
+  block: AvalancheBlock;
 };
 
 export type AvalancheReceipt = {

--- a/packages/types-avalanche/src/global.ts
+++ b/packages/types-avalanche/src/global.ts
@@ -1,11 +1,12 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import {Provider} from '@ethersproject/abstract-provider';
 import Pino from 'pino';
-import {Store, DynamicDatasourceCreator, ApiAt} from './interfaces';
+import {Store, DynamicDatasourceCreator} from './interfaces';
 
 declare global {
-  const api: ApiAt;
+  const api: Provider;
   const logger: Pino.Logger;
   const store: Store;
   const createDynamicDatasource: DynamicDatasourceCreator;

--- a/packages/types-avalanche/src/interfaces.ts
+++ b/packages/types-avalanche/src/interfaces.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {ApiPromise} from '@polkadot/api';
-import {ApiDecoration} from '@polkadot/api/types';
+// import {ApiPromise} from '@polkadot/api';
+// import {ApiDecoration} from '@polkadot/api/types';
 import {AlgorandBlock, AlgorandBlockWrapper, AlgorandEvent, AlgorandTransaction} from './algorand';
 import {
   AvalancheBlock,
@@ -19,7 +19,7 @@ export interface Entity {
   id: string;
 }
 
-export type ApiAt = ApiDecoration<'promise'> & {rpc: ApiPromise['rpc']};
+// export type ApiAt = ApiDecoration<'promise'> & {rpc: ApiPromise['rpc']};
 
 export type FunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? K : never;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,6 +1555,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/abstract-provider@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "@ethersproject/abstract-provider@npm:5.6.1"
+  dependencies:
+    "@ethersproject/bignumber": ^5.6.2
+    "@ethersproject/bytes": ^5.6.1
+    "@ethersproject/logger": ^5.6.0
+    "@ethersproject/networks": ^5.6.3
+    "@ethersproject/properties": ^5.6.0
+    "@ethersproject/transactions": ^5.6.2
+    "@ethersproject/web": ^5.6.1
+  checksum: a1be8035d9e67fd41a336e2d38f5cf03b7a2590243749b4cf807ad73906b5a298e177ebe291cb5b54262ded4825169bf82968e0e5b09fbea17444b903faeeab0
+  languageName: node
+  linkType: hard
+
 "@ethersproject/abstract-signer@npm:5.6.0, @ethersproject/abstract-signer@npm:^5.6.0":
   version: 5.6.0
   resolution: "@ethersproject/abstract-signer@npm:5.6.0"
@@ -1581,12 +1596,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/address@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "@ethersproject/address@npm:5.6.1"
+  dependencies:
+    "@ethersproject/bignumber": ^5.6.2
+    "@ethersproject/bytes": ^5.6.1
+    "@ethersproject/keccak256": ^5.6.1
+    "@ethersproject/logger": ^5.6.0
+    "@ethersproject/rlp": ^5.6.1
+  checksum: 262096ef05a1b626c161a72698a5d8b06aebf821fe01a1651ab40f80c29ca2481b96be7f972745785fd6399906509458c4c9a38f3bc1c1cb5afa7d2f76f7309a
+  languageName: node
+  linkType: hard
+
 "@ethersproject/base64@npm:5.6.0, @ethersproject/base64@npm:^5.6.0":
   version: 5.6.0
   resolution: "@ethersproject/base64@npm:5.6.0"
   dependencies:
     "@ethersproject/bytes": ^5.6.0
   checksum: 5f316367acf18fdba82d50868171251f75218740a1c9bad8b11c6c3372c86ae323f91bc6727e78e527866357974d19fcced12f666fb067ffba2be638d54d36f7
+  languageName: node
+  linkType: hard
+
+"@ethersproject/base64@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "@ethersproject/base64@npm:5.6.1"
+  dependencies:
+    "@ethersproject/bytes": ^5.6.1
+  checksum: d21c5c297e1b8bc48fe59012c0cd70a90df7772fac07d9cc3da499d71d174d9f48edfd83495d4a1496cb70e8d1b33fb5b549a9529c5c2f97bb3a07d3f33a3fe8
   languageName: node
   linkType: hard
 
@@ -1611,7 +1648,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/bytes@npm:5.6.1, @ethersproject/bytes@npm:^5.6.0":
+"@ethersproject/bignumber@npm:^5.6.2":
+  version: 5.6.2
+  resolution: "@ethersproject/bignumber@npm:5.6.2"
+  dependencies:
+    "@ethersproject/bytes": ^5.6.1
+    "@ethersproject/logger": ^5.6.0
+    bn.js: ^5.2.1
+  checksum: 9cf31c10274f1b6d45b16aed29f43729e8f5edec38c8ec8bb90d6b44f0eae14fda6519536228d23916a375ce11e71a77279a912d653ea02503959910b6bf9de7
+  languageName: node
+  linkType: hard
+
+"@ethersproject/bytes@npm:5.6.1, @ethersproject/bytes@npm:^5.6.0, @ethersproject/bytes@npm:^5.6.1":
   version: 5.6.1
   resolution: "@ethersproject/bytes@npm:5.6.1"
   dependencies:
@@ -1626,6 +1674,15 @@ __metadata:
   dependencies:
     "@ethersproject/bignumber": ^5.6.0
   checksum: da54458a0133b64c02052b86fefa6118ed88c449b02a61ba57745bf08029658214291935b0500461bde3f734ea98e6d8edc586eed9ce9fa7e6a16d9397716ff7
+  languageName: node
+  linkType: hard
+
+"@ethersproject/constants@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "@ethersproject/constants@npm:5.6.1"
+  dependencies:
+    "@ethersproject/bignumber": ^5.6.2
+  checksum: 3c6abcee60f1620796dc40210a638b601ad8a2d3f6668a69c42a5ca361044f21296b16d1d43b8a00f7c28b385de4165983a8adf671e0983f5ef07459dfa84997
   languageName: node
   linkType: hard
 
@@ -1714,6 +1771,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/keccak256@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "@ethersproject/keccak256@npm:5.6.1"
+  dependencies:
+    "@ethersproject/bytes": ^5.6.1
+    js-sha3: 0.8.0
+  checksum: fdc950e22a1aafc92fdf749cdc5b8952b85e8cee8872d807c5f40be31f58675d30e0eca5e676876b93f2cd22ac63a344d384d116827ee80928c24b7c299991f5
+  languageName: node
+  linkType: hard
+
 "@ethersproject/logger@npm:5.6.0, @ethersproject/logger@npm:^5.6.0":
   version: 5.6.0
   resolution: "@ethersproject/logger@npm:5.6.0"
@@ -1727,6 +1794,15 @@ __metadata:
   dependencies:
     "@ethersproject/logger": ^5.6.0
   checksum: 3326a2d4accee41c9e93bdd3ae51db2319edd4eb9f7aca16e251261157b3940806fe837e9082f28f126164d9bb7583083c6be9493e7073d25289d3e7802c6873
+  languageName: node
+  linkType: hard
+
+"@ethersproject/networks@npm:^5.6.3":
+  version: 5.6.4
+  resolution: "@ethersproject/networks@npm:5.6.4"
+  dependencies:
+    "@ethersproject/logger": ^5.6.0
+  checksum: d41c07497de4ace3f57e972428685a8703a867600cf01f2bc15a21fcb7f99afb3f05b3d8dbb29ac206473368f30d60b98dc445cc38403be4cbe6f804f70e5173
   languageName: node
   linkType: hard
 
@@ -1823,6 +1899,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/rlp@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "@ethersproject/rlp@npm:5.6.1"
+  dependencies:
+    "@ethersproject/bytes": ^5.6.1
+    "@ethersproject/logger": ^5.6.0
+  checksum: 43a281d0e7842606e2337b5552c13f4b5dad209dce173de39ef6866e02c9d7b974f1cae945782f4c4b74a8e22d8272bfd0348c1cd1bfeb2c278078ef95565488
+  languageName: node
+  linkType: hard
+
 "@ethersproject/sha2@npm:5.6.0, @ethersproject/sha2@npm:^5.6.0":
   version: 5.6.0
   resolution: "@ethersproject/sha2@npm:5.6.0"
@@ -1862,6 +1948,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/signing-key@npm:^5.6.2":
+  version: 5.6.2
+  resolution: "@ethersproject/signing-key@npm:5.6.2"
+  dependencies:
+    "@ethersproject/bytes": ^5.6.1
+    "@ethersproject/logger": ^5.6.0
+    "@ethersproject/properties": ^5.6.0
+    bn.js: ^5.2.1
+    elliptic: 6.5.4
+    hash.js: 1.1.7
+  checksum: 7889d0934c9664f87e7b7e021794e2d2ddb2e81c1392498e154cf2d5909b922d74d3df78cec44187f63dc700eddad8f8ea5ded47d2082a212a591818014ca636
+  languageName: node
+  linkType: hard
+
 "@ethersproject/solidity@npm:5.6.0":
   version: 5.6.0
   resolution: "@ethersproject/solidity@npm:5.6.0"
@@ -1887,6 +1987,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/strings@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "@ethersproject/strings@npm:5.6.1"
+  dependencies:
+    "@ethersproject/bytes": ^5.6.1
+    "@ethersproject/constants": ^5.6.1
+    "@ethersproject/logger": ^5.6.0
+  checksum: dcf33c2ddb22a48c3d7afc151a5f37e5a4da62a742a298988d517dc9adfaff9c5a0ebd8f476ec9792704cfc8142abd541e97432bc47cb121093edac7a5cfaf22
+  languageName: node
+  linkType: hard
+
 "@ethersproject/transactions@npm:5.6.0, @ethersproject/transactions@npm:^5.6.0":
   version: 5.6.0
   resolution: "@ethersproject/transactions@npm:5.6.0"
@@ -1901,6 +2012,23 @@ __metadata:
     "@ethersproject/rlp": ^5.6.0
     "@ethersproject/signing-key": ^5.6.0
   checksum: b01a3a9ce1e2d945825adbecfc71b992293e0274b77caf2c0b3c45bb76919ce64aa888a5705e6745a84448c50fc4eb58ff5e0ad11c37b1aae33c7a7d3b8af883
+  languageName: node
+  linkType: hard
+
+"@ethersproject/transactions@npm:^5.6.2":
+  version: 5.6.2
+  resolution: "@ethersproject/transactions@npm:5.6.2"
+  dependencies:
+    "@ethersproject/address": ^5.6.1
+    "@ethersproject/bignumber": ^5.6.2
+    "@ethersproject/bytes": ^5.6.1
+    "@ethersproject/constants": ^5.6.1
+    "@ethersproject/keccak256": ^5.6.1
+    "@ethersproject/logger": ^5.6.0
+    "@ethersproject/properties": ^5.6.0
+    "@ethersproject/rlp": ^5.6.1
+    "@ethersproject/signing-key": ^5.6.2
+  checksum: 5cf13936ce406f97b71fc1e99090698c2e4276dcb17c5a022aa3c3f55825961edcb53d4a59166acab797275afa45fb93f1b9b602ebc709da6afa66853f849609
   languageName: node
   linkType: hard
 
@@ -1948,6 +2076,19 @@ __metadata:
     "@ethersproject/properties": ^5.6.0
     "@ethersproject/strings": ^5.6.0
   checksum: 42b6e71658393e5abf8341c6bea0deb22cc744b4d22b3a979ed876bc772723b800c18e5180e223f77c47fb045828ef16ba5a01e8dd346474cf430533d1f053bc
+  languageName: node
+  linkType: hard
+
+"@ethersproject/web@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "@ethersproject/web@npm:5.6.1"
+  dependencies:
+    "@ethersproject/base64": ^5.6.1
+    "@ethersproject/bytes": ^5.6.1
+    "@ethersproject/logger": ^5.6.0
+    "@ethersproject/properties": ^5.6.0
+    "@ethersproject/strings": ^5.6.1
+  checksum: 4acb62bb04431f5a1b1ec27e88847087676dd2fd72ba40c789f2885493e5eed6b6d387d5b47d4cdfc2775bcbe714e04bfaf0d04a6f30e929310384362e6be429
   languageName: node
   linkType: hard
 
@@ -4122,6 +4263,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subql/types-avalanche@workspace:packages/types-avalanche"
   dependencies:
+    "@ethersproject/abstract-provider": ^5.6.1
     "@polkadot/api": ^8
     "@types/app-module-path": ^2.2.0
   peerDependencies:
@@ -6541,6 +6683,13 @@ __metadata:
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
   checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "bn.js@npm:5.2.1"
+  checksum: 3dd8c8d38055fedfa95c1d5fc3c99f8dd547b36287b37768db0abab3c239711f88ff58d18d155dd8ad902b0b0cee973747b7ae20ea12a09473272b0201c9edd3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Add CChain provider that implements Eth provider interface for querying contracts
- Better support for subnets that have EVM support
- Add block to log object in order to get block timestamp
- Improve getting target height to be supported on other subnets
- Rework formatting data structures for better type checking

Resolves https://github.com/subquery/subql/issues/1121 and https://github.com/subquery/subql/issues/1122