### PR TITLE
Fix block offset been reset to 1

### DIFF
--- a/packages/node/src/indexer/project.service.ts
+++ b/packages/node/src/indexer/project.service.ts
@@ -340,7 +340,7 @@ export class ProjectService {
 
   async setBlockOffset(offset: number): Promise<void> {
     if (
-      this._blockOffset ||
+      this._blockOffset !== undefined ||
       offset === null ||
       offset === undefined ||
       isNaN(offset)


### PR DESCRIPTION
# Description

There is a bug blockOffset been set twice with starter project, or any project start with block 1.

```
2023-03-21T01:19:40.240Z <BlockDispatcherService> INFO fetch block [6,10], total 5 blocks 
2023-03-21T01:19:40.345Z <BlockDispatcherService> INFO Enqueueing blocks 21...25, total 5 blocks 
2023-03-21T01:19:41.067Z <Project> INFO set blockOffset to 0 
2023-03-21T01:19:41.093Z <mmr> INFO file based database MMR start with next block height at 1 
2023-03-21T01:19:41.112Z <Project> INFO set blockOffset to 1 
2023-03-21T01:19:42.113Z <BlockDispatcherService> INFO fetch block [11,15], total 5 blocks 
2023-03-21T01:19:42.347Z <BlockDispatcherService> INFO Enqueueing blocks 26...30, total 5 blocks 

```

This is due to when `this._blockOffset` been set to number 0, it will skip check here
https://github.com/subquery/subql/blob/6ba248b2903227b70d2da36fe922aa7546a77c7c/packages/node/src/indexer/project.service.ts#L343

And set blockOffset again. We actually want to check whether `this._blockOffset` is defined.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
