### PR TITLE
`dictionary-optimisation` flag 

### DIFF
--- a/packages/query/src/graphql/plugins/PgDistinctPlugin.ts
+++ b/packages/query/src/graphql/plugins/PgDistinctPlugin.ts
@@ -90,6 +90,7 @@ export const PgDistinctPlugin: Plugin = (builder) => {
             // Dependent on https://github.com/graphile/graphile-engine/pull/805
             (queryBuilder as any).distinctOn(id);
 
+            // set BlockHeight as orderBy key, as by default it uses primaryKey (This will speed up the query speed of dictionaries)
             if (argv('dictionary-optimisation')) {
               queryBuilder.setOrderIsUnique();
             }

--- a/packages/query/src/graphql/plugins/PgDistinctPlugin.ts
+++ b/packages/query/src/graphql/plugins/PgDistinctPlugin.ts
@@ -6,6 +6,7 @@ import {Build, Plugin} from 'graphile-build';
 import type {GraphQLEnumType} from 'graphql';
 import * as PgSql from 'pg-sql2';
 import {SQLNode} from 'pg-sql2';
+import {argv} from '../../yargs';
 
 type Extend = <T1, T2>(base: T1, extra: T2, hint?: string) => T1 & T2;
 
@@ -88,6 +89,10 @@ export const PgDistinctPlugin: Plugin = (builder) => {
 
             // Dependent on https://github.com/graphile/graphile-engine/pull/805
             (queryBuilder as any).distinctOn(id);
+
+            if (argv('dictionary-optimisation')) {
+              queryBuilder.setOrderIsUnique();
+            }
           });
         },
       }));

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -113,6 +113,12 @@ export function getYargsOption() {
         type: 'boolean',
         default: false,
       },
+      'dictionary-optimisation': {
+        demandOption: false,
+        describe: 'Dictionary optimisation',
+        type: 'boolean',
+        default: false,
+      },
     });
 }
 


### PR DESCRIPTION
# Description
Instead of using orderBy PK when using dictionary, uses blockheight (while using distinct). And adding a flag to toggle this behaviour

Fixes 
Algorand dictionary timeout

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] My code is up to date with the base branch
