### PR TITLE
fix logic with reindex and unfinalized height and dynamic ds

### DIFF
--- a/packages/node/src/indexer/dynamic-ds.service.ts
+++ b/packages/node/src/indexer/dynamic-ds.service.ts
@@ -37,6 +37,20 @@ export class DynamicDsService {
 
   private _datasources: SubqlProjectDs[];
 
+  async resetDynamicDatasource(targetHeight: number, tx: Transaction) {
+    const dynamicDs = await this.getDynamicDatasourceParams();
+    if (dynamicDs.length !== 0) {
+      const filteredDs = dynamicDs.filter(
+        (ds) => ds.startBlock <= targetHeight,
+      );
+      const dsRecords = JSON.stringify(filteredDs);
+      await this.metaDataRepo.upsert(
+        { key: METADATA_KEY, value: dsRecords },
+        { transaction: tx },
+      );
+    }
+  }
+
   async createDynamicDatasource(
     params: DatasourceParams,
     tx: Transaction,

--- a/packages/node/src/indexer/project.service.ts
+++ b/packages/node/src/indexer/project.service.ts
@@ -191,7 +191,6 @@ export class ProjectService {
       'genesisHash',
       'chainId',
       'processedBlockCount',
-      'bestBlocks',
       'lastFinalizedVerifiedHeight',
     ] as const;
 
@@ -258,13 +257,6 @@ export class ProjectService {
         value: packageVersion,
       });
     }
-    if (!keyValue.bestBlocks) {
-      await metadataRepo.upsert({
-        key: 'bestBlocks',
-        value: '{}',
-      });
-    }
-
     return metadataRepo;
   }
 
