### PR TITLE
Update the jsonField directive to have an option for disabling the index

### DIFF
--- a/packages/utils/src/graphql/entities.ts
+++ b/packages/utils/src/graphql/entities.ts
@@ -122,11 +122,11 @@ export function getAllEntitiesRelations(_schema: GraphQLSchema | string): GraphQ
       }
       // If is jsonField
       else if (jsonObjects.map((json) => json.name).includes(typeString)) {
-        const jsonObjectX = jsonObjects.find((object) => object.name === typeString);
-        const jsonObject = setJsonObjectType(jsonObjectX, jsonObjects);
-        newModel.fields.push(packJSONField(typeString, field, jsonObject));
+        const jsonObject = jsonObjects.find((object) => object.name === typeString);
+        const jsonObjectType = setJsonObjectType(jsonObject, jsonObjects);
+        newModel.fields.push(packJSONField(typeString, field, jsonObjectType));
 
-        const directive = jsonObjectX.astNode.directives.find(({name: {value}}) => value === DirectiveName.JsonField);
+        const directive = jsonObject.astNode.directives.find(({name: {value}}) => value === DirectiveName.JsonField);
         const argValue = directive?.arguments?.find((arg) => arg.name.value === 'indexed')?.value;
         // For backwards compatibility if the argument is not defined then the index will be added
         if (!argValue || (isBooleanValueNode(argValue) && argValue.value !== false)) {

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -263,4 +263,32 @@ describe('utils that handle schema.graphql', () => {
     expect(accountModel.fields[0].jsonInterface.fields[2].type).toBe('Json');
     expect(accountModel.fields[0].jsonInterface.fields[2].jsonInterface.name).toBe('MyJson2');
   });
+
+  it('can read jsonfield without index', () => {
+    const graphqlSchema = gql`
+      type MyJson @jsonField(indexed: false) {
+        data: String!
+        data2: [String]
+      }
+      type MyJson2 @jsonField(indexed: true) {
+        data: String!
+        data2: [String]
+      }
+      type MyJson3 @jsonField {
+        data: String!
+        data2: [String]
+      }
+      type Account @entity {
+        field1: MyJson!
+        field2: MyJson2!
+        field3: MyJson3!
+      }
+    `;
+    const schema = buildSchemaFromDocumentNode(graphqlSchema);
+    const entities = getAllEntitiesRelations(schema);
+
+    expect(entities.models?.[0].indexes.length).toEqual(2);
+    expect(entities.models?.[0].indexes[0].fields).toEqual(['field2']);
+    expect(entities.models?.[0].indexes[1].fields).toEqual(['field3']);
+  });
 });

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -264,7 +264,7 @@ describe('utils that handle schema.graphql', () => {
     expect(accountModel.fields[0].jsonInterface.fields[2].jsonInterface.name).toBe('MyJson2');
   });
 
-  it('can read jsonfield without index', () => {
+  it('can read jsonfield with indexed option', () => {
     const graphqlSchema = gql`
       type MyJson @jsonField(indexed: false) {
         data: String!

--- a/packages/utils/src/graphql/schema/directives.ts
+++ b/packages/utils/src/graphql/schema/directives.ts
@@ -6,6 +6,6 @@ import gql from 'graphql-tag';
 export const directives = gql`
   directive @derivedFrom(field: String!) on FIELD_DEFINITION
   directive @entity on OBJECT
-  directive @jsonField on OBJECT
+  directive @jsonField(indexed: Boolean) on OBJECT
   directive @index(unique: Boolean) on FIELD_DEFINITION
 `;


### PR DESCRIPTION
You can now specify an `indexed` argument on a jsonField like so:

```graphql
type MyJson @jsonField(indexed: false) {
    data: String!
    data2: [String]
}
```

The default value is `true` for backwards compatibility.

The reason for this change is to support Cosmos Dictionaries with Cockroach db where there is poor insertion performance with GIN indexes and JSONB data