### PR TITLE
Fix running custom ds processors in parallel on different data

### DIFF
--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -380,9 +380,11 @@ export class IndexerManager {
         throw e;
       });
 
-    await Promise.all(
-      transformedData.map((data) => vm.securedExec(handler.handler, [data])),
-    );
+    // We can not run this in parallel. the transformed data items may be dependent on one another.
+    // An example of this is with Acala EVM packing multiple EVM logs into a single Substrate event
+    for (const _data of transformedData) {
+      await vm.securedExec(handler.handler, [_data]);
+    }
   }
 }
 


### PR DESCRIPTION
# Description
With custom ds processors handlers could be run in parallel on different data, in certain scenarios this could cause race conditions. We now run the handlers sequentially

Example of the error:
```
ERROR failed to index block at height 1408360 handleRewardsUpdated(Error: Failed to set Entity Indexer with _id 0x6971c53e0d1c4Bb4Fd507A377C97B456eDEAb6D2: SequelizeExclusionConstraintError: Exclusion constraint error
    at Object.set (/Users/scotttwiname/Projects/subql/packages/node/src/indexer/store.service.ts:746:17)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)) Error: Failed to set Entity Indexer with _id 0x6971c53e0d1c4Bb4Fd507A377C97B456eDEAb6D2: SequelizeExclusionConstraintError: Exclusion constraint error
/Users/scotttwiname/Projects/subql/packages/node/src/indexer/store.service.ts:746
          throw new Error(
                ^
Error: Failed to set Entity Indexer with _id 0x6971c53e0d1c4Bb4Fd507A377C97B456eDEAb6D2: SequelizeExclusionConstraintError: Exclusion constraint error
    at Object.set (/Users/scotttwiname/Projects/subql/packages/node/src/indexer/store.service.ts:746:17)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  handler: 'handleRewardsUpdated'
}
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
