### PR TITLE
Back port changes in algorand sdk to dictionary service

### DIFF
--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -28,9 +28,27 @@ export type SpecVersionDictionary = {
 const logger = getLogger('dictionary');
 
 function extractVar(name: string, cond: DictionaryQueryCondition): GqlVar {
+  let gqlType: string;
+  switch (typeof cond.value) {
+    case 'number':
+      gqlType = 'BigFloat!';
+      break;
+    case 'boolean':
+      gqlType = 'Boolean!';
+      break;
+    default:
+    case 'string':
+      gqlType = 'String!';
+      break;
+  }
+
+  if (cond.matcher === 'contains') {
+    gqlType = 'JSON';
+  }
+
   return {
     name,
-    gqlType: cond.matcher === 'contains' ? 'JSON' : 'String!',
+    gqlType,
     value: cond.value,
   };
 }


### PR DESCRIPTION
# Description
Ports these changes from avalanche sdk to maintain compatibility with node core.

https://github.com/subquery/subql-algorand/blob/main/packages/node/src/indexer/dictionary.service.ts#L48-L62
