### PR TITLE
support cockroach db with non-historical

### DIFF
--- a/packages/node-core/src/indexer/storeCache/cacheModel.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.ts
@@ -228,7 +228,8 @@ export class CachedModel<
       ]);
     } else {
       dbOperation = Promise.all([
-        // cockroach having issue with bulkCreate
+        // We need to use upsert instead of bulkCreate for cockroach db
+        // see this https://github.com/subquery/subql/issues/1606
         this.useCockroachDb
           ? records.map((r) => {
               this.model.upsert(r, {transaction: tx});

--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -32,11 +32,8 @@ export class StoreCacheService implements BeforeApplicationShutdown {
     this.storeCacheThreshold = config.storeCacheThreshold;
   }
 
-  setUseCockroach(useCockroachDb: boolean): void {
+  init(historical: boolean, useCockroachDb: boolean): void {
     this._useCockroachDb = useCockroachDb;
-  }
-
-  setHistorical(historical: boolean): void {
     this._historical = historical;
   }
 


### PR DESCRIPTION
# Description


TODO: 

- [x] check whether we still can use bulkCreate under cacheModel, and performance different? bulkCreate seems working with non relationship entity

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
