### PR TITLE
Allow github actions for template projects

### DIFF
--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -110,11 +110,6 @@ export async function prepare(projectPath: string, project: ProjectSpecBase): Pr
   } catch (e) {
     throw new Error('Failed to remove .git from template project');
   }
-  try {
-    await promisify(rimraf)(`${projectPath}/.github`);
-  } catch (e) {
-    throw new Error('Failed to remove .github from template project');
-  }
 }
 
 async function preparePackage(projectPath: string, project: ProjectSpecBase): Promise<void> {


### PR DESCRIPTION
# Description
Allow projects created using `subql init` to use CLI deploy workflow (on github actions)

