### PR TITLE
Add a way to pass settings to the graphql playground

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 All logs must start with the format: [x.y.z] - yyyy-mm-dd
 
 ## [Unreleased]
+### Chnaged
+- Add `--playground-settings` options for passing the settings to the pleyground (#1436)
 
 ## [1.8.0] - 2022-11-23
 ### Fixed

--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -140,7 +140,9 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
         calculateHttpHeaders: true,
       }),
       this.config.get('playground')
-        ? ApolloServerPluginLandingPageGraphQLPlayground()
+        ? ApolloServerPluginLandingPageGraphQLPlayground({
+            settings: argv['playground-settings'] ? JSON.parse(argv['playground-settings']) : undefined,
+          })
         : ApolloServerPluginLandingPageDisabled(),
       queryComplexityPlugin({schema, maxComplexity: argv['query-complexity']}),
     ];

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -19,6 +19,11 @@ export function getYargsOption() {
       describe: 'Enable graphql playground',
       type: 'boolean',
     },
+    'playground-settings': {
+      demandOption: false,
+      describe: 'Pass the settings to the graphql playground (JSON format)',
+      type: 'string',
+    },
     'output-fmt': {
       demandOption: false,
       describe: 'Print log as json or plain text',


### PR DESCRIPTION
# Description

This change enables passing default settings to the playground.

I need it to set the proper credential options (`{"request.credentials": "include"}`).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
