### PR TITLE
fix publish failed due to file object is null

### DIFF
--- a/packages/cli/src/controller/publish-controller.ts
+++ b/packages/cli/src/controller/publish-controller.ts
@@ -79,7 +79,7 @@ async function replaceFileReferences<T>(
     return (await Promise.all(
       input.map((val) => replaceFileReferences(projectDir, val, authToken, ipfs))
     )) as unknown as T;
-  } else if (typeof input === 'object') {
+  } else if (typeof input === 'object' && input !== null) {
     if (input instanceof Map) {
       input = mapToObject(input) as T;
     }
@@ -165,7 +165,7 @@ function mapToObject(map: Map<string | number, unknown>): Record<string | number
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isFileReference(value: any): value is FileReference {
-  return value.file && typeof value.file === 'string';
+  return value?.file && typeof value.file === 'string';
 }
 
 interface ClusterResponseData {


### PR DESCRIPTION
# Description

Fixes the issue when publish file object and failed to check if the object is `null`, this can happen in evm topics:

```
            topics:
              - 'Transfer(address indexed from,address indexed to,uint256 value)'
              - null
              - null
              - null
```


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
