### PR TITLE
Check queue for lower blocks before processing fetched blocks

### DIFF
--- a/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
@@ -151,10 +151,16 @@ export class BlockDispatcherService
           specChanged ? undefined : this.runtimeService.parentSpecVersion,
         );
 
-        if (bufferedHeight > this._latestBufferedHeight) {
-          logger.debug(`Queue was reset for new DS, discarding fetched blocks`);
+        // Check if the queues have been flushed between queue.takeMany and fetchBlocksBatches resolving
+        // Peeking the queue is because the latestBufferedHeight could have regrown since fetching block
+        if (
+          bufferedHeight > this._latestBufferedHeight ||
+          this.queue.peek() < Math.min(...blockNums)
+        ) {
+          logger.info(`Queue was reset for new DS, discarding fetched blocks`);
           continue;
         }
+
         const blockTasks = blocks.map((block) => async () => {
           const height = block.block.block.header.number.toNumber();
           try {


### PR DESCRIPTION
Backporting fix from ethereum https://github.com/subquery/subql-ethereum/pull/28