### PR TITLE
Fix Query service with historical + aggregates enabled

### DIFF
--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -18,7 +18,7 @@ import {makePluginHook} from 'postgraphile';
 import {getPostGraphileBuilder, PostGraphileCoreOptions} from 'postgraphile-core';
 import {SubscriptionServer} from 'subscriptions-transport-ws';
 import {Config} from '../configure';
-import {PinoConfig} from '../utils/logger';
+import {getLogger, PinoConfig} from '../utils/logger';
 import {getYargsOption} from '../yargs';
 import {plugins} from './plugins';
 import {PgSubscriptionPlugin} from './plugins/PgSubscriptionPlugin';
@@ -26,6 +26,8 @@ import {queryComplexityPlugin} from './plugins/QueryComplexityPlugin';
 import {ProjectService} from './project.service';
 
 const {argv} = getYargsOption();
+const logger = getLogger('graphql-module');
+
 const SCHEMA_RETRY_INTERVAL = 10; //seconds
 const SCHEMA_RETRY_NUMBER = 5;
 @Module({
@@ -68,6 +70,9 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
         return graphqlSchema;
       } catch (e) {
         await delay(SCHEMA_RETRY_INTERVAL);
+        if (retries === 1) {
+          logger.error(e);
+        }
         return this.buildSchema(dbSchema, options, --retries);
       }
     } else {

--- a/packages/query/src/graphql/plugins/PgAggregationPlugin.ts
+++ b/packages/query/src/graphql/plugins/PgAggregationPlugin.ts
@@ -11,12 +11,11 @@ import AggregateSpecsPlugin from '@graphile/pg-aggregates/dist/AggregateSpecsPlu
 import FilterRelationalAggregatesPlugin from '@graphile/pg-aggregates/dist/FilterRelationalAggregatesPlugin';
 import InflectionPlugin from '@graphile/pg-aggregates/dist/InflectionPlugin';
 import {AggregateSpec, AggregateGroupBySpec} from '@graphile/pg-aggregates/dist/interfaces';
-import OrderByAggregatesPlugin from '@graphile/pg-aggregates/dist/OrderByAggregatesPlugin';
 
 import type {Plugin} from 'graphile-build';
 import {makePluginByCombiningPlugins} from 'graphile-utils';
-
 import {argv} from '../../yargs';
+import OrderByAggregatesPlugin from './PgOrderByAggregatesPlugin';
 
 const aggregate = argv('aggregate') as boolean;
 

--- a/packages/query/src/graphql/plugins/PgOrderByAggregatesPlugin.ts
+++ b/packages/query/src/graphql/plugins/PgOrderByAggregatesPlugin.ts
@@ -1,0 +1,167 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* WARNING
+ * This is a fork of https://github.com/graphile/pg-aggregates/blob/c8dd0f951663d5dacde21da26f3b94b62dc296c5/src/OrderByAggregatesPlugin.ts
+ * The only modification is to filter out `_id` and `_block_height` attributes to fix a naming conflict
+ */
+
+import {AggregateSpec} from '@graphile/pg-aggregates/dist/interfaces';
+import type {Plugin} from 'graphile-build';
+import type {SQL, QueryBuilder, PgClass, PgEntity} from 'graphile-build-pg';
+
+type OrderBySpecIdentity = string | SQL | ((options: {queryBuilder: QueryBuilder}) => SQL);
+
+type OrderSpec = [OrderBySpecIdentity, boolean] | [OrderBySpecIdentity, boolean, boolean];
+export interface OrderSpecs {
+  [orderByEnumValue: string]: {
+    value: {
+      alias?: string;
+      specs: Array<OrderSpec>;
+      unique: boolean;
+    };
+  };
+}
+
+const OrderByAggregatesPlugin: Plugin = (builder) => {
+  builder.hook('GraphQLEnumType:values', (values, build, context) => {
+    const {
+      extend,
+      inflection,
+      pgIntrospectionResultsByKind: introspectionResultsByKind,
+      pgOmit: omit,
+      pgSql: sql,
+    } = build;
+    const pgAggregateSpecs: AggregateSpec[] = build.pgAggregateSpecs;
+    const {
+      scope: {isPgRowSortEnum},
+    } = context;
+
+    const pgIntrospection: PgEntity | undefined = context.scope.pgIntrospection;
+
+    if (!isPgRowSortEnum || !pgIntrospection || pgIntrospection.kind !== 'class') {
+      return values;
+    }
+
+    const foreignTable: PgClass = pgIntrospection;
+
+    const foreignKeyConstraints = foreignTable.foreignConstraints.filter((con) => con.type === 'f');
+
+    const newValues = foreignKeyConstraints.reduce((memo, constraint) => {
+      if (omit(constraint, 'read')) {
+        return memo;
+      }
+      const table: PgClass | undefined = introspectionResultsByKind.classById[constraint.classId];
+      if (!table) {
+        throw new Error(`Could not find the table that referenced us (constraint: ${constraint.name})`);
+      }
+      const keys = constraint.keyAttributes;
+      const foreignKeys = constraint.foreignKeyAttributes;
+      if (!keys.every((_) => _) || !foreignKeys.every((_) => _)) {
+        throw new Error('Could not find key columns!');
+      }
+      if (keys.some((key) => omit(key, 'read'))) {
+        return memo;
+      }
+      if (foreignKeys.some((key) => omit(key, 'read'))) {
+        return memo;
+      }
+      const isUnique = !!table.constraints.find(
+        (c) =>
+          (c.type === 'p' || c.type === 'u') &&
+          c.keyAttributeNums.length === keys.length &&
+          c.keyAttributeNums.every((n, i) => keys[i].num === n)
+      );
+      if (isUnique) {
+        // No point aggregating over a relation that's unique
+        return memo;
+      }
+
+      const tableAlias = sql.identifier(Symbol(`${foreignTable.namespaceName}.${foreignTable.name}`));
+
+      // Add count
+      memo = build.extend(
+        memo,
+        orderByAscDesc(
+          inflection.orderByCountOfManyRelationByKeys(keys, table, foreignTable, constraint),
+          ({queryBuilder}) => {
+            const foreignTableAlias = queryBuilder.getTableAlias();
+            const conditions: SQL[] = [];
+            keys.forEach((key, i) => {
+              conditions.push(
+                sql.fragment`${tableAlias}.${sql.identifier(key.name)} = ${foreignTableAlias}.${sql.identifier(
+                  foreignKeys[i].name
+                )}`
+              );
+            });
+            return sql.fragment`(select count(*) from ${sql.identifier(
+              table.namespaceName,
+              table.name
+            )} ${tableAlias} where (${sql.join(conditions, ' AND ')}))`;
+          },
+          false
+        ),
+        `Adding orderBy count to '${foreignTable.namespaceName}.${foreignTable.name}' using constraint '${constraint.name}'`
+      );
+
+      // Filter out attributes relating to historical. This was causing conflicts with `id` and `_id`
+      const attributes = table.attributes.filter((attr) => attr.name !== '_id' && attr.name !== '_block_height');
+
+      // Add other aggregates
+      pgAggregateSpecs.forEach((spec) => {
+        attributes.forEach((attr) => {
+          memo = build.extend(
+            memo,
+            orderByAscDesc(
+              inflection.orderByColumnAggregateOfManyRelationByKeys(keys, table, foreignTable, constraint, spec, attr),
+              ({queryBuilder}) => {
+                const foreignTableAlias = queryBuilder.getTableAlias();
+                const conditions: SQL[] = [];
+                keys.forEach((key, i) => {
+                  conditions.push(
+                    sql.fragment`${tableAlias}.${sql.identifier(key.name)} = ${foreignTableAlias}.${sql.identifier(
+                      foreignKeys[i].name
+                    )}`
+                  );
+                });
+                return sql.fragment`(select ${spec.sqlAggregateWrap(
+                  sql.fragment`${tableAlias}.${sql.identifier(attr.name)}`
+                )} from ${sql.identifier(table.namespaceName, table.name)} ${tableAlias} where (${sql.join(
+                  conditions,
+                  ' AND '
+                )}))`;
+              },
+              false
+            ),
+            `Adding orderBy ${spec.id} of '${attr.name}' to '${foreignTable.namespaceName}.${foreignTable.name}' using constraint '${constraint.name}'`
+          );
+        });
+      });
+
+      return memo;
+    }, {} as OrderSpecs);
+
+    return extend(values, newValues, `Adding aggregate orders to '${foreignTable.namespaceName}.${foreignTable.name}'`);
+  });
+};
+
+export function orderByAscDesc(baseName: string, columnOrSqlFragment: OrderBySpecIdentity, unique = false): OrderSpecs {
+  return {
+    [`${baseName}_ASC`]: {
+      value: {
+        alias: `${baseName}_ASC`,
+        specs: [[columnOrSqlFragment, true]],
+        unique,
+      },
+    },
+    [`${baseName}_DESC`]: {
+      value: {
+        alias: `${baseName}_DESC`,
+        specs: [[columnOrSqlFragment, false]],
+        unique,
+      },
+    },
+  };
+}
+
+export default OrderByAggregatesPlugin;


### PR DESCRIPTION
# Description
With historical enabled all tables have an additional column `_id` this would cause a naming conflict with `id`. This PR forks the `OrderByAggregatesPlugin` and modifies it to filter out the `_id` column. This was the easiest solution without introducing a breaking change such as renaming the `_id` column to something else that didn't cause conflicts.

Also for development purposes, I have added logging for the internal error.

Example of error:
```
ERROR A naming conflict has occurred - two entities have tried to define the same key 'DELEGATIONS_SUM_ID_ASC'.

  The first entity was:

    Adding orderBy sum of 'id' to 'app.delegators' using constraint 'FAKE_app_delegations_foreignKey_1'

  The second entity was:

    Adding orderBy sum of '_id' to 'app.delegators' using constraint 'FAKE_app_delegations_foreignKey_1'
/Users/scotttwiname/Projects/subql/packages/query/src/graphql/graphql.module.ts:54
      throw new Error(`create apollo server failed, ${e.message}`);
            ^
Error: create apollo server failed, Failed to build schema app 5 times
    at GraphqlModule.onModuleInit (/Users/scotttwiname/Projects/subql/packages/query/src/graphql/graphql.module.ts:54:13)
    at async callModuleInitHook (/Users/scotttwiname/Projects/subql/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
    at async NestApplication.callInitHook (/Users/scotttwiname/Projects/subql/node_modules/@nestjs/core/nest-application-context.js:178:13)
    at async NestApplication.init (/Users/scotttwiname/Projects/subql/node_modules/@nestjs/core/nest-application.js:96:9)
    at async NestApplication.listen (/Users/scotttwiname/Projects/subql/node_modules/@nestjs/core/nest-application.js:158:33)
    at async /Users/scotttwiname/Projects/subql/packages/query/src/main.ts:37:3
```
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
