### PR TITLE
fix missing esModuleInterop

### DIFF
--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -42,5 +42,8 @@
   "devDependencies": {
     "@types/async-lock": "^1"
   },
+  "resolutions": {
+    "node-fetch": "2.6.7"
+  },
   "stableVersion": "2.0.1-2"
 }

--- a/packages/node-core/tsconfig.json
+++ b/packages/node-core/tsconfig.json
@@ -5,6 +5,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "noImplicitAny": true,
+    "esModuleInterop": true,
+    "importHelpers": true,
     "strict": true
   },
   "references": [{"path": "../common"}, {"path": "../utils"}, {"path": "../testing"}],


### PR DESCRIPTION
# Description

We got `Error [ERR_REQUIRE_ESM]: require() of ES Module /` for node-fetch

likely due to node-core ts config missing 

https://www.typescriptlang.org/tsconfig#esModuleInterop

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
