### PR TITLE
fix node-fetch 2.6.7 to cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
     "fuzzy": "^0.1.3",
     "inquirer": "^8.2.0",
     "inquirer-autocomplete-prompt": "^1.4.0",
+    "node-fetch": "2.6.7",
     "oclif": "^2.4.4",
     "rimraf": "^3.0.2",
     "simple-git": "^3.1.1",
@@ -34,8 +35,7 @@
     "webpack": "^5.68.0",
     "webpack-merge": "^5.8.0",
     "websocket": "^1.0.34",
-    "yaml-loader": "^0.6.0",
-    "node-fetch": "2.6.7"
+    "yaml-loader": "^0.6.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,6 +3442,7 @@ __metadata:
     globby: ^11
     inquirer: ^8.2.0
     inquirer-autocomplete-prompt: ^1.4.0
+    node-fetch: 2.6.7
     oclif: ^2.4.4
     rimraf: ^3.0.2
     simple-git: ^3.1.1


### PR DESCRIPTION
# Description

Fixes cli failed due to use node-fetch 3.x.x, as it only support ES module, force downgrade to 2.6.7 until we are ready to move to ES module

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
