### PR TITLE
add connection filters

### DIFF
--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -111,6 +111,9 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
       replaceAllPlugins: plugins,
       subscriptions: true,
       dynamicJson: true,
+      graphileBuildOptions: {
+        connectionFilterRelations: true,
+      },
     };
 
     if (argv.subscription) {


### PR DESCRIPTION
# Description

1/2 part of #1482 

In the query section, we enabled filter in virtual field, this allow nest filter. example:
However, this won't allow sort by totalCount.

```
query{
  authors(filter: {id:{equalTo:"someone"}}){
    nodes{
      books(filter:{year:{greaterThan:1995}}){
        totalCount
        nodes{
          id,
          year,
        }
      }
    }
  }
}
```
We need to implement https://www.graphile.org/postgraphile/smart-tags/#filterable

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
