### PR TITLE
Use performance.now instead of date for profiler.

### DIFF
--- a/packages/node-core/src/profiler.ts
+++ b/packages/node-core/src/profiler.ts
@@ -12,7 +12,7 @@ function isPromise(e: any): boolean {
 const logger = getLogger('profiler');
 
 function printCost(start: Date, end: Date, target: string, method: string): void {
-  logger.info(`${target}, ${method}, ${end.getTime() - start.getTime()} ms`);
+  logger.info(`${target}, ${method}, ${end - start} ms`);
 }
 
 export function profiler(enabled = true): MethodDecorator {
@@ -21,21 +21,21 @@ export function profiler(enabled = true): MethodDecorator {
       const orig = descriptor.value;
       // tslint:disable no-function-expression no-invalid-this
       descriptor.value = function (...args: any[]): any {
-        const start = new Date();
+        const start = performance.now();
         const res = orig.bind(this)(...args);
         if (isPromise(res)) {
           res.then(
             (_: any) => {
-              printCost(start, new Date(), target.constructor.name, name);
+              printCost(start, performance.now(), target.constructor.name, name);
               return _;
             },
             (err: any) => {
-              printCost(start, new Date(), target.constructor.name, name);
+              printCost(start, performance.now(), target.constructor.name, name);
               throw err;
             }
           );
         } else {
-          printCost(start, new Date(), target.constructor.name, name);
+          printCost(start, performance.now(), target.constructor.name, name);
         }
         return res;
       };
@@ -48,21 +48,21 @@ type AnyFn = (...args: any[]) => any;
 export const profilerWrap =
   <T extends AnyFn>(method: T, target: any, name: string) =>
   (...args: Parameters<T>): ReturnType<T> => {
-    const start = new Date();
+    const start = performance.now();
     const res = method(...args);
     if (isPromise(res)) {
       res.then(
         (_: any) => {
-          printCost(start, new Date(), target, name);
+          printCost(start, performance.now(), target, name);
           return _;
         },
         (err: any) => {
-          printCost(start, new Date(), target, name);
+          printCost(start, performance.now(), target, name);
           throw err;
         }
       );
     } else {
-      printCost(start, new Date(), target, name);
+      printCost(start, performance.now(), target, name);
     }
     return res;
   };


### PR DESCRIPTION
# Description
To get more detailed profiler information we can use `performance.now()` instead of `new Date().getTime()`

example output: `15.373999953269958 ms`

## Type of change

Please delete options that are not relevant.
- [x] Internal change

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
