### PR TITLE
add dictionary query timeout option

### DIFF
--- a/packages/node/src/configure/NodeConfig.ts
+++ b/packages/node/src/configure/NodeConfig.ts
@@ -31,6 +31,7 @@ export interface IConfig {
   readonly proofOfIndex: boolean;
   readonly mmrPath?: string;
   readonly ipfs?: string;
+  readonly dictionaryTimeout: number;
 }
 
 export type MinConfig = Partial<Omit<IConfig, 'subquery'>> &
@@ -46,6 +47,7 @@ const DEFAULT_CONFIG = {
   indexCountLimit: 10,
   timestampField: true,
   proofOfIndex: false,
+  dictionaryTimeout: 30,
 };
 
 export class NodeConfig implements IConfig {
@@ -133,6 +135,10 @@ export class NodeConfig implements IConfig {
 
   get proofOfIndex(): boolean {
     return this._config.proofOfIndex;
+  }
+
+  get dictionaryTimeout(): number {
+    return this._config.dictionaryTimeout;
   }
 
   get mmrPath(): string {

--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -15,6 +15,7 @@ import fetch from 'node-fetch';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { getLogger } from '../utils/logger';
 import { profiler } from '../utils/profiler';
+import { timeout } from '../utils/promise';
 import { getYargsOption } from '../yargs';
 
 export type SpecVersion = {
@@ -155,10 +156,13 @@ export class DictionaryService implements OnApplicationShutdown {
     );
 
     try {
-      const resp = await this.client.query({
-        query: gql(query),
-        variables,
-      });
+      const resp = await timeout(
+        this.client.query({
+          query: gql(query),
+          variables,
+        }),
+        argv['dictionary-timeout'],
+      );
       const blockHeightSet = new Set<number>();
       const specVersionBlockHeightSet = new Set<number>();
       const entityEndBlock: { [entity: string]: number } = {};
@@ -277,9 +281,12 @@ export class DictionaryService implements OnApplicationShutdown {
   async getSpecVersionsRaw(): Promise<SpecVersionDictionary> {
     const { query } = this.specVersionQuery();
     try {
-      const resp = await this.client.query({
-        query: gql(query),
-      });
+      const resp = await timeout(
+        this.client.query({
+          query: gql(query),
+        }),
+        argv['dictionary-timeout'],
+      );
 
       const _metadata = resp.data._metadata;
       const specVersions = resp.data.specVersions;

--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -12,6 +12,7 @@ import { Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { DictionaryQueryCondition, DictionaryQueryEntry } from '@subql/types';
 import { buildQuery, GqlNode, GqlQuery, GqlVar, MetaData } from '@subql/utils';
 import fetch from 'node-fetch';
+import { NodeConfig } from '../configure/NodeConfig';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { getLogger } from '../utils/logger';
 import { profiler } from '../utils/profiler';
@@ -114,7 +115,10 @@ export class DictionaryService implements OnApplicationShutdown {
   private client: ApolloClient<NormalizedCacheObject>;
   private isShutdown = false;
 
-  constructor(protected project: SubqueryProject) {
+  constructor(
+    protected project: SubqueryProject,
+    private nodeConfig: NodeConfig,
+  ) {
     this.client = new ApolloClient({
       cache: new InMemoryCache({ resultCaching: true }),
       link: new HttpLink({ uri: this.project.network.dictionary, fetch }),
@@ -161,7 +165,7 @@ export class DictionaryService implements OnApplicationShutdown {
           query: gql(query),
           variables,
         }),
-        argv['dictionary-timeout'],
+        this.nodeConfig.dictionaryTimeout,
       );
       const blockHeightSet = new Set<number>();
       const specVersionBlockHeightSet = new Set<number>();
@@ -285,7 +289,7 @@ export class DictionaryService implements OnApplicationShutdown {
         this.client.query({
           query: gql(query),
         }),
-        argv['dictionary-timeout'],
+        this.nodeConfig.dictionaryTimeout,
       );
 
       const _metadata = resp.data._metadata;

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -117,6 +117,12 @@ export function getYargsOption() {
       describe: 'Specify the dictionary api for this network',
       type: 'string',
     },
+    'dictionary-timeout': {
+      demandOption: false,
+      describe: 'Max timeout for dictionary query',
+      type: 'number',
+      default: 30, //sec
+    },
     'mmr-path': {
       alias: 'm',
       demandOption: false,

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -121,7 +121,6 @@ export function getYargsOption() {
       demandOption: false,
       describe: 'Max timeout for dictionary query',
       type: 'number',
-      default: 30, //sec
     },
     'mmr-path': {
       alias: 'm',


### PR DESCRIPTION
# Description

While query service it self has `query-timeout`, (on host service this is set to 60 seconds) but sometime long waiting for dictionary query is not the idea. We should provide an option allow indexer to decide how they want to dictionary act. This can provide a shorter timeout for dictionary query, like 20 seconds. So if query has timeout, it will back to use original batch (range)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
