### PR TITLE
Make flushing cache configurable

### DIFF
--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -47,6 +47,7 @@ export interface IConfig {
   readonly pgCert?: string;
   readonly storeCacheThreshold?: number;
   readonly storeGetCacheSize?: number;
+  readonly storeCacheAsync?: boolean;
 }
 
 export type MinConfig = Partial<Omit<IConfig, 'subquery'>> & Pick<IConfig, 'subquery'>;
@@ -118,6 +119,10 @@ export class NodeConfig implements IConfig {
 
   get storeGetCacheSize(): number {
     return this._config.storeGetCacheSize;
+  }
+
+  get storeCacheAsync(): boolean {
+    return this._config.storeCacheAsync;
   }
 
   get networkEndpoint(): string | undefined {

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -176,10 +176,16 @@ export abstract class BaseBlockDispatcher<Q extends IQueue> implements IBlockDis
       this.latestProcessedHeight = height;
     }
 
-    void this.storeCacheService.flushCache().catch((e) => {
-      logger.error(e, 'Flushing cache failed');
-      process.exit(1);
-    });
+    if (this.nodeConfig.storeCacheAsync) {
+      // Flush all completed block data and don't wait
+      void this.storeCacheService.flushCache(false, false).catch((e) => {
+        logger.error(e, 'Flushing cache failed');
+        process.exit(1);
+      });
+    } else {
+      // Flush all data from cache and wait
+      await this.storeCacheService.flushCache(false, true);
+    }
   }
 
   private async updatePOI(height: number, blockHash: string, operationHash: Uint8Array): Promise<void> {

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -166,6 +166,41 @@ export const yargsOptions = yargs(hideBin(process.argv))
       type: 'boolean',
       default: false,
     },
+    'pg-ca': {
+      demandOption: false,
+      describe:
+        'Postgres ca certificate - to enables TLS/SSL connections to your PostgreSQL, path to the server certificate file are required, e.g /path/to/server-certificates/root.crt',
+      type: 'string',
+    },
+    'pg-key': {
+      demandOption: false,
+      describe:
+        'Postgres client key - Path to key file e.g /path/to/client-key/postgresql.key',
+      type: 'string',
+    },
+    'pg-cert': {
+      demandOption: false,
+      describe:
+        'Postgres client certificate - Path to client certificate e.g /path/to/client-certificates/postgresql.crt',
+      type: 'string',
+    },
+    'store-cache-threshold': {
+      demandOption: false,
+      describe:
+        'Store cache will flush when number of records excess this threshold',
+      type: 'number',
+    },
+    'store-get-cache-size': {
+      demandOption: false,
+      describe: 'Store get cache size for each model',
+      type: 'number',
+    },
+    'store-cache-async': {
+      demandOption: false,
+      describe:
+        'If enabled writing data to the store is asynchronous with regards to block processing',
+      type: 'boolean',
+    },
     subquery: {
       alias: 'f',
       demandOption: true,
@@ -212,35 +247,6 @@ export const yargsOptions = yargs(hideBin(process.argv))
       demandOption: false,
       describe:
         'Number of worker threads to use for fetching and processing blocks. Disabled by default.',
-      type: 'number',
-    },
-    'pg-ca': {
-      demandOption: false,
-      describe:
-        'Postgres ca certificate - to enables TLS/SSL connections to your PostgreSQL, path to the server certificate file are required, e.g /path/to/server-certificates/root.crt',
-      type: 'string',
-    },
-    'pg-key': {
-      demandOption: false,
-      describe:
-        'Postgres client key - Path to key file e.g /path/to/client-key/postgresql.key',
-      type: 'string',
-    },
-    'pg-cert': {
-      demandOption: false,
-      describe:
-        'Postgres client certificate - Path to client certificate e.g /path/to/client-certificates/postgresql.crt',
-      type: 'string',
-    },
-    'store-cache-threshold': {
-      demandOption: false,
-      describe:
-        'Store cache will flush when number of records excess this threshold',
-      type: 'number',
-    },
-    'store-get-cache-size': {
-      demandOption: false,
-      describe: 'Store get cache size for each model',
       type: 'number',
     },
   });


### PR DESCRIPTION
Adds the option to choose how the cache is flushed:

* Flush asynchronously to processing blocks and only flush completed blocks data
* Flush all data in sync with processing blocks 

Also ordered the flags alphabetically 