### PR TITLE
prevent calling getGqlType for 'contains' matcher

### DIFF
--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -62,9 +62,11 @@ function getGqlType(value: any): string {
 }
 
 function extractVar(name: string, cond: DictionaryQueryCondition): GqlVar {
-  let gqlType = getGqlType(cond.value);
+  let gqlType: string;
   if (cond.matcher === 'contains') {
     gqlType = 'JSON';
+  } else {
+    gqlType = getGqlType(cond.value);
   }
 
   return {

--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -62,12 +62,7 @@ function getGqlType(value: any): string {
 }
 
 function extractVar(name: string, cond: DictionaryQueryCondition): GqlVar {
-  let gqlType: string;
-  if (cond.matcher === 'contains') {
-    gqlType = 'JSON';
-  } else {
-    gqlType = getGqlType(cond.value);
-  }
+  const gqlType = cond.matcher === 'contains' ? 'JSON' : getGqlType(cond.value);
 
   return {
     name,


### PR DESCRIPTION
# Description
getGqlType() will throw error if condition value is an object. prevent calling getGqlType() for conditions with `contains` matcher

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
