### PR TITLE
Add limit and offset options to store.getByField

### DIFF
--- a/packages/node-core/src/yargs.ts
+++ b/packages/node-core/src/yargs.ts
@@ -161,6 +161,12 @@ export function getYargsOption() {
       describe: 'Number of worker threads to use for fetching and processing blocks. Disabled by default.',
       type: 'number',
     },
+    'query-limit': {
+      demandOption: false,
+      describe: 'The limit of items a project can query with store.getByField at once',
+      type: 'number',
+      default: 100,
+    },
   });
 }
 

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -3,7 +3,7 @@
 
 import {AnyTuple, Codec} from '@polkadot/types-codec/types';
 import {GenericExtrinsic} from '@polkadot/types/extrinsic';
-import {EventRecord, SignedBlock, Extrinsic} from '@polkadot/types/interfaces';
+import {EventRecord, SignedBlock} from '@polkadot/types/interfaces';
 import {IEvent} from '@polkadot/types/types';
 
 export interface Entity {
@@ -15,9 +15,14 @@ export type FunctionPropertyNames<T> = {
 }[keyof T];
 
 export interface Store {
-  get(entity: string, id: string): Promise<Entity | null>;
-  getByField(entity: string, field: string, value: any): Promise<Entity[]>;
-  getOneByField(entity: string, field: string, value: any): Promise<Entity | null>;
+  get<T extends Entity>(entity: string, id: string): Promise<T | null>;
+  getByField<T extends Entity>(
+    entity: string,
+    field: keyof T,
+    value: T[keyof T] | T[keyof T][],
+    options?: {offset?: number; limit?: number}
+  ): Promise<T[]>;
+  getOneByField<T extends Entity>(entity: string, field: keyof T, value: T[keyof T]): Promise<T | null>;
   set(entity: string, id: string, data: Entity): Promise<void>;
   bulkCreate(entity: string, data: Entity[]): Promise<void>;
   //if fields in provided, only specify fields will be updated

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -15,14 +15,9 @@ export type FunctionPropertyNames<T> = {
 }[keyof T];
 
 export interface Store {
-  get<T extends Entity>(entity: string, id: string): Promise<T | null>;
-  getByField<T extends Entity>(
-    entity: string,
-    field: keyof T,
-    value: T[keyof T] | T[keyof T][],
-    options?: {offset?: number; limit?: number}
-  ): Promise<T[]>;
-  getOneByField<T extends Entity>(entity: string, field: keyof T, value: T[keyof T]): Promise<T | null>;
+  get(entity: string, id: string): Promise<Entity | null>;
+  getByField(entity: string, field: string, value: any, options?: {offset?: number; limit?: number}): Promise<Entity[]>;
+  getOneByField(entity: string, field: string, value: any): Promise<Entity | null>;
   set(entity: string, id: string, data: Entity): Promise<void>;
   bulkCreate(entity: string, data: Entity[]): Promise<void>;
   //if fields in provided, only specify fields will be updated


### PR DESCRIPTION
# Description
* Add the option for limit and offset to store.getByField
* The option to set the default limit via new cli flag `query-limit`

Fixes https://github.com/subquery/subql/issues/1258

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
