### PR TITLE
Fix ds template not being found as it was in another tmp directory

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Unable to create ds processor from template when project hosted on IPFS (#1190)
+
 ## [1.5.0] - 2022-07-12
 ### Added
 - add option `dictionary-timeout`, allow indexer decide timeout for query dictionary result (#1177)

--- a/packages/node/src/configure/SubqueryProject.ts
+++ b/packages/node/src/configure/SubqueryProject.ts
@@ -175,7 +175,11 @@ async function loadProjectFromManifest0_2_1(
     path,
     networkOverrides,
   );
-  project.templates = await loadProjectTemplates(projectManifest, reader);
+  project.templates = await loadProjectTemplates(
+    projectManifest,
+    project.root,
+    reader,
+  );
   return project;
 }
 
@@ -193,7 +197,11 @@ async function loadProjectFromManifest1_0_0(
     path,
     networkOverrides,
   );
-  project.templates = await loadProjectTemplates(projectManifest, reader);
+  project.templates = await loadProjectTemplates(
+    projectManifest,
+    project.root,
+    reader,
+  );
   project.runner = projectManifest.runner;
   if (!validateSemver(packageVersion, project.runner.node.version)) {
     throw new Error(
@@ -205,11 +213,10 @@ async function loadProjectFromManifest1_0_0(
 
 async function loadProjectTemplates(
   projectManifest: ProjectManifestV0_2_1Impl | ProjectManifestV1_0_0Impl,
+  root: string,
   reader: Reader,
 ): Promise<SubqlProjectDsTemplate[]> {
   if (projectManifest.templates && projectManifest.templates.length !== 0) {
-    const root = await getProjectRoot(reader);
-
     const dsTemplates = await updateDataSourcesV0_2_0(
       projectManifest.templates,
       reader,


### PR DESCRIPTION
# Description
Templates datasource processors were being fetched from IPFS to another temp directory that wasn't within the project root, this was causing the file to not be resolved. 

Relates to https://github.com/subquery/subql/issues/1142

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch


Test project: `QmagdDNVMUfKSq8JFV7na4E93UT3pigC5kmB7SeAeGAR3L`
