### PR TITLE
fix parentSpecVersion could be undefined

### DIFF
--- a/packages/node/src/indexer/runtimeService.ts
+++ b/packages/node/src/indexer/runtimeService.ts
@@ -95,15 +95,19 @@ export class RuntimeService implements OnApplicationShutdown {
       const parentSpecVersion = this.specVersionMap.find(
         (spec) => Number(spec.id) === this.parentSpecVersion,
       );
-      for (const specVersion of this.specVersionMap) {
-        if (
-          specVersion.start > parentSpecVersion.end &&
-          specVersion.start <= height
-        ) {
-          const blockHash = await this.api.rpc.chain.getBlockHash(
-            specVersion.start,
-          );
-          await SubstrateUtil.prefetchMetadata(this.api, blockHash);
+      if (parentSpecVersion === undefined) {
+        await SubstrateUtil.prefetchMetadata(this.api, blockHash);
+      } else {
+        for (const specVersion of this.specVersionMap) {
+          if (
+            specVersion.start > parentSpecVersion.end &&
+            specVersion.start <= height
+          ) {
+            const blockHash = await this.api.rpc.chain.getBlockHash(
+              specVersion.start,
+            );
+            await SubstrateUtil.prefetchMetadata(this.api, blockHash);
+          }
         }
       }
     } else {


### PR DESCRIPTION
# Description

This fix a very edge case of dictionary project got parentSpecVersion got undefined case.

Due to dictionary project using its own specVersion maps, If the parent specVersion got undefined in the dictionary specVersion map, it will never been found as it never been set, loop dependencies!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
