### PR TITLE
change dictionary to use equalToInsensitive

### DIFF
--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -67,14 +67,16 @@ function extractVars(
         and: i.map((j, innerIdx) => {
           const v = extractVar(`${entity}_${outerIdx}_${innerIdx}`, j);
           gqlVars.push(v);
-          return { [sanitizeArgField(j.field)]: { equalTo: `$${v.name}` } };
+          return {
+            [sanitizeArgField(j.field)]: { equalToInsensitive: `$${v.name}` },
+          };
         }),
       };
     } else if (i.length === 1) {
       const v = extractVar(`${entity}_${outerIdx}_0`, i[0]);
       gqlVars.push(v);
       filter.or[outerIdx] = {
-        [sanitizeArgField(i[0].field)]: { equalTo: `$${v.name}` },
+        [sanitizeArgField(i[0].field)]: { equalToInsensitive: `$${v.name}` },
       };
     }
   });

--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -68,6 +68,8 @@ function extractVars(
           const v = extractVar(`${entity}_${outerIdx}_${innerIdx}`, j);
           gqlVars.push(v);
           return {
+            // Use case insensitive here due to go-dictionary generate name is in lower cases
+            // Origin dictionary still using camelCase
             [sanitizeArgField(j.field)]: { equalToInsensitive: `$${v.name}` },
           };
         }),


### PR DESCRIPTION
# Description

Make dictionary model/event/method case insensitive

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
