### PR TITLE
add dedicate data base flag for create project

### DIFF
--- a/packages/cli/src/commands/project/create-project.ts
+++ b/packages/cli/src/commands/project/create-project.ts
@@ -21,7 +21,7 @@ export default class Create_project extends Command {
     subtitle: Flags.string({description: 'Enter subtitle', default: '', required: false}),
     description: Flags.string({description: 'Enter description', default: '', required: false}),
     apiVersion: Flags.string({description: 'Enter api version', default: '2', required: false}),
-    dedicateDB: Flags.string({description: 'Enter dedicate DataBase', required: false}),
+    dedicatedDB: Flags.string({description: 'Enter dedicated DataBase', required: false}),
   };
 
   async run(): Promise<void> {
@@ -43,7 +43,7 @@ export default class Create_project extends Command {
       gitRepo,
       flags.description,
       flags.apiVersion,
-      flags.dedicateDB,
+      flags.dedicatedDB,
       ROOT_API_URL_PROD
     ).catch((e) => this.error(e));
 

--- a/packages/cli/src/commands/project/create-project.ts
+++ b/packages/cli/src/commands/project/create-project.ts
@@ -21,6 +21,7 @@ export default class Create_project extends Command {
     subtitle: Flags.string({description: 'Enter subtitle', default: '', required: false}),
     description: Flags.string({description: 'Enter description', default: '', required: false}),
     apiVersion: Flags.string({description: 'Enter api version', default: '2', required: false}),
+    dedicateDB: Flags.string({description: 'Enter dedicate DataBase', required: false}),
   };
 
   async run(): Promise<void> {
@@ -42,6 +43,7 @@ export default class Create_project extends Command {
       gitRepo,
       flags.description,
       flags.apiVersion,
+      flags.dedicateDB,
       ROOT_API_URL_PROD
     ).catch((e) => this.error(e));
 

--- a/packages/cli/src/controller/project-controller.ts
+++ b/packages/cli/src/controller/project-controller.ts
@@ -22,6 +22,7 @@ export async function createProject(
   gitRepository: string,
   description: string,
   apiVersion: string,
+  dedicateDB: string | undefined,
   url: string
 ): Promise<createProjectType> {
   try {
@@ -41,6 +42,7 @@ export async function createProject(
           logoUrl: logoUrl,
           name: project_name,
           subtitle: subtitle,
+          dedicateDBKey: dedicateDB,
         },
       })
     ).data;


### PR DESCRIPTION
# Description
allow user can add dedicated db when using create project command
Fixes #1353 

## Type of change


- [ ] New feature (non-breaking change which adds functionality)


## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
