### PR TITLE
Enable env vars parsing at node and query commands

### DIFF
--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -6,6 +6,7 @@ import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 
 export const yargsOptions = yargs(hideBin(process.argv))
+  .env('SUBQL_NODE')
   .command({
     command: 'force-clean',
     describe:

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -7,105 +7,107 @@ import yargs from 'yargs/yargs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getYargsOption() {
-  return yargs(hideBin(process.argv)).options({
-    name: {
-      demandOption: true,
-      alias: 'n',
-      describe: 'Project name',
-      type: 'string',
-    },
-    playground: {
-      demandOption: false,
-      describe: 'Enable graphql playground',
-      type: 'boolean',
-    },
-    'playground-settings': {
-      demandOption: false,
-      describe: 'Pass the settings to the graphql playground (JSON format)',
-      type: 'string',
-    },
-    'output-fmt': {
-      demandOption: false,
-      describe: 'Print log as json or plain text',
-      type: 'string',
-      default: 'colored',
-      choices: ['json', 'colored'],
-    },
-    'log-level': {
-      demandOption: false,
-      describe: 'Specify log level to print.',
-      type: 'string',
-      default: 'info',
-      choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
-    },
-    'log-path': {
-      demandOption: false,
-      describe: 'Path to create log file e.g ./src/name.log',
-      type: 'string',
-    },
-    'log-rotate': {
-      demandOption: false,
-      describe: 'Rotate log files in directory specified by log-path',
-      type: 'boolean',
-      default: false,
-    },
-    indexer: {
-      demandOption: false,
-      describe: 'Url that allows query to access indexer metadata',
-      type: 'string',
-    },
-    unsafe: {
-      demandOption: false,
-      describe: 'Disable limits on query depth and allowable number returned query records',
-      type: 'boolean',
-    },
-    subscription: {
-      demandOption: false,
-      describe: 'Enable subscription service',
-      type: 'boolean',
-      default: false,
-    },
-    port: {
-      alias: 'p',
-      demandOption: false,
-      describe: 'The port the service will bind to',
-      type: 'number',
-    },
-    'query-complexity': {
-      demandOption: false,
-      describe: 'Level of query complexity',
-      type: 'number',
-    },
-    'max-connection': {
-      demandOption: false,
-      describe: 'Max connection to pg pool',
-      type: 'number',
-      default: 10,
-    },
-    'query-timeout': {
-      demandOption: false,
-      describe: 'Query timeout in milliseconds',
-      type: 'number',
-      default: 10000,
-    },
-    'query-explain': {
-      demandOption: false,
-      describe: 'Explain query in SQL statement',
-      type: 'boolean',
-    },
-    aggregate: {
-      demandOption: false,
-      default: true,
-      describe: 'Enable aggregate feature',
-      type: 'boolean',
-    },
-    'disable-hot-schema': {
-      demandOption: false,
-      describe: 'Hot reload schema on schema-changes',
-      type: 'boolean',
-      default: false,
-    },
-  });
+  return yargs(hideBin(process.argv))
+    .env('SUBQL_QUERY')
+    .options({
+      name: {
+        demandOption: true,
+        alias: 'n',
+        describe: 'Project name',
+        type: 'string',
+      },
+      playground: {
+        demandOption: false,
+        describe: 'Enable graphql playground',
+        type: 'boolean',
+      },
+      'playground-settings': {
+        demandOption: false,
+        describe: 'Pass the settings to the graphql playground (JSON format)',
+        type: 'string',
+      },
+      'output-fmt': {
+        demandOption: false,
+        describe: 'Print log as json or plain text',
+        type: 'string',
+        default: 'colored',
+        choices: ['json', 'colored'],
+      },
+      'log-level': {
+        demandOption: false,
+        describe: 'Specify log level to print.',
+        type: 'string',
+        default: 'info',
+        choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
+      },
+      'log-path': {
+        demandOption: false,
+        describe: 'Path to create log file e.g ./src/name.log',
+        type: 'string',
+      },
+      'log-rotate': {
+        demandOption: false,
+        describe: 'Rotate log files in directory specified by log-path',
+        type: 'boolean',
+        default: false,
+      },
+      indexer: {
+        demandOption: false,
+        describe: 'Url that allows query to access indexer metadata',
+        type: 'string',
+      },
+      unsafe: {
+        demandOption: false,
+        describe: 'Disable limits on query depth and allowable number returned query records',
+        type: 'boolean',
+      },
+      subscription: {
+        demandOption: false,
+        describe: 'Enable subscription service',
+        type: 'boolean',
+        default: false,
+      },
+      port: {
+        alias: 'p',
+        demandOption: false,
+        describe: 'The port the service will bind to',
+        type: 'number',
+      },
+      'query-complexity': {
+        demandOption: false,
+        describe: 'Level of query complexity',
+        type: 'number',
+      },
+      'max-connection': {
+        demandOption: false,
+        describe: 'Max connection to pg pool',
+        type: 'number',
+        default: 10,
+      },
+      'query-timeout': {
+        demandOption: false,
+        describe: 'Query timeout in milliseconds',
+        type: 'number',
+        default: 10000,
+      },
+      'query-explain': {
+        demandOption: false,
+        describe: 'Explain query in SQL statement',
+        type: 'boolean',
+      },
+      aggregate: {
+        demandOption: false,
+        default: true,
+        describe: 'Enable aggregate feature',
+        type: 'boolean',
+      },
+      'disable-hot-schema': {
+        demandOption: false,
+        describe: 'Hot reload schema on schema-changes',
+        type: 'boolean',
+        default: false,
+      },
+    });
 }
 
 export function argv(arg: string): unknown {


### PR DESCRIPTION
# Description

This change enables setting the cli options from the env vars for the `query` and `node`.

This is useful for custom private deployments, for instance in Kubernetes it makes it easy to pass the schema name or indexer URL from the ConfigMaps or dynamic field annotations.

> I will be adding some k8s deployment improvements on top of these changes, but they are worth doing in a separate PR.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
