### PR TITLE
Fix custom metadata keys not being applied

### DIFF
--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -331,11 +331,10 @@ export class DictionaryService implements OnApplicationShutdown {
   }
 
   private metadataQuery(): GqlQuery {
-    const keys = ['lastProcessedHeight', 'genesisHash', 'startHeight'];
     const nodes: GqlNode[] = [
       {
         entity: '_metadata',
-        project: this.useStartHeight ? keys : keys.filter((key) => key !== 'startHeight'),
+        project: this.useStartHeight ? [...this.metadataKeys, 'startHeight'] : this.metadataKeys,
       },
     ];
     return buildQuery([], nodes);


### PR DESCRIPTION
# Description
Other chains use different metadata keys, e.g. cosmos uses `chain` instead of `genesisHash` this applies the custom keys to the metadata query.
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
