### PR TITLE
Update metadata when dictionary skips large number of blocks

### DIFF
--- a/packages/node-core/src/db/db.module.ts
+++ b/packages/node-core/src/db/db.module.ts
@@ -74,7 +74,7 @@ const buildSequelizeOptions = (nodeConfig: NodeConfig, option: DbOption): Sequel
     },
     logging: nodeConfig.debug
       ? (sql: string, timing?: number) => {
-          // logger.debug(sql);
+          logger.debug(sql);
         }
       : false,
   };

--- a/packages/node-core/src/indexer/benchmark.service.ts
+++ b/packages/node-core/src/indexer/benchmark.service.ts
@@ -32,7 +32,7 @@ export class BenchmarkService {
   @Interval(SAMPLING_TIME_VARIANCE * 1000)
   async benchmark(): Promise<void> {
     try {
-      if (!this.currentProcessingHeight || !this.currentProcessingTimestamp || !this.currentProcessedBlockAmount) {
+      if (!this.currentProcessingHeight || !this.currentProcessingTimestamp) {
         await delay(10);
       } else {
         if (this.lastRegisteredHeight && this.lastRegisteredTimestamp) {


### PR DESCRIPTION
Force flush cache when the dictionary skips a large number of blocks. 

This will update metadata with latest block heights