### PR TITLE
Fix template issues

### DIFF
--- a/packages/node/src/indexer/dynamic-ds.service.ts
+++ b/packages/node/src/indexer/dynamic-ds.service.ts
@@ -8,11 +8,12 @@ import { getLogger, MetadataRepo } from '@subql/node-core';
 import { Transaction } from 'sequelize/types';
 import { SubqlProjectDs, SubqueryProject } from '../configure/SubqueryProject';
 import { DsProcessorService } from './ds-processor.service';
-import _ from 'lodash';
+import { cloneDeep } from 'lodash';
 
 const logger = getLogger('dynamic-ds');
 
 const METADATA_KEY = 'dynamicDatasources';
+const TEMP_DS_PREFIX = 'ds_';
 
 interface DatasourceParams {
   templateName: string;
@@ -23,6 +24,7 @@ interface DatasourceParams {
 @Injectable()
 export class DynamicDsService {
   private metaDataRepo: MetadataRepo;
+  private tempDsRecords: Record<string, string>;
 
   constructor(
     private readonly dsProcessorService: DsProcessorService,
@@ -75,13 +77,26 @@ export class DynamicDsService {
     return this._datasources;
   }
 
-  private async getDynamicDatasourceParams(): Promise<DatasourceParams[]> {
+  deleteTempDsRecords(blockHeight: number) {
+    delete this.tempDsRecords[TEMP_DS_PREFIX + blockHeight];
+  }
+
+  private async getDynamicDatasourceParams(
+    blockHeight?: number,
+  ): Promise<DatasourceParams[]> {
     assert(this.metaDataRepo, `Model _metadata does not exist`);
     const record = await this.metaDataRepo.findByPk(METADATA_KEY);
-    const results = record?.value;
+    let results = record?.value;
 
     if (!results || typeof results !== 'string') {
-      return [];
+      if (blockHeight !== undefined) {
+        results = this.tempDsRecords?.[TEMP_DS_PREFIX + blockHeight];
+        if (!results || typeof results !== 'string') {
+          return [];
+        }
+      } else {
+        return [];
+      }
     }
 
     return JSON.parse(results);
@@ -91,20 +106,26 @@ export class DynamicDsService {
     dsParams: DatasourceParams,
     tx: Transaction,
   ): Promise<void> {
-    const existing = await this.getDynamicDatasourceParams();
+    const existing = await this.getDynamicDatasourceParams(dsParams.startBlock);
 
     assert(this.metaDataRepo, `Model _metadata does not exist`);
-    await this.metaDataRepo.upsert(
-      { key: METADATA_KEY, value: JSON.stringify([...existing, dsParams]) }
-    );
+    const dsRecords = JSON.stringify([...existing, dsParams]);
+    await this.metaDataRepo
+      .upsert({ key: METADATA_KEY, value: dsRecords }, { transaction: tx })
+      .then(() => {
+        this.tempDsRecords = {
+          ...this.tempDsRecords,
+          ...{ [TEMP_DS_PREFIX + dsParams.startBlock]: dsRecords },
+        };
+      });
   }
 
   private async getDatasource(
     params: DatasourceParams,
   ): Promise<SubqlProjectDs> {
-    const template = _.cloneDeep(this.project.templates.find(
-      (t) => t.name === params.templateName,
-    ));
+    const template = cloneDeep(
+      this.project.templates.find((t) => t.name === params.templateName),
+    );
 
     if (!template) {
       throw new Error(

--- a/packages/node/src/indexer/dynamic-ds.service.ts
+++ b/packages/node/src/indexer/dynamic-ds.service.ts
@@ -8,6 +8,7 @@ import { getLogger, MetadataRepo } from '@subql/node-core';
 import { Transaction } from 'sequelize/types';
 import { SubqlProjectDs, SubqueryProject } from '../configure/SubqueryProject';
 import { DsProcessorService } from './ds-processor.service';
+import _ from 'lodash';
 
 const logger = getLogger('dynamic-ds');
 
@@ -94,17 +95,16 @@ export class DynamicDsService {
 
     assert(this.metaDataRepo, `Model _metadata does not exist`);
     await this.metaDataRepo.upsert(
-      { key: METADATA_KEY, value: JSON.stringify([...existing, dsParams]) },
-      { transaction: tx },
+      { key: METADATA_KEY, value: JSON.stringify([...existing, dsParams]) }
     );
   }
 
   private async getDatasource(
     params: DatasourceParams,
   ): Promise<SubqlProjectDs> {
-    const template = this.project.templates.find(
+    const template = _.cloneDeep(this.project.templates.find(
       (t) => t.name === params.templateName,
-    );
+    ));
 
     if (!template) {
       throw new Error(

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -574,6 +574,7 @@ export class FetchService implements OnApplicationShutdown {
 
   async resetForNewDs(blockHeight: number): Promise<void> {
     await this.syncDynamicDatascourcesFromMeta();
+    this.dynamicDsService.deleteTempDsRecords(blockHeight);
     this.updateDictionary();
     this.blockDispatcher.flushQueue(blockHeight);
   }


### PR DESCRIPTION
# Description

1. When multiple templates are created in the same block, the template information is not immediately saved to _metadata.dynamicDatasources, so only the address of the last template is saved in _metadata.dynamicDatasources. When the service is restarted, multiple identical templates are created that contain only the last address.
https://github.com/subquery/subql/blob/main/packages/node/src/indexer/dynamic-ds.service.ts#L98
```diff

async saveDynamicDatasourceParams(dsParams, tx) {
    ...
    // Only insert the last dynamic datasource in the current block event
-   await this.metaDataRepo.upsert({ key: METADATA_KEY, value: JSON.stringify([...existing, dsParams]) }, { transaction: tx });
+   await this.metaDataRepo.upsert({ key: METADATA_KEY, value: JSON.stringify([...existing, dsParams]) });
}

```
2. When creating multiple templates in the same block, due to object merging, in this._datasources, the last dsObj.processor.options will overwrite all previous dsObj.processor.options, resulting in an error in template event monitoring
https://github.com/subquery/subql/blob/main/packages/node/src/indexer/dynamic-ds.service.ts#L105
```diff
+ import _ from 'lodash';

async getDatasource(params) {
    // Dynamic datasources are the same in the current block event
-   const template = this.project.templates.find((t) => t.name === params.templateName);
+   const template = _.cloneDeep(this.project.templates.find((t) => t.name === params.templateName));
    ...
}
```
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] My code is up to date with the base branch
