### PR TITLE
fix missing async handler filter

### DIFF
--- a/packages/node/src/utils/project.ts
+++ b/packages/node/src/utils/project.ts
@@ -299,3 +299,9 @@ export function loadChainTypesFromJs(
   }
   return rawContent;
 }
+
+export const asyncFilter = async (arr, predicate) => {
+  const results = await Promise.all(arr.map(predicate));
+
+  return arr.filter((_v, index) => results[index]);
+};


### PR DESCRIPTION
# Description

Due to wasm filter need async load asset, the filter handler process will also need to await `filterProcessor` get ready first.
Temp solution we will add asyncFilter. 

We will find better approach to allow import asset from node side and store in processor memory later.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
