### PR TITLE
Cache and worker related fixes

### DIFF
--- a/packages/node-core/src/indexer/worker/worker.builder.ts
+++ b/packages/node-core/src/indexer/worker/worker.builder.ts
@@ -105,21 +105,26 @@ abstract class WorkerIO {
     const id = this.getReqId();
 
     return new Promise<T>((resolve, reject) => {
-      this.responseListeners[id] = (data, error) => {
-        if (error) {
-          const e = new Error(error.message);
-          e.stack = error.stack ?? e.stack;
-          reject(e);
-        } else {
-          resolve(data);
-        }
-      };
+      try {
+        this.responseListeners[id] = (data, error) => {
+          if (error) {
+            const e = new Error(error.message);
+            e.stack = error.stack ?? e.stack;
+            reject(e);
+          } else {
+            resolve(data);
+          }
+        };
 
-      this.port.postMessage(<Request>{
-        id,
-        name: fnName,
-        args,
-      });
+        this.port.postMessage(<Request>{
+          id,
+          name: fnName,
+          args,
+        });
+      } catch (e) {
+        this.logger.error(e, `Failed to post message, function="${fnName}", args="${JSON.stringify(args)}"`);
+        reject(e);
+      }
     });
   }
 }

--- a/packages/node-core/src/indexer/worker/worker.dynamic-ds.service.ts
+++ b/packages/node-core/src/indexer/worker/worker.dynamic-ds.service.ts
@@ -19,7 +19,8 @@ export class WorkerDynamicDsService<DS> implements IDynamicDsService<DS> {
   constructor(private host: HostDynamicDS<DS>) {}
 
   async createDynamicDatasource(params: DatasourceParams): Promise<DS> {
-    return this.host.dynamicDsCreateDynamicDatasource(params);
+    // Make sure the params are serializable over the bridge by using JSON conversion
+    return this.host.dynamicDsCreateDynamicDatasource(JSON.parse(JSON.stringify(params)));
   }
 
   async getDynamicDatasources(): Promise<DS[]> {

--- a/packages/node/src/indexer/project.service.ts
+++ b/packages/node/src/indexer/project.service.ts
@@ -119,7 +119,7 @@ export class ProjectService implements IProjectService {
       }
 
       // Flush any pending operations to setup DB
-      await this.storeService.storeCache.flushCache();
+      await this.storeService.storeCache.flushCache(true);
     } else {
       this._schema = await this.getExistingProjectSchema();
 

--- a/packages/node/src/indexer/worker/worker.ts
+++ b/packages/node/src/indexer/worker/worker.ts
@@ -33,7 +33,6 @@ import {
 } from '@subql/node-core';
 import { SubqlProjectDs } from '../../configure/SubqueryProject';
 import { SpecVersion } from '../dictionary.service';
-import { DynamicDsService } from '../dynamic-ds.service';
 import { IndexerManager } from '../indexer.manager';
 import { WorkerModule } from './worker.module';
 import {
@@ -92,15 +91,7 @@ async function fetchBlock(
 async function processBlock(height: number): Promise<ProcessBlockResponse> {
   assert(workerService, 'Not initialised');
 
-  const res = await workerService.processBlock(height);
-
-  // Clean up the temp ds records for worker thread instance
-  if (res.dynamicDsCreated) {
-    const dynamicDsService = app.get(DynamicDsService);
-    dynamicDsService.deleteTempDsRecords(height);
-  }
-
-  return res;
+  return workerService.processBlock(height);
 }
 
 function syncRuntimeService(
@@ -185,7 +176,7 @@ export type IIndexerWorker = {
   syncRuntimeService: SyncRuntimeService;
   getSpecFromMap: GetSpecFromMap;
   getMemoryLeft: GetMemoryLeft;
-  waitForWorkerBatchSize: WaitForWorkerBatchSize
+  waitForWorkerBatchSize: WaitForWorkerBatchSize;
 };
 
 export type IInitIndexerWorker = IIndexerWorker & {


### PR DESCRIPTION
Fixes:

- Handle error when posting message over workers (helps detect serialization issues)
- JSON serialization for creating dynamic ds over workers
- Fix not force flushing cache on initial db setup meaning metadata can be missing
- Don't call `deleteTempDsRecords` in workers now that dynamic ds service works differently