### PR TITLE
Get actual queue size after flush and add test

### DIFF
--- a/packages/node-core/src/utils/autoQueue.spec.ts
+++ b/packages/node-core/src/utils/autoQueue.spec.ts
@@ -19,7 +19,7 @@ describe('Auto Queue', () => {
     expect(newQ.size).toEqual(3);
 
     newQ.flush();
-
-    expect(newQ.size).toEqual(0);
+    // expect queue should be empty，this not including ongoing processing task
+    expect(newQ.queueSize).toEqual(0);
   });
 });

--- a/packages/node-core/src/utils/autoQueue.spec.ts
+++ b/packages/node-core/src/utils/autoQueue.spec.ts
@@ -1,0 +1,25 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {AutoQueue} from './autoQueue';
+import {delay} from './promise';
+
+describe('Auto Queue', () => {
+  it('create and flush AutoQueue', () => {
+    const newQ = new AutoQueue<void>(5);
+
+    const task1 = () => delay(5);
+    const task2 = () => delay(1);
+    const task3 = () => delay(10);
+
+    newQ.put(task1);
+    newQ.put(task2);
+    newQ.put(task3);
+
+    expect(newQ.size).toEqual(3);
+
+    newQ.flush();
+
+    expect(newQ.size).toEqual(0);
+  });
+});

--- a/packages/node-core/src/utils/autoQueue.ts
+++ b/packages/node-core/src/utils/autoQueue.ts
@@ -63,7 +63,6 @@ export class Queue<T> implements IQueue {
 
   takeAll(): T[] {
     const result = this.items;
-
     this.items = [];
     return result;
   }
@@ -169,6 +168,9 @@ export class AutoQueue<T> implements IQueue {
     // Empty the queue
     // TODO do we need to reject all promises?
     this.queue.takeAll();
+    this.pendingPromise = false;
+    this._abort = false;
+    this.processingTasks = 0;
   }
 
   abort(): void {

--- a/packages/node-core/src/utils/autoQueue.ts
+++ b/packages/node-core/src/utils/autoQueue.ts
@@ -96,6 +96,10 @@ export class AutoQueue<T> implements IQueue {
     return this.queue.size + this.processingTasks;
   }
 
+  get queueSize(): number {
+    return this.queue.size;
+  }
+
   get capacity(): number {
     return this.queue.capacity;
   }
@@ -168,9 +172,6 @@ export class AutoQueue<T> implements IQueue {
     // Empty the queue
     // TODO do we need to reject all promises?
     this.queue.takeAll();
-    this.pendingPromise = false;
-    this._abort = false;
-    this.processingTasks = 0;
   }
 
   abort(): void {


### PR DESCRIPTION
# Description
Current autoQueue after flush, and when we get queue size we are expecting to get 0 but return 1, this is due to it count processingTasks as 1.

This fix will force update all attributes to init value. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
