### PR TITLE
Remove unused RuntimeService from indexer module, it had missing dependencies

### DIFF
--- a/packages/node/src/indexer/indexer.module.ts
+++ b/packages/node/src/indexer/indexer.module.ts
@@ -10,7 +10,6 @@ import { DsProcessorService } from './ds-processor.service';
 import { DynamicDsService } from './dynamic-ds.service';
 import { IndexerManager } from './indexer.manager';
 import { ProjectService } from './project.service';
-import { RuntimeService } from './runtimeService';
 import { SandboxService } from './sandbox.service';
 import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
 import { WorkerService } from './worker/worker.service';
@@ -39,7 +38,6 @@ import { WorkerService } from './worker/worker.service';
     ProjectService,
     WorkerService,
     UnfinalizedBlocksService,
-    RuntimeService,
   ],
   exports: [StoreService, MmrService],
 })

--- a/packages/node/src/indexer/worker/worker.ts
+++ b/packages/node/src/indexer/worker/worker.ts
@@ -43,7 +43,7 @@ async function initWorker(): Promise<void> {
     }
 
     app = await NestFactory.create(WorkerModule, {
-      logger: new NestLogger(),
+      logger: new NestLogger(), // TIP: If the worker is crashing comment out this line for better logging
     });
 
     await app.init();


### PR DESCRIPTION
# Description
Indexer module had RuntimeService as a provider but it was missing the dictionary dependency with workers. As the runtime service was unused within the Indexer module, the easiest solution was to remove it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
