### PR TITLE
Flush data at specific block heights

### DIFF
--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -176,7 +176,10 @@ export abstract class BaseBlockDispatcher<Q extends IQueue> implements IBlockDis
       this.latestProcessedHeight = height;
     }
 
-    await this.storeCacheService.flushCache();
+    void this.storeCacheService.flushCache().catch((e) => {
+      logger.error(e, 'Flushing cache failed');
+      process.exit(1);
+    });
   }
 
   private async updatePOI(height: number, blockHash: string, operationHash: Uint8Array): Promise<void> {

--- a/packages/node-core/src/indexer/storeCache/cacheModel.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.ts
@@ -215,11 +215,14 @@ export class CachedModel<
     // Get records relevant to the block height
     const setRecords = blockHeight
       ? Object.entries(this.setCache).reduce((acc, [key, value]) => {
-          acc[key] = value.fromBelowHeight(blockHeight + 1);
-
+          const newValue = value.fromBelowHeight(blockHeight + 1);
+          if (newValue.getValues().length) {
+            acc[key] = newValue;
+          }
           return acc;
         }, {} as SetData<T>)
       : this.setCache;
+
     const removeRecords = blockHeight
       ? Object.entries(this.removeCache).reduce((acc, [key, value]) => {
           if (value.removedAtBlock <= blockHeight) {

--- a/packages/node-core/src/indexer/storeCache/cacheModel.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.ts
@@ -350,10 +350,14 @@ export class CachedModel<
     });
     const mergedRecords = closeSetRecords.concat(closeRemoveRecords);
 
+    if (!mergedRecords.length) {
+      return;
+    }
+
     await this.model.sequelize.query(
       `UPDATE ${this.model.getTableName()} table1 SET _block_range = int8range(lower("_block_range"), table2._block_end)
             from (SELECT UNNEST(array[${mergedRecords.map((r) =>
-              this.model.sequelize.escape(`'${r.id}'`)
+              this.model.sequelize.escape(r.id)
             )}]) AS id, UNNEST(array[${mergedRecords.map((r) => r.blockHeight)}]) AS _block_end) AS table2
             WHERE table1.id = table2.id and "_block_range" @> _block_end-1::int8;`,
       {transaction: tx}

--- a/packages/node-core/src/indexer/storeCache/cacheModel.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.ts
@@ -284,12 +284,17 @@ export class CachedModel<
       this.setCache = {};
       this.removeCache = {};
       this.flushableRecordCounter = 0;
+      return;
     }
+
+    let newCounter = 0;
 
     // Clear everything below the block height
     this.setCache = Object.entries(this.setCache).reduce((acc, [key, value]) => {
       const newValue = value.fromAboveHeight(blockHeight);
-      if (newValue.getLatest() !== undefined) {
+      const numValues = newValue.getValues().length;
+      if (numValues) {
+        newCounter += numValues;
         acc[key] = value.fromAboveHeight(blockHeight);
       }
       return acc;
@@ -297,10 +302,13 @@ export class CachedModel<
 
     this.removeCache = Object.entries(this.removeCache).reduce((acc, [key, value]) => {
       if (value.removedAtBlock > blockHeight) {
+        newCounter++;
         acc[key] = value;
       }
       return acc;
     }, {} as Record<string, RemoveValue>);
+
+    this.flushableRecordCounter = newCounter;
   }
 
   // If field and value are passed, will getByField

--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -23,6 +23,7 @@ export class StoreCacheService implements BeforeApplicationShutdown {
   private metadataRepo: MetadataRepo;
   private poiRepo: PoiRepo;
   private pendingFlush: Promise<void>;
+  private queuedFlush: Promise<void>;
   private storeCacheThreshold: number;
 
   constructor(private sequelize: Sequelize, private config: NodeConfig, protected eventEmitter: EventEmitter2) {
@@ -79,28 +80,47 @@ export class StoreCacheService implements BeforeApplicationShutdown {
     logger.info('Flushing cache');
     const tx = await this.sequelize.transaction();
     try {
+      // Get the block height of all data we want to flush up to
+      const blockHeight = await this.metadata.find('lastProcessedHeight');
       // Get models that have data to flush
       const updatableModels = Object.values(this.cachedModels).filter((m) => m.isFlushable);
 
-      await Promise.all(updatableModels.map((model) => model.flush(tx)));
+      await Promise.all(updatableModels.map((model) => model.flush(tx, blockHeight)));
 
       await tx.commit();
     } catch (e) {
+      logger.error(e, 'Database transaction failed');
       await tx.rollback();
       throw e;
     }
   }
 
   async flushCache(forceFlush?: boolean): Promise<void> {
-    // When we force flush, this will ensure not interrupt current block flushing,
-    // Force flush will continue after last block flush tx committed.
-    if (this.pendingFlush !== undefined) {
-      await this.pendingFlush;
+    // Awaits any existing flush
+    const flushCacheGuarded = async (forceFlush?: boolean): Promise<void> => {
+      // When we force flush, this will ensure not interrupt current block flushing,
+      // Force flush will continue after last block flush tx committed.
+      if (this.pendingFlush !== undefined) {
+        await this.pendingFlush;
+      }
+      if (this.isFlushable() || forceFlush) {
+        this.pendingFlush = this._flushCache();
+
+        // Remove reference to pending flush once it completes
+        this.pendingFlush.finally(() => (this.pendingFlush = undefined));
+
+        await this.pendingFlush;
+      }
+    };
+
+    // Queued flush ensures that we only prepare one more task to flush, successive calls will return the same promise
+    if (this.queuedFlush === undefined) {
+      this.queuedFlush = flushCacheGuarded(forceFlush);
+
+      this.queuedFlush.finally(() => (this.queuedFlush = undefined));
     }
-    if (this.isFlushable() || forceFlush) {
-      this.pendingFlush = this._flushCache();
-      await this.pendingFlush;
-    }
+
+    return this.queuedFlush;
   }
 
   isFlushable(): boolean {

--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -77,7 +77,7 @@ export class StoreCacheService implements BeforeApplicationShutdown {
   }
 
   private async _flushCache(): Promise<void> {
-    logger.info('Flushing cache');
+    logger.debug('Flushing cache');
     const tx = await this.sequelize.transaction();
     try {
       // Get the block height of all data we want to flush up to

--- a/packages/node-core/src/indexer/storeCache/types.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/types.spec.ts
@@ -1,0 +1,32 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {SetValueModel} from './types';
+
+describe('SetValueModel', () => {
+  let model: SetValueModel<string>;
+
+  beforeAll(() => {
+    model = new SetValueModel<string>();
+
+    let n = 0;
+    while (n < 5) {
+      model.set(n.toString(), n);
+      n++;
+    }
+  });
+
+  it('fromBelowHeight works', () => {
+    expect(model.fromBelowHeight(5).getValues()).toEqual(model.getValues());
+
+    expect(model.fromBelowHeight(2).getValues()).toEqual([
+      {data: '0', startHeight: 0, endHeight: 1},
+      {data: '1', startHeight: 1, endHeight: null},
+    ]);
+  });
+
+  it('fromAboveHeight works', () => {
+    expect(model.fromAboveHeight(6).getValues()).toEqual([]);
+    expect(model.fromAboveHeight(3).getValues()).toEqual([{data: '4', startHeight: 4, endHeight: null}]);
+  });
+});

--- a/packages/node-core/src/indexer/storeCache/types.ts
+++ b/packages/node-core/src/indexer/storeCache/types.ts
@@ -30,7 +30,7 @@ export interface ICachedModel<T> {
 export interface ICachedModelControl {
   isFlushable: boolean;
   flushableRecordCounter: number;
-  flush(tx: Transaction): Promise<void>;
+  flush(tx: Transaction, blockHeight?: number): Promise<void>;
 }
 
 export type EntitySetData = Record<string, SetData<any>>;
@@ -106,6 +106,33 @@ export class SetValueModel<T> {
 
   getValues(): SetValue<T>[] {
     return this.historicalValues;
+  }
+
+  fromBelowHeight(height: number): SetValueModel<T> {
+    const newModel = new SetValueModel<T>();
+
+    newModel.historicalValues = this.historicalValues
+      .filter((v) => v.startHeight < height)
+      .map((v) => {
+        if (v.endHeight < height) {
+          return v;
+        }
+
+        return {
+          ...v,
+          endHeight: null,
+        };
+      });
+
+    return newModel;
+  }
+
+  fromAboveHeight(height: number): SetValueModel<T> {
+    const newModel = new SetValueModel<T>();
+
+    newModel.historicalValues = this.historicalValues.filter((v) => v.startHeight > height);
+
+    return newModel;
   }
 
   markAsRemoved(removeAtBlock: number): void {

--- a/packages/node-core/src/indexer/storeCache/types.ts
+++ b/packages/node-core/src/indexer/storeCache/types.ts
@@ -57,7 +57,7 @@ export class SetValueModel<T> {
   private historicalValues: SetValue<T>[] = [];
   private _latestIndex = -1;
 
-  create(data: T, blockHeight: number): void {
+  private create(data: T, blockHeight: number): void {
     this.historicalValues.push({data, startHeight: blockHeight, endHeight: null});
     this._latestIndex += 1;
   }


### PR DESCRIPTION
Flush data at specific heights, this means we can flush at any time and it doesn't have to be in sync with indexing blocks

Also updates flushing the cache to be non-blocking.