@@ -373,6 +365,7 @@ export class ProjectService {
       lastProcessedHeight,
       this.storeService,
       this.unfinalizedBlockService,
+      this.dynamicDsService,
       this.mmrService,
       this.sequelize,
       /* Not providing force clean service, it should never be needed */

--- a/packages/node/src/subcommands/reindex.init.ts
+++ b/packages/node/src/subcommands/reindex.init.ts
@@ -15,7 +15,14 @@ export async function reindexInit(targetHeight: number): Promise<void> {
     const reindexService = app.get(ReindexService);
 
     await reindexService.init();
-    await reindexService.reindex(targetHeight);
+    const actualReindexHeight =
+      await reindexService.getTargetHeightWithUnfinalizedBlocks(targetHeight);
+    if (actualReindexHeight !== targetHeight) {
+      logger.info(
+        `Found index target height ${targetHeight} beyond indexed unfinalized block ${actualReindexHeight}, will index to ${actualReindexHeight}`,
+      );
+    }
+    await reindexService.reindex(actualReindexHeight);
   } catch (e) {
     logger.error(e, 'Reindex failed to execute');
     process.exit(1);

--- a/packages/node/src/subcommands/reindex.module.ts
+++ b/packages/node/src/subcommands/reindex.module.ts
@@ -5,6 +5,8 @@ import { Module } from '@nestjs/common';
 import { DbModule, MmrService, StoreService } from '@subql/node-core';
 import { ConfigureModule } from '../configure/configure.module';
 import { ApiService } from '../indexer/api.service';
+import { DsProcessorService } from '../indexer/ds-processor.service';
+import { DynamicDsService } from '../indexer/dynamic-ds.service';
 import { UnfinalizedBlocksService } from '../indexer/unfinalizedBlocks.service';
 import { ForceCleanService } from './forceClean.service';
 import { ReindexService } from './reindex.service';
@@ -16,6 +18,8 @@ import { ReindexService } from './reindex.service';
     MmrService,
     ForceCleanService,
     UnfinalizedBlocksService,
+    DynamicDsService,
+    DsProcessorService,
     {
       // Used to work with DI for unfinalizedBlocksService but not used with reindex
       provide: ApiService,

--- a/packages/node/src/subcommands/reindex.service.ts
+++ b/packages/node/src/subcommands/reindex.service.ts
@@ -14,6 +14,7 @@ import {
 } from '@subql/node-core';
 import { Sequelize } from 'sequelize';
 import { SubqlProjectDs, SubqueryProject } from '../configure/SubqueryProject';
+import { DynamicDsService } from '../indexer/dynamic-ds.service';
 import { UnfinalizedBlocksService } from '../indexer/unfinalizedBlocks.service';
 import { initDbSchema } from '../utils/project';
 import { reindex } from '../utils/reindex';
@@ -35,6 +36,7 @@ export class ReindexService {
     private readonly project: SubqueryProject,
     private readonly forceCleanService: ForceCleanService,
     private readonly unfinalizedBlocksService: UnfinalizedBlocksService,
+    private readonly dynamicDsService: DynamicDsService,
   ) {}
 
   async init(): Promise<void> {
@@ -46,6 +48,7 @@ export class ReindexService {
     }
     await this.initDbSchema();
     this.metadataRepo = MetadataFactory(this.sequelize, this.schema);
+    this.dynamicDsService.init(this.metadataRepo);
   }
 
   async getTargetHeightWithUnfinalizedBlocks(inputHeight): Promise<number> {
@@ -119,6 +122,7 @@ export class ReindexService {
       lastProcessedHeight,
       this.storeService,
       this.unfinalizedBlocksService,
+      this.dynamicDsService,
       this.mmrService,
       this.sequelize,
       this.forceCleanService,

--- a/packages/node/src/subcommands/reindex.service.ts
+++ b/packages/node/src/subcommands/reindex.service.ts
@@ -59,7 +59,7 @@ export class ReindexService {
       return inputHeight;
     }
     const [firstBestBlock] = bestBlocks[0];
-    return firstBestBlock;
+    return Math.min(inputHeight, firstBestBlock);
   }
 
   private async getExistingProjectSchema(): Promise<string> {

--- a/packages/node/src/utils/reindex.ts
+++ b/packages/node/src/utils/reindex.ts
@@ -3,6 +3,7 @@
 
 import { getLogger, MmrService, StoreService } from '@subql/node-core';
 import { Sequelize } from 'sequelize';
+import { DynamicDsService } from '../indexer/dynamic-ds.service';
 import { UnfinalizedBlocksService } from '../indexer/unfinalizedBlocks.service';
 import { ForceCleanService } from '../subcommands/forceClean.service';
 
@@ -15,6 +16,7 @@ export async function reindex(
   lastProcessedHeight: number,
   storeService: StoreService,
   unfinalizedBlockService: UnfinalizedBlocksService,
+  dynamicDsService: DynamicDsService,
   mmrService: MmrService,
   sequelize: Sequelize,
   forceCleanService?: ForceCleanService,
@@ -48,6 +50,7 @@ export async function reindex(
         storeService.rewind(targetBlockHeight, transaction),
         unfinalizedBlockService.resetUnfinalizedBlocks(transaction),
         unfinalizedBlockService.resetLastFinalizedVerifiedHeight(transaction),
+        dynamicDsService.resetDynamicDatasource(targetBlockHeight, transaction),
       ]);
 
       if (blockOffset) {


### PR DESCRIPTION
# Description

Also fixes #1379 

If issue when reindex , unfinalized block service unbale to init issue.

This change will check unfinalized block height with reindex target height and pick correct one to rollback. 
```
[Nest] 77498  - 11/04/2022, 2:13:43 PM     LOG [InstanceLoader] ReindexModule dependencies initialized +93ms
[Nest] 77498  - 11/04/2022, 2:13:43 PM     LOG [InstanceLoader] ConfigureModule dependencies initialized +0ms
2022-11-04T01:13:43.657Z <indexer> INFO indexer manager start 
2022-11-04T01:13:43.700Z <store> INFO Historical state is enabled 
(node:77498) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'getApi' of undefined
    at UnfinalizedBlocksService.get api [as api] (/Users/jiatwork/ofn/subql/packages/node/src/indexer/unfinalizedBlocks.service.ts:79:28)
    at UnfinalizedBlocksService.init (/Users/jiatwork/ofn/subql/packages/node/src/indexer/unfinalizedBlocks.service.ts:52:39)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
(Use `node --trace-warnings ...` to show where the warning was created)


```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
