### PR TITLE
add flag query-limit

### DIFF
--- a/packages/query/src/graphql/plugins/PgConnectionArgFirstLastBeforeAfter.ts
+++ b/packages/query/src/graphql/plugins/PgConnectionArgFirstLastBeforeAfter.ts
@@ -7,8 +7,6 @@
 import {QueryBuilder} from '@subql/x-graphile-build-pg';
 import {argv} from '../../yargs';
 
-const MAX_ENTITY_COUNT = 100;
-
 const base64Decode = (str) => Buffer.from(String(str), 'base64').toString('utf8');
 
 export default (builder) => {
@@ -26,7 +24,7 @@ export default (builder) => {
         scope: {fieldName, isPgFieldConnection, isPgFieldSimpleCollection, pgFieldIntrospection: source},
       } = context;
       const unsafe = argv('unsafe') as boolean;
-      const safeClamp = (x: number) => (unsafe ? x : Math.min(x, MAX_ENTITY_COUNT));
+      const safeClamp = (x: number) => Math.min(x, argv('query-limit') as number);
 
       if (
         !(isPgFieldConnection || isPgFieldSimpleCollection) ||
@@ -41,7 +39,7 @@ export default (builder) => {
         return {
           pgQuery: (queryBuilder: QueryBuilder) => {
             if (!first && !last && !unsafe) {
-              queryBuilder.first(MAX_ENTITY_COUNT);
+              queryBuilder.first(argv('query-limit') as number);
             }
             if (first) {
               first = safeClamp(first);

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {argv as yargv} from 'yargs';
+// import {argv as yargv} from 'yargs';
 import {hideBin} from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 
@@ -60,6 +60,12 @@ export function getYargsOption() {
         demandOption: false,
         describe: 'Disable limits on query depth and allowable number returned query records',
         type: 'boolean',
+      },
+      'query-limit': {
+        demandOption: false,
+        describe: 'Set limit on query depth',
+        type: 'number',
+        default: 100,
       },
       subscription: {
         demandOption: false,


### PR DESCRIPTION
# Description
Adding `--query-limit` to query service. Allowing limited query results. Defaulted to 100.

Documentation PR: https://github.com/subquery/documentation/pull/281

Fixes #1507

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] My code is up to date with the base branch
