### PR TITLE
Dynamic cache threshold and metrics

### DIFF
--- a/packages/node-core/src/events.ts
+++ b/packages/node-core/src/events.ts
@@ -12,6 +12,8 @@ export enum IndexerEvent {
   NetworkMetadata = 'network_metadata',
   UsingDictionary = 'using_dictionary',
   SkipDictionary = 'skip_dictionary',
+  StoreCacheThreshold = 'store_cache_threshold',
+  StoreCacheRecordsSize = 'store_cache_records_size',
   Ready = 'ready',
 }
 

--- a/packages/node-core/src/meta/event.listener.ts
+++ b/packages/node-core/src/meta/event.listener.ts
@@ -34,7 +34,11 @@ export class MetricEventListener {
     @InjectMetric('subql_indexer_skip_dictionary_count')
     private skipDictionaryCountMetric: Gauge<string>,
     @InjectMetric('subql_indexer_processed_block_count')
-    private processedBlockCountMetric: Gauge<string>
+    private processedBlockCountMetric: Gauge<string>,
+    @InjectMetric('subql_indexer_store_cache_threshold')
+    private storeCacheThreshold: Gauge<string>,
+    @InjectMetric('subql_indexer_store_cache_records_size')
+    private storeCacheRecordsSize: Gauge<string>
   ) {}
 
   @OnEvent(IndexerEvent.ApiConnected)
@@ -81,5 +85,15 @@ export class MetricEventListener {
   handleSkipDictionary(): void {
     this.skipDictionaryCount += 1;
     this.skipDictionaryCountMetric.set(this.skipDictionaryCount);
+  }
+
+  @OnEvent(IndexerEvent.StoreCacheThreshold)
+  handleStoreCacheThreshold({value}: EventPayload<number>): void {
+    this.storeCacheThreshold.set(value);
+  }
+
+  @OnEvent(IndexerEvent.StoreCacheRecordsSize)
+  handleStoreCacheRecordsSize({value}: EventPayload<number>): void {
+    this.storeCacheRecordsSize.set(value);
   }
 }

--- a/packages/node/src/meta/meta.module.ts
+++ b/packages/node/src/meta/meta.module.ts
@@ -64,6 +64,14 @@ import { MetaService } from './meta.service';
       name: 'subql_indexer_processed_block_count',
       help: 'The number of processed block',
     }),
+    makeGaugeProvider({
+      name: 'subql_indexer_store_cache_threshold',
+      help: 'Store cache will flush once cache record size excess this threshold',
+    }),
+    makeGaugeProvider({
+      name: 'subql_indexer_store_cache_records_size',
+      help: 'Number of records waiting to flush in store cache',
+    }),
     MetaService,
     HealthService,
     ReadyService,


### PR DESCRIPTION
# Description

Set threshold dynamic

Use block queue size to indicate processing speed, 

- queue empty,  we are processing faster, so we can flush more frequently
- query is full,  flush at original threshold

This fix the issue with unfinalized block feature, flush should happen every block.

Also add metrics to monitoring those two parameters: blockCache records size and dynamic threshold value.

So user can adjust threshold base on these numbers

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
