### PR TITLE
support bulkGet and add bulkUpdate 

### DIFF
--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -634,32 +634,6 @@ group by
     }
   }
 
-  private async updateHistorical(
-    model: ModelCtor<Model>,
-    data: Entity,
-    attributes: CreationAttributes<Model>,
-  ) {
-    const [updatedRows] = await model.update(attributes, {
-      hooks: false,
-      transaction: this.tx,
-      where: this.sequelize.and(
-        { id: data.id },
-        this.sequelize.where(
-          this.sequelize.fn('lower', this.sequelize.col('_block_range')),
-          this.blockHeight,
-        ),
-      ),
-    });
-    if (updatedRows < 1) {
-      // TODO, can be improved here if called from BulkUpdate
-      // We can collect entities meet this conditions, use promise.all and bulkCreate here
-      await this.markAsDeleted(model, data.id);
-      await model.create(attributes, {
-        transaction: this.tx,
-      });
-    }
-  }
-
   getStore(): Store {
     return {
       get: async (entity: string, id: string): Promise<Entity | undefined> => {
@@ -741,8 +715,26 @@ group by
           assert(model, `model ${entity} not exists`);
           const attributes = data as unknown as CreationAttributes<Model>;
           if (this.historical) {
-            // If entity was already saved in current block, update that entity instead
-            await this.updateHistorical(model, data, attributes);
+            const [updatedRows] = await model.update(attributes, {
+              hooks: false,
+              transaction: this.tx,
+              where: this.sequelize.and(
+                { id: data.id },
+                this.sequelize.where(
+                  this.sequelize.fn(
+                    'lower',
+                    this.sequelize.col('_block_range'),
+                  ),
+                  this.blockHeight,
+                ),
+              ),
+            });
+            if (updatedRows < 1) {
+              await this.markAsDeleted(model, data.id);
+              await model.create(attributes, {
+                transaction: this.tx,
+              });
+            }
           } else {
             await model.upsert(attributes, {
               transaction: this.tx,
@@ -791,13 +783,36 @@ group by
                 `Update specified fields with historical feature is not supported`,
               );
             }
+            const newRecordAttributes: CreationAttributes<Model>[] = [];
             await Promise.all(
               data.map(async (record) => {
                 const attributes =
                   record as unknown as CreationAttributes<Model>;
-                await this.updateHistorical(model, record, attributes);
+                const [updatedRows] = await model.update(attributes, {
+                  hooks: false,
+                  transaction: this.tx,
+                  where: this.sequelize.and(
+                    { id: record.id },
+                    this.sequelize.where(
+                      this.sequelize.fn(
+                        'lower',
+                        this.sequelize.col('_block_range'),
+                      ),
+                      this.blockHeight,
+                    ),
+                  ),
+                });
+                if (updatedRows < 1) {
+                  await this.markAsDeleted(model, record.id);
+                  newRecordAttributes.push(attributes);
+                }
               }),
             );
+            if (newRecordAttributes.length !== 0) {
+              await model.bulkCreate(newRecordAttributes, {
+                transaction: this.tx,
+              });
+            }
           } else {
             const modelFields =
               fields ??

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -823,7 +823,6 @@ group by
               data as unknown as CreationAttributes<Model>[],
               {
                 transaction: this.tx,
-                ignoreDuplicates: true,
                 updateOnDuplicate: modelFields,
               },
             );

--- a/packages/node/src/indexer/store.service.ts
+++ b/packages/node/src/indexer/store.service.ts
@@ -776,12 +776,12 @@ group by
       ): Promise<void> => {
         try {
           const model = this.sequelize.model(entity);
+          assert(model, `model ${entity} not exists`);
           const modelFields =
             fields ??
             Object.keys(model.getAttributes()).filter(
               (item) => !KEY_FIELDS.includes(item),
             );
-          assert(model, `model ${entity} not exists`);
           await model.bulkCreate(
             data as unknown as CreationAttributes<Model>[],
             {

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -20,6 +20,8 @@ export interface Store {
   getOneByField(entity: string, field: string, value: any): Promise<Entity | null>;
   set(entity: string, id: string, data: Entity): Promise<void>;
   bulkCreate(entity: string, data: Entity[]): Promise<void>;
+  //if fields in provided, only specify fields will be updated
+  bulkUpdate(entity: string, data: Entity[], fields?: string[]): Promise<void>;
   remove(entity: string, id: string): Promise<void>;
 }
 


### PR DESCRIPTION
# Description

Fixes #1237 

**bulkGet:** 

We currently already support bulkGet method , you can use  `getByField` and pass 3rd parameter as an array.
```
const starterEntites = await store.getByField('StarterEntity','field1',[50,100,150])
```
This will returns entities `field1` equal to 50, 100 and 150.

**bulkCreate:** 

Add bulkUpdate method, allow user to update multiple entities in single call. 
```
starterEntites[0]['field2']= 'Apple'
starterEntites[1]['field2']= 'Lemon'
starterEntites[2]['field2']= 'Orange
await store.bulkUpdate('StarterEntity',starterEntites)
```
This will update all starterEntities and its fields with updated field2.

You can also specify which filed you want to update, by :

```
// If field5 has changed
starterEntites[0]['field5']= false

// This won't update field5, only will update field2. 
await store.bulkUpdate('StarterEntity',starterEntites,['field2'])
```

Follow up: **BulkUpdate with Historical is supported** 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
