### PR TITLE
Add missing node-fetch dependency to lock down version

### DIFF
--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -33,6 +33,7 @@
     "async-mutex": "^0.4.0",
     "lodash": "^4.17.21",
     "lru-cache": "8.0.4",
+    "node-fetch": "^2.6.7",
     "prom-client": "^14.0.1",
     "sequelize": "6.28.0",
     "source-map": "^0.7.4",
@@ -41,8 +42,5 @@
   },
   "devDependencies": {
     "@types/async-lock": "^1"
-  },
-  "resolutions": {
-    "node-fetch": "2.6.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4183,6 +4183,7 @@ __metadata:
     async-mutex: ^0.4.0
     lodash: ^4.17.21
     lru-cache: 8.0.4
+    node-fetch: ^2.6.7
     prom-client: ^14.0.1
     sequelize: 6.28.0
     source-map: ^0.7.4


### PR DESCRIPTION
`node-fetch` is used in the dictionary service but it was never added as an explicit dependency, but it was always found as a transient dependency