### PR TITLE
Subql init mono

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "node-fetch": "2.6.7",
     "oclif": "^2.4.4",
     "rimraf": "^3.0.2",
-    "simple-git": "^3.1.1",
+    "simple-git": "^3.12.0",
     "ts-loader": "^9.2.6",
     "tslib": "^2.3.1",
     "webpack": "^5.68.0",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -23,8 +23,6 @@ import {
 import {ProjectSpecBase} from '../types';
 inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
 
-const RECOMMEND_VERSION = '1.0.0';
-
 // Helper function for fuzzy search on prompt input
 function filterInput(arr: string[]) {
   return (_: any, input: string) => {
@@ -98,10 +96,6 @@ export default class Init extends Command {
 
     let templates: Template[];
     let selectedTemplate: Template;
-
-    //use branch name as SpecVersion here
-    // TODO, deprecate specVersion. add back filter here  .filter(({branch}) => branch === flags.specVersion);
-    // Put starter under family->network->project
 
     templates = await fetchTemplates();
     await this.observeTemplates(templates, flags);

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -4,8 +4,9 @@
 import * as fs from 'fs';
 import os from 'os';
 import path from 'path';
+import {NETWORK_FAMILY} from '@subql/common';
 import git from 'simple-git';
-import {cloneProjectGit, prepare} from './init-controller';
+import {cloneProjectGit} from './init-controller';
 
 jest.mock('simple-git', () => {
   const mGit = {
@@ -38,8 +39,15 @@ describe('Cli can create project (mocked)', () => {
     (git().clone as jest.Mock).mockImplementationOnce((cb) => {
       cb(new Error());
     });
-    await expect(cloneProjectGit(tempPath, projectSpec.name, 'invalid_url', 'invalid_branch')).rejects.toThrow(
-      /Failed to clone starter template from git/
-    );
+    await expect(
+      cloneProjectGit(
+        tempPath,
+        projectSpec.name,
+        'invalid_url',
+        'invalid_branch',
+        NETWORK_FAMILY.substrate,
+        'invalid_network'
+      )
+    ).rejects.toThrow(/Failed to clone starter template from git/);
   });
 });

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -39,15 +39,8 @@ describe('Cli can create project (mocked)', () => {
     (git().clone as jest.Mock).mockImplementationOnce((cb) => {
       cb(new Error());
     });
-    await expect(
-      cloneProjectGit(
-        tempPath,
-        projectSpec.name,
-        'invalid_url',
-        'invalid_branch',
-        NETWORK_FAMILY.substrate,
-        'invalid_network'
-      )
-    ).rejects.toThrow(/Failed to clone starter template from git/);
+    await expect(cloneProjectGit(tempPath, projectSpec.name, 'invalid_url', 'invalid_branch')).rejects.toThrow(
+      /Failed to clone starter template from git/
+    );
   });
 });

--- a/packages/cli/src/controller/init-controller.test.ts
+++ b/packages/cli/src/controller/init-controller.test.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as fs from 'fs';
-import os from 'os';
 import path from 'path';
-import {fetchTemplates, cloneProjectGit, cloneProjectTemplate, prepare, readDefaults} from './init-controller';
+import {makeTempDir, NETWORK_FAMILY} from '@subql/common';
+import {cloneProjectGit, cloneProjectTemplate, fetchTemplates, prepare, readDefaults} from './init-controller';
 
 // async
 const fileExists = async (file: string): Promise<boolean> => {
@@ -15,12 +15,6 @@ const fileExists = async (file: string): Promise<boolean> => {
   });
 };
 
-async function makeTempDir() {
-  const sep = path.sep;
-  const tmpDir = os.tmpdir();
-  const tempPath = await fs.promises.mkdtemp(`${tmpDir}${sep}`);
-  return tempPath;
-}
 jest.setTimeout(30000);
 
 const projectSpec = {
@@ -49,7 +43,9 @@ describe('Cli can create project', () => {
       tempPath,
       projectSpec.name,
       'https://github.com/subquery/subql-starter',
-      'v0.2.0'
+      'multi',
+      NETWORK_FAMILY.substrate,
+      'Polkadot'
     );
     await prepare(projectPath, projectSpec);
     await expect(fileExists(path.join(tempPath, `${projectSpec.name}`))).resolves.toEqual(true);
@@ -78,4 +74,19 @@ describe('Cli can create project', () => {
     expect(projectSpec.description).toEqual(description);
     expect(projectSpec.license).toEqual(license);
   });
+
+  it('allow git from sub directory', async () => {
+    const tempPath = await makeTempDir();
+
+    const projectPath = await cloneProjectGit(
+      tempPath,
+      projectSpec.name,
+      'https://github.com/subquery/subql-starter',
+      'multi',
+      NETWORK_FAMILY.substrate,
+      'Polkadot'
+    );
+    // await prepare(projectPath, projectSpec);
+    // await expect(fileExists(path.join(tempPath, `${projectSpec.name}`))).resolves.toEqual(true);
+  }, 5000000);
 });

--- a/packages/cli/src/controller/init-controller.test.ts
+++ b/packages/cli/src/controller/init-controller.test.ts
@@ -3,8 +3,15 @@
 
 import * as fs from 'fs';
 import path from 'path';
-import {makeTempDir, NETWORK_FAMILY} from '@subql/common';
-import {cloneProjectGit, cloneProjectTemplate, fetchTemplates, prepare, readDefaults} from './init-controller';
+import {makeTempDir} from '@subql/common';
+import {
+  cloneProjectGit,
+  cloneProjectTemplate,
+  fetchTemplates,
+  prepare,
+  readDefaults,
+  Template,
+} from './init-controller';
 
 // async
 const fileExists = async (file: string): Promise<boolean> => {
@@ -43,9 +50,7 @@ describe('Cli can create project', () => {
       tempPath,
       projectSpec.name,
       'https://github.com/subquery/subql-starter',
-      'multi',
-      NETWORK_FAMILY.substrate,
-      'Polkadot'
+      'v1.0.0'
     );
     await prepare(projectPath, projectSpec);
     await expect(fileExists(path.join(tempPath, `${projectSpec.name}`))).resolves.toEqual(true);
@@ -62,7 +67,7 @@ describe('Cli can create project', () => {
   it('prepare correctly applies project details', async () => {
     const tempPath = await makeTempDir();
     const templates = await fetchTemplates();
-    const template = templates.find(({name, specVersion}) => name === 'subql-starter' && specVersion === '1.0.0');
+    const template = templates.find(({name}) => name === 'Polkadot-starter');
     const projectPath = await cloneProjectTemplate(tempPath, projectSpec.name, template);
     await prepare(projectPath, projectSpec);
     const [specVersion, repository, endpoint, author, version, description, license] = await readDefaults(projectPath);
@@ -78,15 +83,17 @@ describe('Cli can create project', () => {
   it('allow git from sub directory', async () => {
     const tempPath = await makeTempDir();
 
-    const projectPath = await cloneProjectGit(
-      tempPath,
-      projectSpec.name,
-      'https://github.com/subquery/subql-starter',
-      'multi',
-      NETWORK_FAMILY.substrate,
-      'Polkadot'
-    );
-    // await prepare(projectPath, projectSpec);
-    // await expect(fileExists(path.join(tempPath, `${projectSpec.name}`))).resolves.toEqual(true);
+    const template: Template = {
+      remote: 'https://github.com/subquery/subql-starter',
+      family: 'Substrate',
+      branch: 'multi',
+      network: 'Polkadot',
+      name: 'Polkadot-starter',
+      description: '',
+    };
+
+    const projectPath = await cloneProjectTemplate(tempPath, projectSpec.name, template);
+    await prepare(projectPath, projectSpec);
+    await expect(fileExists(path.join(tempPath, `${projectSpec.name}`))).resolves.toEqual(true);
   }, 5000000);
 });

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -34,31 +34,6 @@ export async function fetchTemplates(remote: string = TEMPLATES_REMOTE): Promise
     });
 }
 
-export async function cloneProjectGit2(
-  localPath: string,
-  projectName: string,
-  projectRemote: string,
-  projectBranch: string,
-  network: string,
-  template: string
-): Promise<any> {
-  const projectPath = path.join(localPath, projectName);
-  console.log(`projectPath: ${projectPath}`);
-
-  //make temp directory to store project
-  const tempPath = await makeTempDir();
-  console.log(`tempPath :${tempPath}`);
-
-  //use sparse-checkout to clone project to temp directory
-  await git(tempPath).init().addRemote('origin', 'https://github.com/subquery/subql-starter.git');
-  await git(tempPath).raw('sparse-checkout', 'set', `${network}/${template}`);
-  await git(tempPath).raw('pull', 'origin', projectBranch);
-  // Copy content to project path
-  copySync(path.join(tempPath, `${network}/${template}`), projectPath);
-  // Clean temp folder
-  fs.rmSync(tempPath, {recursive: true, force: true});
-}
-
 export async function cloneProjectGit(
   localPath: string,
   projectName: string,
@@ -98,26 +73,6 @@ export async function cloneProjectTemplate(
   fs.rmSync(tempPath, {recursive: true, force: true});
   return projectPath;
 }
-
-// export async function cloneProjectTemplate(
-//   localPath: string,
-//   projectName: string,
-//   template: Template
-// ): Promise<string> {
-//   const projectPath = path.join(localPath, projectName);
-//   try {
-//     await git().clone(template.remote, projectPath, ['-b', template.branch, '--single-branch']);
-//   } catch (e) {
-//     let err = 'Failed to clone starter template from git';
-//     try {
-//       execSync('git --version');
-//     } catch (_) {
-//       err += ', please install git and ensure that it is available from command line';
-//     }
-//     throw new Error(err);
-//   }
-//   return projectPath;
-// }
 
 export async function readDefaults(projectPath: string): Promise<string[]> {
   const packageData = await fs.promises.readFile(`${projectPath}/package.json`);

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -5,15 +5,15 @@ import childProcess, {execSync} from 'child_process';
 import fs from 'fs';
 import * as path from 'path';
 import {promisify} from 'util';
-import {ProjectManifestV0_2_0, ProjectManifestV1_0_0} from '@subql/common';
+import {makeTempDir, NETWORK_FAMILY, ProjectManifestV0_2_0, ProjectManifestV1_0_0} from '@subql/common';
 import {ProjectManifestV0_0_1} from '@subql/common-substrate';
 import axios from 'axios';
+import {copySync} from 'fs-extra';
 import yaml from 'js-yaml';
 import rimraf from 'rimraf';
 import git from 'simple-git';
 import {isProjectSpecV0_2_0, isProjectSpecV1_0_0, ProjectSpecBase} from '../types';
-
-const TEMPLATES_REMOTE = 'https://raw.githubusercontent.com/subquery/templates/main/templates.json';
+const TEMPLATES_REMOTE = 'https://raw.githubusercontent.com/subquery/templates/multi/templates.json';
 
 export interface Template {
   name: string;
@@ -21,7 +21,7 @@ export interface Template {
   remote: string;
   branch: string;
   network: string;
-  specVersion: string;
+  specVersion: string; //TODO, remove this, use branch as specVersion
   family: string;
 }
 
@@ -39,42 +39,46 @@ export async function cloneProjectGit(
   localPath: string,
   projectName: string,
   projectRemote: string,
-  branch: string
-): Promise<string> {
+  projectBranch: string,
+  family: NETWORK_FAMILY,
+  network: string
+): Promise<any> {
   const projectPath = path.join(localPath, projectName);
-  try {
-    await git().clone(projectRemote, projectPath, ['-b', branch, '--single-branch']);
-  } catch (e) {
-    let err = 'Failed to clone starter template from git';
-    try {
-      execSync('git --version');
-    } catch (_) {
-      err += ', please install git and ensure that it is available from command line';
-    }
-    throw new Error(err);
-  }
-  return projectPath;
+  console.log(`projectPath: ${projectPath}`);
+
+  //make temp directory to store project
+  const tempPath = await makeTempDir();
+  console.log(`tempPath :${tempPath}`);
+
+  //use sparse-checkout to clone project to temp directory
+  await git(tempPath).init().addRemote('origin', 'https://github.com/subquery/subql-starter.git');
+  await git(tempPath).raw('sparse-checkout', 'set', `${family}/${network}`);
+  await git(tempPath).raw('pull', 'origin', projectBranch);
+  // Copy content to project path
+  copySync(path.join(tempPath, `${family}/${network}`), projectPath);
+  // Clean temp folder
+  fs.rmSync(tempPath, {recursive: true, force: true});
 }
 
-export async function cloneProjectTemplate(
-  localPath: string,
-  projectName: string,
-  template: Template
-): Promise<string> {
-  const projectPath = path.join(localPath, projectName);
-  try {
-    await git().clone(template.remote, projectPath, ['-b', template.branch, '--single-branch']);
-  } catch (e) {
-    let err = 'Failed to clone starter template from git';
-    try {
-      execSync('git --version');
-    } catch (_) {
-      err += ', please install git and ensure that it is available from command line';
-    }
-    throw new Error(err);
-  }
-  return projectPath;
-}
+// export async function cloneProjectTemplate(
+//   localPath: string,
+//   projectName: string,
+//   template: Template
+// ): Promise<string> {
+//   const projectPath = path.join(localPath, projectName);
+//   try {
+//     await git().clone(template.remote, projectPath, ['-b', template.branch, '--single-branch']);
+//   } catch (e) {
+//     let err = 'Failed to clone starter template from git';
+//     try {
+//       execSync('git --version');
+//     } catch (_) {
+//       err += ', please install git and ensure that it is available from command line';
+//     }
+//     throw new Error(err);
+//   }
+//   return projectPath;
+// }
 
 export async function readDefaults(projectPath: string): Promise<string[]> {
   const packageData = await fs.promises.readFile(`${projectPath}/package.json`);

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {promisify} from 'util';
-import {ReaderFactory} from '@subql/common';
+import {NETWORK_FAMILY, ReaderFactory} from '@subql/common';
 import {parseSubstrateProjectManifest, ProjectManifestV1_0_0Impl} from '@subql/common-substrate';
 import {create} from 'ipfs-http-client';
 import rimraf from 'rimraf';
@@ -81,7 +81,9 @@ export async function createTestProject(projectSpec: ProjectSpecBase): Promise<s
     tmpdir,
     projectSpec.name,
     'https://github.com/subquery/subql-starter',
-    branch
+    `multi`,
+    NETWORK_FAMILY.substrate,
+    'Polkadot'
   );
   await prepare(projectPath, projectSpec);
 

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -156,18 +156,17 @@ describe('Cli publish', () => {
   });
 
   it('convert to deployment and removed descriptive field', async () => {
-    projectDir = await createTestProject(projectSpecV0_2_0);
+    projectDir = await createTestProject(projectSpecV1_0_0);
     const reader = await ReaderFactory.create(projectDir);
     const manifest = parseSubstrateProjectManifest(await reader.getProjectSchema()).asImpl;
     const deployment = manifest.toDeployment();
-    expect(deployment).not.toContain('name');
     expect(deployment).not.toContain('author');
     expect(deployment).not.toContain('endpoint');
     expect(deployment).not.toContain('dictionary');
     expect(deployment).not.toContain('description');
     expect(deployment).not.toContain('repository');
 
-    expect(deployment).toContain('genesisHash');
+    expect(deployment).toContain('chainId');
     expect(deployment).toContain('specVersion');
     expect(deployment).toContain('dataSources');
   });

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -21,7 +21,7 @@ import {
   ProjectSpecV0_2_0,
   ProjectSpecV1_0_0,
 } from '../types';
-import {cloneProjectGit, prepare} from './init-controller';
+import {cloneProjectTemplate, fetchTemplates, prepare} from './init-controller';
 import {uploadFile, uploadToIpfs} from './publish-controller';
 
 const projectSpecV0_0_1: ProjectSpecV0_0_1 = {
@@ -75,16 +75,9 @@ jest.setTimeout(150000);
 export async function createTestProject(projectSpec: ProjectSpecBase): Promise<string> {
   const tmpdir = await fs.promises.mkdtemp(`${os.tmpdir()}${path.sep}`);
   const projectDir = path.join(tmpdir, projectSpec.name);
+  const templates = await fetchTemplates();
 
-  const branch = isProjectSpecV0_0_1(projectSpec) ? 'v0.0.1' : isProjectSpecV1_0_0(projectSpec) ? 'v1.0.0' : 'v0.2.0';
-  const projectPath = await cloneProjectGit(
-    tmpdir,
-    projectSpec.name,
-    'https://github.com/subquery/subql-starter',
-    `multi`,
-    NETWORK_FAMILY.substrate,
-    'Polkadot'
-  );
+  const projectPath = await cloneProjectTemplate(tmpdir, projectSpec.name, templates[0]);
   await prepare(projectPath, projectSpec);
 
   // Install dependencies

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,6 +16,7 @@
     "axios": "^0.27.2",
     "class-transformer": "0.5.1",
     "class-validator": "^0.13.2",
+    "fs-extra": "^10.1.0",
     "ipfs-http-client": "^52.0.3",
     "js-yaml": "^4.1.0",
     "reflect-metadata": "^0.1.13",
@@ -24,6 +25,7 @@
   "devDependencies": {
     "@types/bn.js": "4.11.6",
     "@types/detect-port": "^1",
+    "@types/fs-extra": "^9.0.13",
     "@types/js-yaml": "^4.0.5",
     "@types/pino": "^6.3.12",
     "@types/semver": "^7.3.9",

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -2,10 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import {ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface} from 'class-validator';
 import detectPort from 'detect-port';
 import {prerelease, satisfies, valid, validRange} from 'semver';
+
+export async function makeTempDir(): Promise<string> {
+  const sep = path.sep;
+  const tmpDir = os.tmpdir();
+  const tempPath = await fs.promises.mkdtemp(`${tmpDir}${sep}`);
+  return tempPath;
+}
 
 export async function findAvailablePort(startPort: number, range = 10): Promise<number> {
   for (let port = startPort; port <= startPort + range; port++) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,6 +3606,7 @@ __metadata:
   dependencies:
     "@types/bn.js": 4.11.6
     "@types/detect-port": ^1
+    "@types/fs-extra": ^9.0.13
     "@types/js-yaml": ^4.0.5
     "@types/pino": ^6.3.12
     "@types/semver": ^7.3.9
@@ -3613,6 +3614,7 @@ __metadata:
     axios: ^0.27.2
     class-transformer: 0.5.1
     class-validator: ^0.13.2
+    fs-extra: ^10.1.0
     ipfs-http-client: ^52.0.3
     js-yaml: ^4.1.0
     reflect-metadata: ^0.1.13
@@ -4114,6 +4116,15 @@ __metadata:
     "@types/qs": "*"
     "@types/serve-static": "*"
   checksum: 12a2a0e6c4b993fc0854bec665906788aea0d8ee4392389d7a98a5de1eefdd33c9e1e40a91f3afd274011119c506f7b4126acb97fae62ae20b654974d44cba12
+  languageName: node
+  linkType: hard
+
+"@types/fs-extra@npm:^9.0.13":
+  version: 9.0.13
+  resolution: "@types/fs-extra@npm:9.0.13"
+  dependencies:
+    "@types/node": "*"
+  checksum: add79e212acd5ac76b97b9045834e03a7996aef60a814185e0459088fd290519a3c1620865d588fa36c4498bf614210d2a703af5cf80aa1dbc125db78f6edac3
   languageName: node
   linkType: hard
 
@@ -8709,7 +8720,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:10.1.0, fs-extra@npm:^10.0.0":
+"fs-extra@npm:10.1.0, fs-extra@npm:^10.0.0, fs-extra@npm:^10.1.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3445,7 +3445,7 @@ __metadata:
     node-fetch: 2.6.7
     oclif: ^2.4.4
     rimraf: ^3.0.2
-    simple-git: ^3.1.1
+    simple-git: ^3.12.0
     ts-loader: ^9.2.6
     tslib: ^2.3.1
     webpack: ^5.68.0
@@ -14771,14 +14771,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^3.1.1":
-  version: 3.7.1
-  resolution: "simple-git@npm:3.7.1"
+"simple-git@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "simple-git@npm:3.12.0"
   dependencies:
     "@kwsites/file-exists": ^1.1.1
     "@kwsites/promise-deferred": ^1.1.1
-    debug: ^4.3.3
-  checksum: df5361e892cadf73f0bfad2b34f3609809465c4ba1c8f3f95b2650e8a40c366c78a1a99c5e4f0eafc2acd33a85a9660d834690bb6331ef11bc1c064f526cd4a8
+    debug: ^4.3.4
+  checksum: a862851030a3f2100f33cafe68de255ba13a8ddef30cbb17a9b8d9a74cc903c7c39ab8b4afde9f6c362a9f4bb65b09989356f6c58171c190611d3916a4802a1e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Wait to merge once subql-starter monorepo ready

Update `subql init ` command to work together with new subql starter and templates.

We will create starter repo for different network family , then under the repo : network -> starter templates 

eg Substrate project  fetch templates from `multi` (will move to main) branch on subql starter https://github.com/subquery/subql-starter/tree/multi/Polkadot/Polkadot-starter

It current lookup from `templates` json file https://github.com/subquery/templates/blob/multi/templates.json

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Internal change
## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
