### PR TITLE
Fix bigInt array entity being treated as a big int

### DIFF
--- a/packages/node/src/utils/graphql.ts
+++ b/packages/node/src/utils/graphql.ts
@@ -33,10 +33,20 @@ export function modelsTypeToModelAttributes(
     if (field.type === 'BigInt') {
       columnOption.get = function () {
         const dataValue = this.getDataValue(field.name);
+        if (field.isArray) {
+          return dataValue ? dataValue.map((v) => BigInt(v)) : null;
+        }
         return dataValue ? BigInt(dataValue) : null;
       };
       columnOption.set = function (val: unknown) {
-        this.setDataValue(field.name, val?.toString());
+        if (field.isArray) {
+          this.setDataValue(
+            field.name,
+            (val as unknown[])?.map((v) => v.toString()),
+          );
+        } else {
+          this.setDataValue(field.name, val?.toString());
+        }
       };
     }
     if (field.type === 'Bytes') {


### PR DESCRIPTION
# Description
Fixes BigInt array being encoded as a BigInt so that it couldn't be decoded when getting the entity

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
