### PR TITLE
Fix wrong default endpoint for cli deploy command

### DIFF
--- a/packages/cli/src/commands/deployment/deploy.ts
+++ b/packages/cli/src/commands/deployment/deploy.ts
@@ -60,7 +60,7 @@ export default class Deploy extends Command {
       if (!flags.useDefaults && !validateEndpoint) {
         endpoint = await promptWithDefaultValues(cli, 'Enter endpoint', validateEndpoint, null, true);
       } else {
-        endpoint = validateEndpoint ? validateEndpoint : validator.chainId;
+        endpoint = validateEndpoint;
       }
     }
 


### PR DESCRIPTION
# Description
The ipfs validate api returned data not have a correct endpoint, there you set chainId to the endpoint. this is wrong.

I think if not have endpoint we don't need to set it. because the indexer will be read from project.yaml.

whatever the chainId is not endpoint.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
