### PR TITLE
Improve dictionary with dynamic query entries 

### DIFF
--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -183,7 +183,6 @@ export class DictionaryService implements OnApplicationShutdown {
     conditions: DictionaryQueryEntry[]
   ): Promise<Dictionary> {
     const {query, variables} = this.dictionaryQuery(startBlock, queryEndBlock, batchSize, conditions);
-    // console.log(query)
     try {
       const resp = await timeout(
         this.client.query({
@@ -310,14 +309,11 @@ export class DictionaryService implements OnApplicationShutdown {
       if (resultLength !== 0) {
         endBlock = attemptingResult.batchBlocks[resultLength - 1];
       } else {
-        console.log(
-          `....!!! **** Jumped to query endBlock ${queryEndBlock}, current dictionary index ${this.currentDictionaryEntryIndex}`
-        );
         endBlock = queryEndBlock;
       }
 
       if (this.updateDictionaryQueryEntries(endBlock)) {
-        logger.warn(`Dictionary been updated........`);
+        logger.info(`Dictionary entries been updated.`);
         return this.queryDictionaryEntriesDynamic(startBlockHeight, queryEndBlock, scaledBatchSize);
       }
       return attemptingResult;

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -263,7 +263,7 @@ export class FetchService implements OnApplicationShutdown {
     await this.syncDynamicDatascourcesFromMeta();
 
     this.updateDictionary();
-    //update current dictionary entries
+    // update current dictionary entries
     this.dictionaryService.updateDictionaryQueryEntries(startHeight);
 
     this.eventEmitter.emit(IndexerEvent.UsingDictionary, {
@@ -436,27 +436,19 @@ export class FetchService implements OnApplicationShutdown {
         );
 
         try {
+          // latestBufferedHeight could not exist when project init,
+          // we can ignore it here, as dictionary entries already update with fetch init.
           if (this.blockDispatcher?.latestBufferedHeight) {
-            logger.info(
-              `this.blockDispatcher?.latestBufferedHeight ${this.blockDispatcher.latestBufferedHeight}`,
-            );
-
             this.dictionaryService.updateDictionaryQueryEntries(
               this.blockDispatcher.latestBufferedHeight,
             );
-          } else {
-            logger.warn(
-              `this.blockDispatcher?.latestBufferedHeight not defined`,
-            );
           }
-
           const dictionary =
             await this.dictionaryService.queryDictionaryEntriesDynamic(
               startBlockHeight,
               queryEndBlock,
               scaledBatchSize,
             );
-
           if (startBlockHeight !== getStartBlockHeight()) {
             logger.debug(
               `Queue was reset for new DS, discarding dictionary query result`,


### PR DESCRIPTION
# Description

There is not much improvement we could make for query distinct. 

However, this pr improves query entries. Rather than use queryEndBlock, we dynamic monitor an attempting query response, if the endBlock is beyond a new datasource, we will update the query entries, and resend the query again.

It will save some queries and block when fetch in between startHeight to queryEndblock. 

- [ ] Haven't check if multiple ds with same startHeight could generate incorrect map?

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
