### PR TITLE
Fix dictionary being disabled with modulo filter

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Utilise dictionary if all block filters have `modulo` set (#1232)
+
 ## [1.6.1] - 2022-08-02
 Priority: High. Fixes 1.6.0 failed to start issue.
 ### Fixed

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -19,6 +19,7 @@ import {
   SubstrateHandler,
   SubstrateDataSource,
   SubstrateRuntimeHandlerFilter,
+  SubstrateBlockFilter,
 } from '@subql/common-substrate';
 import {
   DictionaryQueryEntry,
@@ -174,7 +175,12 @@ export class FetchService implements OnApplicationShutdown {
         if (!filterList.length) return [];
         switch (baseHandlerKind) {
           case SubstrateHandlerKind.Block:
-            return [];
+            for (const filter of filterList as SubstrateBlockFilter[]) {
+              if (filter.modulo === undefined) {
+                return [];
+              }
+            }
+            break;
           case SubstrateHandlerKind.Call: {
             for (const filter of filterList as SubstrateCallFilter[]) {
               if (filter.module !== undefined && filter.method !== undefined) {

--- a/packages/node/src/indexer/worker/block-dispatcher.service.ts
+++ b/packages/node/src/indexer/worker/block-dispatcher.service.ts
@@ -143,7 +143,11 @@ export class BlockDispatcherService
   enqueueBlocks(heights: number[]): void {
     if (!heights.length) return;
 
-    logger.info(`Enqueing blocks ${heights[0]}...${last(heights)}`);
+    logger.info(
+      `Enqueing blocks ${heights[0]}...${last(heights)}, total ${
+        heights.length
+      } blocks`,
+    );
 
     this.fetchQueue.putMany(heights);
     this.latestBufferedHeight = last(heights);


### PR DESCRIPTION
# Description
Fixes dictionary being disabled if all the block filters have a modulo filter

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
