### PR TITLE
fix output-format flag on node

### DIFF
--- a/packages/node/src/indexer/worker/worker.ts
+++ b/packages/node/src/indexer/worker/worker.ts
@@ -12,7 +12,7 @@ const { argv } = yargsOptions;
 
 initLogger(
   argv.debug,
-  argv.outputFormat as 'json' | 'colored',
+  argv.outputFmt as 'json' | 'colored',
   argv.logLevel as string | undefined,
 );
 

--- a/packages/node/src/main.ts
+++ b/packages/node/src/main.ts
@@ -9,7 +9,7 @@ const { argv } = yargsOptions;
 // initLogger is imported from true path, to make sure getLogger (or other logger values that relies on logger) isn't initialised
 initLogger(
   argv.debug,
-  argv.outputFormat as 'json' | 'colored',
+  argv.outputFmt as 'json' | 'colored',
   argv.logLevel as string | undefined,
 );
 

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -14,7 +14,7 @@ export const yargsOptions = yargs(hideBin(process.argv))
     handler: (argv) => {
       initLogger(
         argv.debug as boolean,
-        argv.outputFormat as 'json' | 'colored',
+        argv.outputFmt as 'json' | 'colored',
         argv.logLevel as string | undefined,
       );
 
@@ -37,7 +37,7 @@ export const yargsOptions = yargs(hideBin(process.argv))
     handler: (argv) => {
       initLogger(
         argv.debug as boolean,
-        argv.outputFormat as 'json' | 'colored',
+        argv.outputFmt as 'json' | 'colored',
         argv.logLevel as string | undefined,
       );
       // lazy import to make sure logger is instantiated before all other services


### PR DESCRIPTION
# Description
Fix typo in `output-fmt` flag

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist

- [x] I have tested locally
- [x] My code is up to date with the base branch
