### PR TITLE
fix dictionary nullable

### DIFF
--- a/packages/cli/src/commands/deployment/deploy.ts
+++ b/packages/cli/src/commands/deployment/deploy.ts
@@ -101,8 +101,10 @@ export default class Deploy extends Command {
       const validateDictEndpoint = processEndpoints(await dictionaryEndpoints(ROOT_API_URL_PROD), validator.chainId);
       if (!flags.useDefaults && !validateDictEndpoint) {
         dict = await promptWithDefaultValues(cli, 'Enter dictionary', validateDictEndpoint, null, false);
-      } else {
+      } else if (validateDictEndpoint) {
         dict = validateDictEndpoint;
+      } else {
+        dict = null;
       }
     }
 


### PR DESCRIPTION
# Description
when using `useDefault` flag, dictionary should default to `null` if using a custom endpoint

Fixes #1366 
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Linked to any relevant issues
- [x] My code is up to date with the base branch
