### PR TITLE
Lock queried rows for each block transaction

### DIFF
--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -560,6 +560,7 @@ group by
           const record = await model.findOne({
             where: {id},
             transaction: this.tx,
+            lock: true,
           });
           return record?.toJSON() as T;
         } catch (e) {
@@ -589,6 +590,7 @@ group by
             transaction: this.tx,
             limit: options?.limit ?? this.config.queryLimit,
             offset: options?.offset,
+            lock: true,
           });
           return records.map((record) => record.toJSON() as T);
         } catch (e) {
@@ -614,6 +616,7 @@ group by
           const record = await model.findOne({
             where: {[field]: value},
             transaction: this.tx,
+            lock: true,
           });
           return record?.toJSON() as T;
         } catch (e) {


### PR DESCRIPTION
# Description
Puts a lock on each query made by handlers in each block. 

⚠️ This is untested ⚠️ 
Things to test:
* It adds the concurrency guarantee we want
* Because we have a transaction for each block, if there are multiple handlers run for the same block that accesses the same value can they still update a single entity multiple times

## Motivation

With multichain indexing we need some more concurrency guarantees. We want to prevent the following example from happening. 
> Chain A reads entity X and then updates it to a new value. Between reading X and updating it chain B updates X.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
