### PR TITLE
Improve big int error in workers

### DIFF
--- a/packages/node-core/src/index.ts
+++ b/packages/node-core/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import './utils/bigint';
+
 export * from './api.service';
 export * from './logger';
 export * from './profiler';

--- a/packages/node-core/src/indexer/worker/worker.builder.ts
+++ b/packages/node-core/src/indexer/worker/worker.builder.ts
@@ -4,6 +4,7 @@
 import * as workers from 'worker_threads';
 import {Logger} from 'pino';
 import {getLogger} from '../../logger';
+import '../../utils/bigint';
 
 export type SerializableError = {
   message: string;
@@ -122,12 +123,7 @@ abstract class WorkerIO {
           args,
         });
       } catch (e) {
-        this.logger.error(
-          e,
-          `Failed to post message, function="${fnName}", args="${JSON.stringify(args, (key, value) =>
-            typeof value === 'bigint' ? value.toString() : value
-          )}"`
-        );
+        this.logger.error(e, `Failed to post message, function="${fnName}", args="${JSON.stringify(args)}"`);
         reject(e);
       }
     });

--- a/packages/node-core/src/indexer/worker/worker.builder.ts
+++ b/packages/node-core/src/indexer/worker/worker.builder.ts
@@ -122,7 +122,12 @@ abstract class WorkerIO {
           args,
         });
       } catch (e) {
-        this.logger.error(e, `Failed to post message, function="${fnName}", args="${JSON.stringify(args)}"`);
+        this.logger.error(
+          e,
+          `Failed to post message, function="${fnName}", args="${JSON.stringify(args, (key, value) =>
+            typeof value === 'bigint' ? value.toString() : value
+          )}"`
+        );
         reject(e);
       }
     });

--- a/packages/node-core/src/utils/bigint.ts
+++ b/packages/node-core/src/utils/bigint.ts
@@ -1,0 +1,11 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+interface BigInt {
+  toJSON(): string;
+}
+
+// Make BigInt json serializable, note this doesn't go from string -> BigInt when parsing
+BigInt.prototype.toJSON = function () {
+  return `${this.toString()}n`;
+};


### PR DESCRIPTION
# Description


Fix worker could throw this uncleared error due to bigint type:

```
2023-04-17T04:46:23.538Z <Worker Service #2> ERROR Failed to index block 2265979: TypeError: Do not know how to serialize a BigInt
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
