### PR TITLE
Make handler types generic

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make handler data types generic (#1194)
 
 ## [1.5.1] - 2022-07-15
 ### Fixed

--- a/packages/node/src/indexer/ds-processor.service.ts
+++ b/packages/node/src/indexer/ds-processor.service.ts
@@ -4,6 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import { Injectable } from '@nestjs/common';
+import { AnyTuple } from '@polkadot/types-codec/types';
 import {
   isCustomDs,
   SubstrateCustomDataSource,
@@ -35,12 +36,13 @@ export function isSecondLayerHandlerProcessor_0_0_0<
   K extends SubstrateHandlerKind,
   F,
   E,
+  IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource,
 >(
   processor:
-    | SecondLayerHandlerProcessor_0_0_0<K, F, E, DS>
-    | SecondLayerHandlerProcessor_1_0_0<K, F, E, DS>,
-): processor is SecondLayerHandlerProcessor_0_0_0<K, F, E, DS> {
+    | SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS>
+    | SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS>,
+): processor is SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS> {
   // Exisiting datasource processors had no concept of specVersion, therefore undefined is equivalent to 0.0.0
   return processor.specVersion === undefined;
 }
@@ -49,12 +51,13 @@ export function isSecondLayerHandlerProcessor_1_0_0<
   K extends SubstrateHandlerKind,
   F,
   E,
+  IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource,
 >(
   processor:
-    | SecondLayerHandlerProcessor_0_0_0<K, F, E, DS>
-    | SecondLayerHandlerProcessor_1_0_0<K, F, E, DS>,
-): processor is SecondLayerHandlerProcessor_1_0_0<K, F, E, DS> {
+    | SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS>
+    | SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS>,
+): processor is SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS> {
   return processor.specVersion === '1.0.0';
 }
 
@@ -62,12 +65,13 @@ export function asSecondLayerHandlerProcessor_1_0_0<
   K extends SubstrateHandlerKind,
   F,
   E,
+  IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource,
 >(
   processor:
-    | SecondLayerHandlerProcessor_0_0_0<K, F, E, DS>
-    | SecondLayerHandlerProcessor_1_0_0<K, F, E, DS>,
-): SecondLayerHandlerProcessor_1_0_0<K, F, E, DS> {
+    | SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS>
+    | SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS>,
+): SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS> {
   if (isSecondLayerHandlerProcessor_1_0_0(processor)) {
     return processor;
   }

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -4,7 +4,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApiPromise } from '@polkadot/api';
-import { RuntimeVersion } from '@polkadot/types/interfaces';
 import { hexToU8a, u8aEq } from '@polkadot/util';
 import {
   isBlockHandlerProcessor,

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -9,6 +9,10 @@ All logs must start with the format: [x.y.z] - yyyy-mm-dd
 
 ## [Unreleased]
 
+
+### Changed
+- Make handler data types generic (#1194)
+
 ## [1.1.0] - 2022-05-31
 ### Changed
 - Update name for substrate types (#1012)

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -9,9 +9,8 @@ All logs must start with the format: [x.y.z] - yyyy-mm-dd
 
 ## [Unreleased]
 
-
 ### Changed
-- Make handler data types generic (#1194)
+- Make `SubstrateExtrinsic` and `SubstrateEvent` types generic. This allows specifying the data/args type rather than being provided with `Codec[]` or `AnyTuple` (#1194)
 
 ## [1.1.0] - 2022-05-31
 ### Changed

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {AnyTuple, Codec} from '@polkadot/types-codec/types';
-import {EventRecord, SignedBlock} from '@polkadot/types/interfaces';
+import {GenericExtrinsic} from '@polkadot/types/extrinsic';
+import {EventRecord, SignedBlock, Extrinsic} from '@polkadot/types/interfaces';
 import {IEvent, IExtrinsic} from '@polkadot/types/types';
 
 export interface Entity {
@@ -32,13 +33,13 @@ export interface SubstrateBlock extends SignedBlock {
 export interface SubstrateExtrinsic<A extends AnyTuple = AnyTuple> {
   // index in the block
   idx: number;
-  extrinsic: IExtrinsic<A>;
+  extrinsic: GenericExtrinsic<A>;
   block: SubstrateBlock;
-  events: TypeedEventRecord<Codec[]>[];
+  events: TypedEventRecord<Codec[]>[];
   success: boolean;
 }
 
-export interface SubstrateEvent<T extends Codec[] = Codec[]> extends TypeedEventRecord<T> {
+export interface SubstrateEvent<T extends AnyTuple = AnyTuple> extends TypedEventRecord<T> {
   // index in the block
   idx: number;
   extrinsic?: SubstrateExtrinsic;
@@ -47,6 +48,6 @@ export interface SubstrateEvent<T extends Codec[] = Codec[]> extends TypeedEvent
 
 export type DynamicDatasourceCreator = (name: string, args: Record<string, unknown>) => Promise<void>;
 
-type TypeedEventRecord<T extends Codec[]> = Omit<EventRecord, 'event'> & {
+type TypedEventRecord<T extends AnyTuple> = Omit<EventRecord, 'event'> & {
   event: IEvent<T>;
 };

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -1,7 +1,9 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {Extrinsic, EventRecord, SignedBlock} from '@polkadot/types/interfaces';
+import {AnyTuple, Codec} from '@polkadot/types-codec/types';
+import {EventRecord, SignedBlock} from '@polkadot/types/interfaces';
+import {IEvent, IExtrinsic} from '@polkadot/types/types';
 
 export interface Entity {
   id: string;
@@ -27,16 +29,16 @@ export interface SubstrateBlock extends SignedBlock {
   events: EventRecord[];
 }
 
-export interface SubstrateExtrinsic {
+export interface SubstrateExtrinsic<A extends AnyTuple = AnyTuple> {
   // index in the block
   idx: number;
-  extrinsic: Extrinsic;
+  extrinsic: IExtrinsic<A>;
   block: SubstrateBlock;
-  events: EventRecord[];
+  events: TypeedEventRecord<Codec[]>[];
   success: boolean;
 }
 
-export interface SubstrateEvent extends EventRecord {
+export interface SubstrateEvent<T extends Codec[] = Codec[]> extends TypeedEventRecord<T> {
   // index in the block
   idx: number;
   extrinsic?: SubstrateExtrinsic;
@@ -44,3 +46,7 @@ export interface SubstrateEvent extends EventRecord {
 }
 
 export type DynamicDatasourceCreator = (name: string, args: Record<string, unknown>) => Promise<void>;
+
+type TypeedEventRecord<T extends Codec[]> = Omit<EventRecord, 'event'> & {
+  event: IEvent<T>;
+};

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {ApiPromise} from '@polkadot/api';
-import {RegistryTypes} from '@polkadot/types/types';
+import {AnyTuple, RegistryTypes} from '@polkadot/types/types';
 import {SubstrateBlock, SubstrateEvent, SubstrateExtrinsic} from './interfaces';
 
 export enum SubstrateDatasourceKind {
@@ -15,10 +15,10 @@ export enum SubstrateHandlerKind {
   Event = 'substrate/EventHandler',
 }
 
-export type RuntimeHandlerInputMap = {
+export type RuntimeHandlerInputMap<T extends AnyTuple = AnyTuple> = {
   [SubstrateHandlerKind.Block]: SubstrateBlock;
-  [SubstrateHandlerKind.Event]: SubstrateEvent;
-  [SubstrateHandlerKind.Call]: SubstrateExtrinsic;
+  [SubstrateHandlerKind.Event]: SubstrateEvent<T>;
+  [SubstrateHandlerKind.Call]: SubstrateExtrinsic<T>;
 };
 
 type RuntimeFilterMap = {
@@ -124,19 +124,21 @@ export interface SubstrateCustomDatasource<
 export interface HandlerInputTransformer_0_0_0<
   T extends SubstrateHandlerKind,
   E,
+  IT extends AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
 > {
-  (input: RuntimeHandlerInputMap[T], ds: DS, api: ApiPromise, assets?: Record<string, string>): Promise<E>; //  | SubstrateBuiltinDataSource
+  (input: RuntimeHandlerInputMap<IT>[T], ds: DS, api: ApiPromise, assets?: Record<string, string>): Promise<E>; //  | SubstrateBuiltinDataSource
 }
 
 export interface HandlerInputTransformer_1_0_0<
   T extends SubstrateHandlerKind,
   F,
   E,
+  IT extends AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
 > {
   (params: {
-    input: RuntimeHandlerInputMap[T];
+    input: RuntimeHandlerInputMap<IT>[T];
     ds: DS;
     filter?: F;
     api: ApiPromise;
@@ -148,19 +150,20 @@ type SecondLayerHandlerProcessorArray<
   K extends string,
   F extends SubstrateNetworkFilter,
   T,
+  IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource<K, F> = SubstrateCustomDatasource<K, F>
 > =
-  | SecondLayerHandlerProcessor<SubstrateHandlerKind.Block, F, T, DS>
-  | SecondLayerHandlerProcessor<SubstrateHandlerKind.Call, F, T, DS>
-  | SecondLayerHandlerProcessor<SubstrateHandlerKind.Event, F, T, DS>;
+  | SecondLayerHandlerProcessor<SubstrateHandlerKind.Block, F, T, IT, DS>
+  | SecondLayerHandlerProcessor<SubstrateHandlerKind.Call, F, T, IT, DS>
+  | SecondLayerHandlerProcessor<SubstrateHandlerKind.Event, F, T, IT, DS>;
 
 export interface SubstrateDatasourceProcessor<
   K extends string,
   F extends SubstrateNetworkFilter,
   DS extends SubstrateCustomDatasource<K, F> = SubstrateCustomDatasource<K, F>,
-  P extends Record<string, SecondLayerHandlerProcessorArray<K, F, any, DS>> = Record<
+  P extends Record<string, SecondLayerHandlerProcessorArray<K, F, any, any, DS>> = Record<
     string,
-    SecondLayerHandlerProcessorArray<K, F, any, DS>
+    SecondLayerHandlerProcessorArray<K, F, any, any, DS>
   >
 > {
   kind: K;
@@ -195,27 +198,30 @@ export interface SecondLayerHandlerProcessor_0_0_0<
   K extends SubstrateHandlerKind,
   F,
   E,
+  IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
 > extends SecondLayerHandlerProcessorBase<K, F, DS> {
   specVersion: undefined;
-  transformer: HandlerInputTransformer_0_0_0<K, E, DS>;
-  filterProcessor: (filter: F | undefined, input: RuntimeHandlerInputMap[K], ds: DS) => boolean;
+  transformer: HandlerInputTransformer_0_0_0<K, E, IT, DS>;
+  filterProcessor: (filter: F | undefined, input: RuntimeHandlerInputMap<IT>[K], ds: DS) => boolean;
 }
 
 export interface SecondLayerHandlerProcessor_1_0_0<
   K extends SubstrateHandlerKind,
   F,
   E,
+  IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
 > extends SecondLayerHandlerProcessorBase<K, F, DS> {
   specVersion: '1.0.0';
-  transformer: HandlerInputTransformer_1_0_0<K, F, E, DS>;
-  filterProcessor: (params: {filter: F | undefined; input: RuntimeHandlerInputMap[K]; ds: DS}) => boolean;
+  transformer: HandlerInputTransformer_1_0_0<K, F, E, IT, DS>;
+  filterProcessor: (params: {filter: F | undefined; input: RuntimeHandlerInputMap<IT>[K]; ds: DS}) => boolean;
 }
 
 export type SecondLayerHandlerProcessor<
   K extends SubstrateHandlerKind,
   F,
   E,
+  IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
-> = SecondLayerHandlerProcessor_0_0_0<K, F, E, DS> | SecondLayerHandlerProcessor_1_0_0<K, F, E, DS>;
+> = SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS> | SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS>;


### PR DESCRIPTION
# Description
Update Substrate extrinsic and event types to be generic. This allows users to specify the arguments of a transaction, the follow up to this would be codegen that builds a type based on these generic parameters

Example:
```ts

// Event
async function handleEvmLog(event: SubstrateEvent<[EvmLog]>): Promise<void> {

  // `eventData` will be of type `EvmLog` before it would have been `Codec`
  const [eventData] = original.event.data; 
}

// Call 
async function handleEvmCall(call: SubstrateExtrinsic<[TransactionV2 | EthTransaction]>): Promise<void> {

  // `tx` will be of type `TransactionV2 | EthTransaction` before it would have been `Codec`
  const [tx] = original.extrinsic.method.args;
}
```

Completes step 1 of https://github.com/subquery/subql/issues/1139

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/201
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
