### PR TITLE
Add --file flag for codegen

### DIFF
--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -9,7 +9,7 @@ export default class Codegen extends Command {
   static description = 'Generate schemas for graph node';
 
   static flags = {
-    file: Flags.string({char: 'f', description: 'specifiy manifest file path'}),
+    file: Flags.string({char: 'f', description: 'Specify manifest file path'}),
     location: Flags.string({char: 'l', description: 'local folder to run codegen in'}),
   };
 

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -9,8 +9,8 @@ export default class Codegen extends Command {
   static description = 'Generate schemas for graph node';
 
   static flags = {
-    file: Flags.string({char: 'f', description: 'specify manifest file path'}),
     location: Flags.string({char: 'l', description: 'local folder to run codegen in'}),
+    file: Flags.string({char: 'f', description: 'specify manifest file path (will overwrite -l if both used)'}),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -21,10 +21,15 @@ export default class Codegen extends Command {
 
     const {file, location} = flags;
 
-    const [fileDir, fileName] = file ? [path.dirname(file), path.basename(file)] : [undefined, undefined];
+    const resolvedFilePath = file ? path.resolve(file) : undefined;
+    const [fileDir, fileName] = resolvedFilePath ? [path.dirname(file), path.basename(file)] : [undefined, undefined];
+
     const resolvedLocation = fileDir ?? (location ? path.resolve(location) : process.cwd());
 
     try {
+      if (file && !resolvedFilePath) {
+        throw new Error('Cannot resolve project manifest from --file argument given');
+      }
       await codegen(resolvedLocation, fileName);
     } catch (err) {
       console.error(err.message);

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -9,8 +9,7 @@ export default class Codegen extends Command {
   static description = 'Generate schemas for graph node';
 
   static flags = {
-    force: Flags.boolean({char: 'f'}),
-    file: Flags.string(),
+    file: Flags.string({char: 'f', description: 'specify manifest name path'}),
     location: Flags.string({char: 'l', description: 'local folder to run codegen in'}),
   };
 
@@ -20,9 +19,11 @@ export default class Codegen extends Command {
     this.log('---------Subql Codegen---------');
     this.log('===============================');
 
+    const file = flags.file ? path.resolve(flags.file) : undefined;
     const location = flags.location ? path.resolve(flags.location) : process.cwd();
+
     try {
-      await codegen(location);
+      await codegen(location, file);
     } catch (err) {
       console.error(err.message);
       process.exit(1);

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -9,7 +9,7 @@ export default class Codegen extends Command {
   static description = 'Generate schemas for graph node';
 
   static flags = {
-    file: Flags.string({char: 'f', description: 'specify manifest name path'}),
+    file: Flags.string({char: 'f', description: 'specifiy manifest file path'}),
     location: Flags.string({char: 'l', description: 'local folder to run codegen in'}),
   };
 
@@ -19,11 +19,13 @@ export default class Codegen extends Command {
     this.log('---------Subql Codegen---------');
     this.log('===============================');
 
-    const file = flags.file ? path.resolve(flags.file) : undefined;
-    const location = flags.location ? path.resolve(flags.location) : process.cwd();
+    const {file, location} = flags;
+
+    const [fileDir, fileName] = file ? [path.dirname(file), path.basename(file)] : [undefined, undefined];
+    const resolvedLocation = fileDir ?? (location ? path.resolve(location) : process.cwd());
 
     try {
-      await codegen(location, file);
+      await codegen(resolvedLocation, fileName);
     } catch (err) {
       console.error(err.message);
       process.exit(1);

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -9,7 +9,7 @@ export default class Codegen extends Command {
   static description = 'Generate schemas for graph node';
 
   static flags = {
-    file: Flags.string({char: 'f', description: 'Specify manifest file path'}),
+    file: Flags.string({char: 'f', description: 'specify manifest file path'}),
     location: Flags.string({char: 'l', description: 'local folder to run codegen in'}),
   };
 

--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -195,20 +195,20 @@ async function prepareDirPath(path: string, recreate: boolean) {
 }
 
 //1. Prepare models directory and load schema
-export async function codegen(projectPath: string): Promise<void> {
+export async function codegen(projectPath: string, file?: string): Promise<void> {
   const modelDir = path.join(projectPath, MODEL_ROOT_DIR);
   const interfacesPath = path.join(projectPath, TYPE_ROOT_DIR, `interfaces.ts`);
   await prepareDirPath(modelDir, true);
   await prepareDirPath(interfacesPath, false);
 
-  const plainManifest = loadFromJsonOrYaml(getManifestPath(projectPath)) as {
+  const plainManifest = loadFromJsonOrYaml(getManifestPath(projectPath, file)) as {
     specVersion: string;
     templates?: TemplateKind[];
   };
   if (plainManifest.templates && plainManifest.templates.length !== 0) {
     await generateDatasourceTemplates(projectPath, plainManifest.specVersion, plainManifest.templates);
   }
-  const schemaPath = getSchemaPath(projectPath);
+  const schemaPath = getSchemaPath(projectPath, file);
 
   await generateJsonInterfaces(projectPath, schemaPath);
   await generateModels(projectPath, schemaPath);

--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -195,20 +195,20 @@ async function prepareDirPath(path: string, recreate: boolean) {
 }
 
 //1. Prepare models directory and load schema
-export async function codegen(projectPath: string, file?: string): Promise<void> {
+export async function codegen(projectPath: string, fileName?: string): Promise<void> {
   const modelDir = path.join(projectPath, MODEL_ROOT_DIR);
   const interfacesPath = path.join(projectPath, TYPE_ROOT_DIR, `interfaces.ts`);
   await prepareDirPath(modelDir, true);
   await prepareDirPath(interfacesPath, false);
 
-  const plainManifest = loadFromJsonOrYaml(getManifestPath(projectPath, file)) as {
+  const plainManifest = loadFromJsonOrYaml(getManifestPath(projectPath, fileName)) as {
     specVersion: string;
     templates?: TemplateKind[];
   };
   if (plainManifest.templates && plainManifest.templates.length !== 0) {
     await generateDatasourceTemplates(projectPath, plainManifest.specVersion, plainManifest.templates);
   }
-  const schemaPath = getSchemaPath(projectPath, file);
+  const schemaPath = getSchemaPath(projectPath, fileName);
 
   await generateJsonInterfaces(projectPath, schemaPath);
   await generateModels(projectPath, schemaPath);

--- a/packages/common/src/project/load.ts
+++ b/packages/common/src/project/load.ts
@@ -32,8 +32,8 @@ export function getManifestPath(manifestDir: string, fileName?: string): string 
   return manifestPath;
 }
 
-export function getSchemaPath(manifestDir: string, filePath?: string): string {
-  const yamlFile = loadFromJsonOrYaml(getManifestPath(manifestDir, filePath));
+export function getSchemaPath(manifestDir: string, fileName?: string): string {
+  const yamlFile = loadFromJsonOrYaml(getManifestPath(manifestDir, fileName));
   if ((yamlFile as any).specVersion === '0.0.1') {
     return path.join(manifestDir, (yamlFile as any).schema);
   }

--- a/packages/common/src/project/load.ts
+++ b/packages/common/src/project/load.ts
@@ -16,11 +16,11 @@ export function loadFromJsonOrYaml(file: string): unknown {
   return yaml.load(rawContent);
 }
 
-export function getManifestPath(manifestDir: string, filePath?: string): string {
+export function getManifestPath(manifestDir: string, fileName?: string): string {
   let manifestPath = manifestDir;
   if (fs.existsSync(manifestDir) && fs.lstatSync(manifestDir).isDirectory()) {
-    const yamlFilePath = filePath ?? path.join(manifestDir, 'project.yaml');
-    const jsonFilePath = filePath ?? path.join(manifestDir, 'project.json');
+    const yamlFilePath = path.join(manifestDir, fileName ?? 'project.yaml');
+    const jsonFilePath = path.join(manifestDir, fileName ?? 'project.json');
     if (fs.existsSync(yamlFilePath)) {
       manifestPath = yamlFilePath;
     } else if (fs.existsSync(jsonFilePath)) {

--- a/packages/common/src/project/load.ts
+++ b/packages/common/src/project/load.ts
@@ -16,26 +16,26 @@ export function loadFromJsonOrYaml(file: string): unknown {
   return yaml.load(rawContent);
 }
 
-export function getManifestPath(file: string): string {
-  let manifestPath = file;
-  if (fs.existsSync(file) && fs.lstatSync(file).isDirectory()) {
-    const yamlFilePath = path.join(file, 'project.yaml');
-    const jsonFilePath = path.join(file, 'project.json');
+export function getManifestPath(manifestDir: string, filePath?: string): string {
+  let manifestPath = manifestDir;
+  if (fs.existsSync(manifestDir) && fs.lstatSync(manifestDir).isDirectory()) {
+    const yamlFilePath = filePath ?? path.join(manifestDir, 'project.yaml');
+    const jsonFilePath = filePath ?? path.join(manifestDir, 'project.json');
     if (fs.existsSync(yamlFilePath)) {
       manifestPath = yamlFilePath;
     } else if (fs.existsSync(jsonFilePath)) {
       manifestPath = jsonFilePath;
     } else {
-      throw new Error(`Could not find project manifest under dir ${file}`);
+      throw new Error(`Could not find project manifest under dir ${manifestDir}`);
     }
   }
   return manifestPath;
 }
 
-export function getSchemaPath(file: string) {
-  const yamlFile = loadFromJsonOrYaml(getManifestPath(file));
+export function getSchemaPath(manifestDir: string, filePath?: string): string {
+  const yamlFile = loadFromJsonOrYaml(getManifestPath(manifestDir, filePath));
   if ((yamlFile as any).specVersion === '0.0.1') {
-    return path.join(file, (yamlFile as any).schema);
+    return path.join(manifestDir, (yamlFile as any).schema);
   }
   const project = yamlFile as ProjectManifestV0_2_0;
   if (!project.schema) {
@@ -44,7 +44,7 @@ export function getSchemaPath(file: string) {
   if (!project.schema.file) {
     throw new Error(`schemaPath expect to be schema.file`);
   }
-  return path.join(file, project.schema.file);
+  return path.join(manifestDir, project.schema.file);
 }
 
 // Only work for manifest specVersion >= 1.0.0


### PR DESCRIPTION
# Description
Includes --file flag which you can use to specify project.yaml file. This will overwrite --location if both flags are used. 

Fixes #1332

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] My code is up to date with the base branch
