### PR TITLE
remove indexer module from testing module

### DIFF
--- a/packages/node/src/indexer/indexer.module.ts
+++ b/packages/node/src/indexer/indexer.module.ts
@@ -58,7 +58,15 @@ import { WorkerUnfinalizedBlocksService } from './worker/worker.unfinalizedBlock
     },
     SandboxService,
     DsProcessorService,
-    DynamicDsService,
+    {
+      provide: DynamicDsService,
+      useFactory: () => {
+        if (isMainThread) {
+          throw new Error('Expected to be worker thread');
+        }
+        return new WorkerDynamicDsService((global as any).host);
+      },
+    },
     PoiService,
     MmrService,
     {
@@ -66,7 +74,16 @@ import { WorkerUnfinalizedBlocksService } from './worker/worker.unfinalizedBlock
       useClass: ProjectService,
     },
     WorkerService,
-    UnfinalizedBlocksService,
+    {
+      provide: UnfinalizedBlocksService,
+      useFactory: () => {
+        if (isMainThread) {
+          throw new Error('Expected to be worker thread');
+          //return new UnfinalizedBlocksService()
+        }
+        return new WorkerUnfinalizedBlocksService((global as any).host);
+      },
+    },
     WorkerRuntimeService,
   ],
   exports: [StoreService, MmrService],

--- a/packages/node/src/indexer/indexer.module.ts
+++ b/packages/node/src/indexer/indexer.module.ts
@@ -79,7 +79,6 @@ import { WorkerUnfinalizedBlocksService } from './worker/worker.unfinalizedBlock
       useFactory: () => {
         if (isMainThread) {
           throw new Error('Expected to be worker thread');
-          //return new UnfinalizedBlocksService()
         }
         return new WorkerUnfinalizedBlocksService((global as any).host);
       },

--- a/packages/node/src/subcommands/testing.module.ts
+++ b/packages/node/src/subcommands/testing.module.ts
@@ -19,7 +19,6 @@ import { DsProcessorService } from '../indexer/ds-processor.service';
 import { DynamicDsService } from '../indexer/dynamic-ds.service';
 import { FetchModule } from '../indexer/fetch.module';
 import { IndexerManager } from '../indexer/indexer.manager';
-import { IndexerModule } from '../indexer/indexer.module';
 import { ProjectService } from '../indexer/project.service';
 import { SandboxService } from '../indexer/sandbox.service';
 import { UnfinalizedBlocksService } from '../indexer/unfinalizedBlocks.service';

--- a/packages/node/src/subcommands/testing.module.ts
+++ b/packages/node/src/subcommands/testing.module.ts
@@ -69,7 +69,7 @@ import { TestingService } from './testing.service';
     IndexerManager,
   ],
 
-  imports: [IndexerModule, MetaModule, FetchModule],
+  imports: [MetaModule, FetchModule],
   controllers: [],
 })
 export class TestingFeatureModule {}


### PR DESCRIPTION
# Description
Remove indexer module from testing module and allow indexer module to be used only by workers

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
