### PR TITLE
manifest node with options

### DIFF
--- a/packages/common-substrate/package.json
+++ b/packages/common-substrate/package.json
@@ -15,10 +15,12 @@
   "dependencies": {
     "@subql/common": "workspace:*",
     "@subql/types": "workspace:*",
-    "class-transformer": "0.4.0",
-    "class-validator": "^0.13.2",
     "js-yaml": "^4.1.0",
     "reflect-metadata": "^0.1.13"
+  },
+  "peerDependencies": {
+    "class-transformer": "*",
+    "class-validator": "*"
   },
   "devDependencies": {
     "@types/bn.js": "4.11.6",

--- a/packages/common-substrate/src/project/project.spec.ts
+++ b/packages/common-substrate/src/project/project.spec.ts
@@ -51,6 +51,12 @@ describe('project.yaml', () => {
     expect(deployment.network.chainId).toBe('moonbeamChainId');
   });
 
+  it('can get runner options for deployment', () => {
+    const deployment = loadSubstrateProjectManifest(path.join(projectsDir, 'project_1.0.0_node_options.yaml')).asV1_0_0
+      .deployment;
+    expect(deployment.runner.node.options.unsafe).toBeTruthy();
+  });
+
   it('can validate deployment runner versions', () => {
     const deployment = new DeploymentV1_0_0();
     const nodeImp = new SubstrateRunnerNodeImpl();

--- a/packages/common-substrate/src/project/utils.ts
+++ b/packages/common-substrate/src/project/utils.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {CustomDatasourceTemplate, RuntimeDatasourceTemplate} from '@subql/common-substrate/project/versioned';
 import {
   SecondLayerHandlerProcessor,
   SubstrateCustomDatasource,
@@ -12,6 +11,7 @@ import {
   SubstrateRuntimeDatasource,
 } from '@subql/types';
 import {gte} from 'semver';
+import {CustomDatasourceTemplate, RuntimeDatasourceTemplate} from '../project/versioned';
 
 export function isBlockHandlerProcessor<T extends SubstrateNetworkFilter, E>(
   hp: SecondLayerHandlerProcessor<SubstrateHandlerKind, T, unknown>

--- a/packages/common-substrate/src/project/versioned/v1_0_0/model.ts
+++ b/packages/common-substrate/src/project/versioned/v1_0_0/model.ts
@@ -6,6 +6,7 @@ import {
   NodeSpec,
   ProjectManifestBaseImpl,
   QuerySpec,
+  RunnerNodeImpl,
   RunnerNodeOptionsModel,
   RunnerQueryBaseModel,
   RunnerSpecs,
@@ -41,18 +42,9 @@ import {SubstrateProjectManifestV1_0_0} from './types';
 
 const SUBSTRATE_NODE_NAME = `@subql/node`;
 
-export class SubstrateRunnerNodeImpl implements NodeSpec {
+export class SubstrateRunnerNodeImpl extends RunnerNodeImpl {
   @Equals(SUBSTRATE_NODE_NAME, {message: `Runner Substrate node name incorrect, suppose be '${SUBSTRATE_NODE_NAME}'`})
   name: string;
-  @IsString()
-  @Validate(SemverVersionValidator)
-  // @Matches(RUNNER_REGEX,{message: 'runner version is not correct'})
-  version: string;
-  @IsOptional()
-  @IsObject()
-  @ValidateNested()
-  @Type(() => RunnerNodeOptionsModel)
-  options?: NodeOptions;
 }
 
 export class SubstrateRunnerSpecsImpl implements RunnerSpecs {

--- a/packages/common-substrate/src/project/versioned/v1_0_0/model.ts
+++ b/packages/common-substrate/src/project/versioned/v1_0_0/model.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  NodeOptions,
   NodeSpec,
   ProjectManifestBaseImpl,
   QuerySpec,
+  RunnerNodeOptionsModel,
   RunnerQueryBaseModel,
   RunnerSpecs,
   SemverVersionValidator,
@@ -46,6 +48,11 @@ export class SubstrateRunnerNodeImpl implements NodeSpec {
   @Validate(SemverVersionValidator)
   // @Matches(RUNNER_REGEX,{message: 'runner version is not correct'})
   version: string;
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => RunnerNodeOptionsModel)
+  options?: NodeOptions;
 }
 
 export class SubstrateRunnerSpecsImpl implements RunnerSpecs {

--- a/packages/common-substrate/test/project_1.0.0_node_options.yaml
+++ b/packages/common-substrate/test/project_1.0.0_node_options.yaml
@@ -1,0 +1,94 @@
+specVersion: 1.0.0
+name: subquery-query-registry-project
+version: 1.0.0
+description: ''
+repository: ''
+runner:
+  node:
+    name: '@subql/node'
+    version: 0.28.0
+    options:
+      historical: true
+      unsafe: true
+  query:
+    name: '@subql/query'
+    version: ^0.12.0
+schema:
+  file: ./schema.graphql
+network:
+  chainId: 'moonbeamChainId'
+  genesisHash: '0x91bc6e169807aaa54802737e1c504b2577d4fafedd5a02c10293b1cd60e39527' # Moonbase Alpha
+  endpoint: wss://moonbeam-alpha.api.onfinality.io/public-ws
+  dictionary: https://api.subquery.network/sq/subquery/moonbase-alpha-dictionary
+
+  chaintypes:
+    file: './types.yaml'
+dataSources:
+  - kind: substrate/Moonbeam
+    startBlock: 1358833
+    processor:
+      file: './node_modules/@subql/contract-processors/dist/moonbeam.js'
+      options:
+        abi: settings
+        address: '0xde030fC2b42AE2438B32506ECf63B2f3c1665579'
+    assets:
+      settings:
+        file: ./src/settings.abi.json
+    mapping:
+      file: ./dist/index.js
+      handlers:
+        - handler: handleUpdateSettings
+          kind: substrate/MoonbeamCall
+          filter:
+            function: setAllAddresses(address _sqToken,address _staking,address _indexerRegistry,address _queryRegistry) # add ",address _serviceAgreementRegistry" in later versions
+
+templates:
+  - name: QueryRegistry
+    kind: substrate/Moonbeam
+    startBlock: 1358829
+    processor:
+      file: './node_modules/@subql/contract-processors/dist/moonbeam.js'
+      options:
+        abi: queryRegistry
+        # address: '0xB0b3f6bc7a8E0bCb2aa1Cd2Ae2dE56fbdA3c0651'
+    assets:
+      queryRegistry:
+        file: ./src/queryRegistry.abi.json
+    mapping:
+      file: ./dist/index.js
+      handlers:
+        - handler: handleNewQuery
+          kind: substrate/MoonbeamEvent
+          filter:
+            topics:
+              - CreateQuery(uint256 queryId, address creator, bytes32 metadata, bytes32 deploymentId, bytes32 version)
+        - handler: handleUpdateQueryMetadata
+          kind: substrate/MoonbeamEvent
+          filter:
+            topics:
+              - UpdateQueryMetadata(address owner, uint256 queryId, bytes32 metadata)
+        - handler: handleUpdateQueryDeployment
+          kind: substrate/MoonbeamEvent
+          filter:
+            topics:
+              - UpdateQueryDeployment(address owner, uint256 queryId, bytes32 deploymentId, bytes32 version)
+        - handler: handleStartIndexing
+          kind: substrate/MoonbeamEvent
+          filter:
+            topics:
+              - StartIndexing(address indexer, bytes32 deploymentId)
+        - handler: handleIndexingUpdate
+          kind: substrate/MoonbeamEvent
+          filter:
+            topics:
+              - UpdateDeploymentStatus(address indexer, bytes32 deploymentId, uint256 blockheight, bytes32 mmrRoot, uint256 timestamp)
+        - handler: handleIndexingReady
+          kind: substrate/MoonbeamEvent
+          filter:
+            topics:
+              - UpdateIndexingStatusToReady(address indexer, bytes32 deploymentId, uint256 _timestamp)
+        - handler: handleStopIndexing
+          kind: substrate/MoonbeamEvent
+          filter:
+            topics:
+              - StopIndexing(address indexer, bytes32 deploymentId)

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,8 +14,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "axios": "^0.27.2",
-    "class-transformer": "0.5.1",
-    "class-validator": "^0.13.2",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "fs-extra": "^10.1.0",
     "ipfs-http-client": "^52.0.3",
     "js-yaml": "^4.1.0",

--- a/packages/common/src/project/database/databaseUtil.ts
+++ b/packages/common/src/project/database/databaseUtil.ts
@@ -1,9 +1,9 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {SUPPORT_DB} from '@subql/common';
 import {Pool} from 'pg';
 import {Sequelize} from 'sequelize';
+import {SUPPORT_DB} from '../../constants';
 
 export async function getDbType(queryFrom: Sequelize | Pool): Promise<SUPPORT_DB> {
   const result = await (queryFrom as any).query('select version()');

--- a/packages/common/src/project/versioned/base.ts
+++ b/packages/common/src/project/versioned/base.ts
@@ -18,8 +18,9 @@ export abstract class ProjectManifestBaseImpl<D extends object> {
   abstract readonly deployment: D;
 
   toDeployment(): string {
-    // classToPlain fixes Map type with assets fields
-    return yaml.dump(classToPlain(this.deployment), {
+    // plainToClass was used but ran into issues
+    // We convert it to a plain object to get Maps converted to Records/Objects
+    return yaml.dump(JSON.parse(JSON.stringify(this.deployment)), {
       sortKeys: true,
       condenseFlow: true,
     });

--- a/packages/common/src/project/versioned/v1_0_0/models.ts
+++ b/packages/common/src/project/versioned/v1_0_0/models.ts
@@ -1,9 +1,10 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {Equals, IsString, Validate} from 'class-validator';
+import {Type} from 'class-transformer';
+import {Equals, IsBoolean, IsObject, IsOptional, IsString, Validate, ValidateNested} from 'class-validator';
 import {SemverVersionValidator} from '../../utils';
-import {QuerySpec} from './types';
+import {NodeOptions, QuerySpec} from './types';
 
 export class RunnerQueryBaseModel implements QuerySpec {
   @Equals('@subql/query')
@@ -12,4 +13,16 @@ export class RunnerQueryBaseModel implements QuerySpec {
   @Validate(SemverVersionValidator)
   // @Matches(RUNNER_REGEX)
   version: string;
+}
+
+export class RunnerNodeOptionsModel implements NodeOptions {
+  @IsOptional()
+  @IsBoolean()
+  historical?: boolean;
+  @IsOptional()
+  @IsBoolean()
+  unsafe?: boolean;
+  @IsOptional()
+  @IsBoolean()
+  unfinalizedBlocks?: boolean;
 }

--- a/packages/common/src/project/versioned/v1_0_0/models.ts
+++ b/packages/common/src/project/versioned/v1_0_0/models.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {Type} from 'class-transformer';
-import {Equals, IsBoolean, IsObject, IsOptional, IsString, Validate, ValidateNested} from 'class-validator';
+import {Equals, IsBoolean, IsObject, IsOptional, IsString, Matches, Validate, ValidateNested} from 'class-validator';
+import {RUNNER_REGEX} from '../../../constants';
 import {SemverVersionValidator} from '../../utils';
-import {NodeOptions, QuerySpec} from './types';
+import {NodeOptions, NodeSpec, QuerySpec} from './types';
 
 export class RunnerQueryBaseModel implements QuerySpec {
   @Equals('@subql/query')
@@ -13,6 +14,20 @@ export class RunnerQueryBaseModel implements QuerySpec {
   @Validate(SemverVersionValidator)
   // @Matches(RUNNER_REGEX)
   version: string;
+}
+
+export class RunnerNodeImpl implements NodeSpec {
+  @IsString()
+  name: string;
+  @IsString()
+  @Validate(SemverVersionValidator)
+  // @Matches(RUNNER_REGEX,{message: 'runner version is not correct'})
+  version: string;
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => RunnerNodeOptionsModel)
+  options?: NodeOptions;
 }
 
 export class RunnerNodeOptionsModel implements NodeOptions {

--- a/packages/common/src/project/versioned/v1_0_0/types.ts
+++ b/packages/common/src/project/versioned/v1_0_0/types.ts
@@ -12,11 +12,18 @@ export interface RunnerSpecs {
 export interface NodeSpec {
   name: string;
   version: string;
+  options?: NodeOptions;
 }
 
 export interface QuerySpec {
   name: string;
   version: string;
+}
+
+export interface NodeOptions {
+  historical?: boolean;
+  unsafe?: boolean;
+  unfinalizedBlocks?: boolean;
 }
 
 export interface ProjectManifestV1_0_0<T extends object = TemplateBase, D extends object = BaseDataSource>

--- a/packages/node-core/src/configure/NodeConfig.spec.ts
+++ b/packages/node-core/src/configure/NodeConfig.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as path from 'path';
+import {IConfig} from '@subql/node-core';
 import {NodeConfig} from './NodeConfig';
 
 describe('NodeConfig', () => {
@@ -21,6 +22,23 @@ describe('NodeConfig', () => {
       subquery: '../../../../subql-example/extrinsics',
       subqueryName: 'extrinsics',
     });
+  });
+
+  it('rebase file config from manifest runner options', () => {
+    const configPath = path.join(__dirname, '../../test/config.json');
+    const fileConfig = NodeConfig.fromFile(configPath);
+
+    const mockArgIConfig = {
+      workers: 4,
+      unsafe: true,
+      disableHistorical: false,
+      unfinalizedBlocks: false,
+    } as Partial<IConfig>;
+    const config = NodeConfig.rebaseWithArgs(fileConfig, mockArgIConfig);
+    // Fill undefined
+    expect(config.workers).toBe(4);
+    // override default config from manifest options
+    expect(config.unsafe).toBeTruthy();
   });
 
   it('throw error for unknown configs', () => {

--- a/packages/node-core/src/configure/NodeConfig.spec.ts
+++ b/packages/node-core/src/configure/NodeConfig.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as path from 'path';
-import {IConfig} from '@subql/node-core';
-import {NodeConfig} from './NodeConfig';
+import {NodeConfig, IConfig} from './NodeConfig';
 
 describe('NodeConfig', () => {
   it('supports read from yaml', () => {

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -92,6 +92,11 @@ export class NodeConfig implements IConfig {
     return new NodeConfig(config);
   }
 
+  static rebaseWithArgs(config: NodeConfig, configFromArgs?: Partial<IConfig>): NodeConfig {
+    const _config = assign({}, (config as any)._config, configFromArgs) as IConfig;
+    return new NodeConfig(_config);
+  }
+
   constructor(config: MinConfig) {
     this._config = assign({}, DEFAULT_CONFIG, config);
   }

--- a/packages/node-core/src/utils/configure.spec.ts
+++ b/packages/node-core/src/utils/configure.spec.ts
@@ -1,0 +1,31 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'path';
+import {NodeConfig, readRawManifest, rebaseArgsWithManifest} from '@subql/node-core';
+
+jest.setTimeout(30000);
+
+describe('configure utils', () => {
+  it('could rebase node args with manifest file ', async () => {
+    const mockArgv = {
+      ipfs: '',
+      unsafe: true,
+      batchSize: 500,
+    } as any;
+
+    const manifestPath = path.join(__dirname, '../../test/v1.0.0/project.yaml');
+    const rawManifest = await readRawManifest(manifestPath, {
+      ipfs: mockArgv.ipfs,
+    });
+
+    rebaseArgsWithManifest(mockArgv, rawManifest);
+
+    // Fill the missing args
+    expect(mockArgv.disableHistorical).toBeTruthy();
+    // Keep the original value from argv
+    expect(mockArgv.batchSize).toBe(500);
+    // Args could override manifest options
+    expect(mockArgv.unsafe).toBeTruthy();
+  });
+});

--- a/packages/node-core/src/utils/configure.spec.ts
+++ b/packages/node-core/src/utils/configure.spec.ts
@@ -3,7 +3,7 @@
 
 import path from 'path';
 import {ReaderFactory} from '@subql/common';
-import {rebaseArgsWithManifest} from '@subql/node-core';
+import {rebaseArgsWithManifest} from '../utils/configure';
 
 jest.setTimeout(30000);
 

--- a/packages/node-core/src/utils/configure.spec.ts
+++ b/packages/node-core/src/utils/configure.spec.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import path from 'path';
-import {NodeConfig, readRawManifest, rebaseArgsWithManifest} from '@subql/node-core';
+import {ReaderFactory} from '@subql/common';
+import {rebaseArgsWithManifest} from '@subql/node-core';
 
 jest.setTimeout(30000);
 
@@ -10,22 +11,21 @@ describe('configure utils', () => {
   it('could rebase node args with manifest file ', async () => {
     const mockArgv = {
       ipfs: '',
-      unsafe: true,
+      unsafe: false,
       batchSize: 500,
     } as any;
 
-    const manifestPath = path.join(__dirname, '../../test/v1.0.0/project.yaml');
-    const rawManifest = await readRawManifest(manifestPath, {
-      ipfs: mockArgv.ipfs,
-    });
+    const manifestPath = path.join(__dirname, '../../test/v1.0.0/projectOptions.yaml');
+    const reader = await ReaderFactory.create(manifestPath);
+    const rawManifest = await reader.getProjectSchema();
 
     rebaseArgsWithManifest(mockArgv, rawManifest);
 
-    // Fill the missing args
-    expect(mockArgv.disableHistorical).toBeTruthy();
+    // Fill the missing args, in manifest runner historical is enabled
+    expect(mockArgv.disableHistorical).toBeFalsy();
     // Keep the original value from argv
     expect(mockArgv.batchSize).toBe(500);
     // Args could override manifest options
-    expect(mockArgv.unsafe).toBeTruthy();
+    expect(mockArgv.unsafe).toBeFalsy();
   });
 });

--- a/packages/node-core/src/utils/configure.ts
+++ b/packages/node-core/src/utils/configure.ts
@@ -1,0 +1,48 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'path';
+import {getProjectRootAndManifest, IPFS_REGEX, NodeOptions, RunnerNodeOptionsModel} from '@subql/common';
+import {plainToClass} from 'class-transformer';
+import {camelCase, last} from 'lodash';
+import {IConfig, MinConfig} from '../configure/NodeConfig';
+
+// These are overridable types from node argv
+export interface ArgvOverrideOptions {
+  unsafe?: boolean;
+  disableHistorical?: boolean;
+  unfinalizedBlocks?: boolean;
+}
+
+export function defaultSubqueryName(config: Partial<IConfig>): MinConfig {
+  if (config.subquery === undefined) {
+    throw new Error(`Must provide local path or IPFS cid of the subquery project`);
+  }
+  const ipfsMatch = config.subquery.match(IPFS_REGEX);
+  return {
+    ...config,
+    subqueryName:
+      config.subqueryName ??
+      (ipfsMatch
+        ? config.subquery.replace(IPFS_REGEX, '')
+        : last(getProjectRootAndManifest(config.subquery).root.split(path.sep))),
+  } as MinConfig;
+}
+
+export function rebaseArgsWithManifest(argvs: ArgvOverrideOptions, rawManifest: unknown): void {
+  const options = plainToClass(RunnerNodeOptionsModel, (rawManifest as any)?.runner?.node?.options);
+  if (!options) {
+    return;
+  }
+  // we override them if they are not provided in args/flag
+  if (argvs.unsafe === undefined && options.unsafe !== undefined) {
+    argvs.unsafe = options.unsafe;
+  }
+  if (argvs.disableHistorical === undefined && options.historical !== undefined) {
+    // THIS IS OPPOSITE
+    argvs.disableHistorical = !options.historical;
+  }
+  if (argvs.unfinalizedBlocks === undefined && options.unfinalizedBlocks !== undefined) {
+    argvs.unfinalizedBlocks = options.unfinalizedBlocks;
+  }
+}

--- a/packages/node-core/src/utils/configure.ts
+++ b/packages/node-core/src/utils/configure.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import path from 'path';
-import {getProjectRootAndManifest, IPFS_REGEX, NodeOptions, RunnerNodeOptionsModel} from '@subql/common';
+import {getProjectRootAndManifest, IPFS_REGEX, RunnerNodeOptionsModel} from '@subql/common';
 import {plainToClass} from 'class-transformer';
-import {camelCase, last} from 'lodash';
+import {last} from 'lodash';
 import {IConfig, MinConfig} from '../configure/NodeConfig';
 
 // These are overridable types from node argv

--- a/packages/node-core/src/utils/index.ts
+++ b/packages/node-core/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './autoQueue';
 export * from './project';
 export * from './fetchHelpers';
 export * from './blockSizeBuffer';
+export * from './configure';

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -1,18 +1,12 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {ReaderFactory, ReaderOptions} from '@subql/common';
 import {isNumber, range, uniq, without, flatten} from 'lodash';
 import {QueryTypes, Sequelize} from 'sequelize';
 import {NodeConfig} from '../configure/NodeConfig';
 import {getLogger} from '../logger';
 
 const logger = getLogger('Project-Utils');
-
-export async function readRawManifest(path: string, readerOptions?: ReaderOptions): Promise<unknown | undefined> {
-  const reader = await ReaderFactory.create(path, readerOptions);
-  return reader.getProjectSchema();
-}
 
 export async function getExistingProjectSchema(
   nodeConfig: NodeConfig,

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -1,12 +1,18 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import {ReaderFactory, ReaderOptions} from '@subql/common';
 import {isNumber, range, uniq, without, flatten} from 'lodash';
 import {QueryTypes, Sequelize} from 'sequelize';
 import {NodeConfig} from '../configure/NodeConfig';
 import {getLogger} from '../logger';
 
 const logger = getLogger('Project-Utils');
+
+export async function readRawManifest(path: string, readerOptions?: ReaderOptions): Promise<unknown | undefined> {
+  const reader = await ReaderFactory.create(path, readerOptions);
+  return reader.getProjectSchema();
+}
 
 export async function getExistingProjectSchema(
   nodeConfig: NodeConfig,

--- a/packages/node-core/test/v1.0.0/projectOptions.yaml
+++ b/packages/node-core/test/v1.0.0/projectOptions.yaml
@@ -1,0 +1,61 @@
+specVersion: 1.0.0
+name: moonriver
+version: 1.0.0
+description: ''
+repository: ''
+runner:
+  node:
+    name: '@subql/node'
+    version: '>=1.0.0'
+    options:
+      historical: true
+      unsafe: false
+      unfinalizeBlocks: false
+  query:
+    name: '@subql/query'
+    version: '*'
+schema:
+  file: ./schema.graphql
+network:
+  chainId: '0x401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b'
+  endpoint: wss://moonriver.api.onfinality.io/public-ws
+  dictionary: 'https://api.subquery.network/sq/subquery/moonriver-dictionary'
+  chaintypes:
+    file: './distMock/chaintypes.js'
+dataSources:
+  - kind: substrate/Runtime
+    startBlock: 69219
+    mapping:
+      file: './distMock/index.js'
+      handlers:
+        - handler: collatorJoined
+          kind: substrate/EventHandler
+          filter:
+            module: parachainStaking
+            method: JoinedCollatorCandidates
+        - handler: collatorLeft
+          kind: substrate/CallHandler
+          filter:
+            module: parachainStaking
+            method: leaveCandidates
+
+  - kind: substrate/Moonbeam
+    startBlock: 562683
+    processor:
+      file: './dist/moonbeam.js'
+      #      file: './node_modules/@subql/contract-processors/dist/moonbeam.js'
+      options:
+        # Must be a key of assets
+        abi: erc20
+        address: '0x6bd193ee6d2104f14f94e2ca6efefae561a4334b'
+    assets:
+      erc20:
+        file: './erc20.abi.json'
+    mapping:
+      file: ./distMock/index.js
+      handlers:
+        - handler: erc20Transfer
+          kind: substrate/MoonbeamEvent
+          filter:
+            topics:
+              - Transfer(address indexed from,address indexed to,uint256 value)

--- a/packages/node-core/test/v1.0.0/projectOptions.yaml
+++ b/packages/node-core/test/v1.0.0/projectOptions.yaml
@@ -9,8 +9,8 @@ runner:
     version: '>=1.0.0'
     options:
       historical: true
-      unsafe: false
-      unfinalizeBlocks: false
+      unsafe: true
+      unfinalizedBlocks: false
   query:
     name: '@subql/query'
     version: '*'

--- a/packages/node/src/configure/SubqueryProject.spec.ts
+++ b/packages/node/src/configure/SubqueryProject.spec.ts
@@ -60,6 +60,7 @@ describe('SubqueryProject', () => {
       //manually pass the endpoint
       const project = await SubqueryProject.create(
         deployment,
+        null,
         { endpoint: ['wss://rpc.polkadot.io/public-ws'] },
         { ipfs: 'http://127.0.0.1:8080' },
       );

--- a/packages/node/src/configure/SubqueryProject.ts
+++ b/packages/node/src/configure/SubqueryProject.ts
@@ -68,13 +68,13 @@ export class SubqueryProject {
 
   static async create(
     path: string,
+    projectSchema: unknown,
     networkOverrides?: Partial<SubstrateProjectNetworkConfig>,
     readerOptions?: ReaderOptions,
   ): Promise<SubqueryProject> {
     // We have to use reader here, because path can be remote or local
     // and the `loadProjectManifest(projectPath)` only support local mode
     const reader = await ReaderFactory.create(path, readerOptions);
-    const projectSchema = await reader.getProjectSchema();
     if (projectSchema === undefined) {
       throw new Error(`Get manifest from project path ${path} failed`);
     }

--- a/packages/node/src/configure/SubqueryProject.ts
+++ b/packages/node/src/configure/SubqueryProject.ts
@@ -68,18 +68,21 @@ export class SubqueryProject {
 
   static async create(
     path: string,
-    projectSchema: unknown,
+    rawManifest: unknown,
+    reader: Reader,
     networkOverrides?: Partial<SubstrateProjectNetworkConfig>,
-    readerOptions?: ReaderOptions,
   ): Promise<SubqueryProject> {
-    // We have to use reader here, because path can be remote or local
+    // rawManifest and reader can be reused here.
+    // It has been pre-fetched and used for rebase manifest runner options with args
+    // in order to generate correct configs.
+
+    // But we still need reader here, because path can be remote or local
     // and the `loadProjectManifest(projectPath)` only support local mode
-    const reader = await ReaderFactory.create(path, readerOptions);
-    if (projectSchema === undefined) {
+    if (rawManifest === undefined) {
       throw new Error(`Get manifest from project path ${path} failed`);
     }
 
-    const manifest = parseSubstrateProjectManifest(projectSchema);
+    const manifest = parseSubstrateProjectManifest(rawManifest);
 
     if (manifest.isV0_0_1) {
       NOT_SUPPORT('0.0.1');

--- a/packages/node/src/configure/configure.module.ts
+++ b/packages/node/src/configure/configure.module.ts
@@ -2,18 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'assert';
-import path from 'path';
 import { DynamicModule, Global, Module } from '@nestjs/common';
-import { getProjectRootAndManifest, IPFS_REGEX } from '@subql/common';
+import { Reader, ReaderFactory } from '@subql/common';
 import { SubstrateProjectNetworkConfig } from '@subql/common-substrate';
 import {
   IConfig,
-  MinConfig,
   NodeConfig,
   getLogger,
   setLevel,
-  readRawManifest,
   rebaseArgsWithManifest,
+  defaultSubqueryName,
 } from '@subql/node-core';
 import { camelCase, last, omitBy, isNil } from 'lodash';
 import { yargsOptions } from '../yargs';
@@ -39,19 +37,6 @@ function yargsToIConfig(yargs: Args): Partial<IConfig> {
     acc[YargsNameMapping[key] ?? camelCase(key)] = value;
     return acc;
   }, {} as any);
-}
-function defaultSubqueryName(config: Partial<IConfig>): MinConfig {
-  const ipfsMatch = config.subquery.match(IPFS_REGEX);
-  return {
-    ...config,
-    subqueryName:
-      config.subqueryName ??
-      (ipfsMatch
-        ? config.subquery.replace(IPFS_REGEX, '')
-        : last(
-            getProjectRootAndManifest(config.subquery).root.split(path.sep),
-          )),
-  } as MinConfig;
 }
 
 // Check if a subquery name is a valid schema name
@@ -93,64 +78,24 @@ function warnDeprecations() {
 @Global()
 @Module({})
 export class ConfigureModule {
-  static async registerWithConfig(config: NodeConfig): Promise<DynamicModule> {
-    if (!validDbSchemaName(config.dbSchema)) {
-      process.exit(1);
-    }
-
-    if (config.debug) {
-      setLevel('debug');
-    }
-
-    const rawManifest = await readRawManifest(config.subquery, {
-      ipfs: config.ipfs,
-    });
-
-    const project = async () => {
-      const p = await SubqueryProject.create(
-        config.subquery,
-        rawManifest,
-        omitBy<SubstrateProjectNetworkConfig>(
-          {
-            endpoint: config.networkEndpoints,
-            dictionary: config.networkDictionary,
-          },
-          isNil,
-        ),
-        {
-          ipfs: config.ipfs,
-        },
-      ).catch((err) => {
-        logger.error(err, 'Create Subquery project from given path failed!');
-        process.exit(1);
-      });
-      return p;
-    };
-
-    return {
-      module: ConfigureModule,
-      providers: [
-        {
-          provide: NodeConfig,
-          useValue: config,
-        },
-        {
-          provide: SubqueryProject,
-          useFactory: project,
-        },
-      ],
-      exports: [NodeConfig, SubqueryProject],
-    };
-  }
   static async register(): Promise<DynamicModule> {
     const { argv } = yargsOptions;
     let config: NodeConfig;
     let rawManifest: unknown;
+    let reader: Reader;
+
+    // Override order : Sub-command/Args/Flags > Manifest Runner options > Default configs
+    // Therefore, we should rebase the manifest runner options with args first but not the config in the end
     if (argv.config) {
+      // get manifest options
       config = NodeConfig.fromFile(argv.config, yargsToIConfig(argv));
-      rawManifest = readRawManifest(config.subquery, {
+      reader = await ReaderFactory.create(config.subquery, {
         ipfs: config.ipfs,
       });
+      rawManifest = await reader.getProjectSchema();
+      rebaseArgsWithManifest(argv, rawManifest);
+      // use rebased argv generate config to override current config
+      config = NodeConfig.rebaseWithArgs(config, yargsToIConfig(argv));
     } else {
       if (!argv.subquery) {
         logger.error(
@@ -159,15 +104,15 @@ export class ConfigureModule {
         yargsOptions.showHelp();
         process.exit(1);
       }
-      rawManifest = await readRawManifest(argv.subquery, {
-        ipfs: argv.ipfs,
-      });
 
       warnDeprecations();
       assert(argv.subquery, 'subquery path is missing');
-
+      reader = await ReaderFactory.create(argv.subquery, {
+        ipfs: argv.ipfs,
+      });
+      rawManifest = await reader.getProjectSchema();
       rebaseArgsWithManifest(argv, rawManifest);
-
+      // Create new nodeConfig with rebased argv
       config = new NodeConfig(defaultSubqueryName(yargsToIConfig(argv)));
     }
 
@@ -183,6 +128,7 @@ export class ConfigureModule {
       const p = await SubqueryProject.create(
         argv.subquery,
         rawManifest,
+        reader,
         omitBy<SubstrateProjectNetworkConfig>(
           {
             endpoint: config.networkEndpoints,
@@ -190,9 +136,6 @@ export class ConfigureModule {
           },
           isNil,
         ),
-        {
-          ipfs: config.ipfs,
-        },
       ).catch((err) => {
         logger.error(err, 'Create Subquery project from given path failed!');
         process.exit(1);

--- a/packages/node/src/configure/configure.module.ts
+++ b/packages/node/src/configure/configure.module.ts
@@ -143,8 +143,6 @@ export class ConfigureModule {
       return p;
     };
 
-    project.name;
-
     return {
       module: ConfigureModule,
       providers: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4107,10 +4107,11 @@ __metadata:
     "@types/bn.js": 4.11.6
     "@types/js-yaml": ^4.0.4
     "@types/pino": ^6.3.12
-    class-transformer: 0.4.0
-    class-validator: ^0.13.2
     js-yaml: ^4.1.0
     reflect-metadata: ^0.1.13
+  peerDependencies:
+    class-transformer: "*"
+    class-validator: "*"
   languageName: unknown
   linkType: soft
 
@@ -4153,8 +4154,8 @@ __metadata:
     "@types/semver": ^7.3.9
     "@types/tar": ^6.1.1
     axios: ^0.27.2
-    class-transformer: 0.5.1
-    class-validator: ^0.13.2
+    class-transformer: ^0.5.1
+    class-validator: ^0.14.0
     fs-extra: ^10.1.0
     ipfs-http-client: ^52.0.3
     js-yaml: ^4.1.0
@@ -5207,6 +5208,13 @@ __metadata:
   version: 13.7.2
   resolution: "@types/validator@npm:13.7.2"
   checksum: e679261dd5392adfeb9b20ba2eaf7d668049ad03b24409a6921bb6a3ee4c3135d46cc536a0eafbbda7f642b196696a6e3e1e615b2d1194330d49b22f1f0acb59
+  languageName: node
+  linkType: hard
+
+"@types/validator@npm:^13.7.10":
+  version: 13.7.15
+  resolution: "@types/validator@npm:13.7.15"
+  checksum: 4e2c63d57c38def8c8308bea76140342c402527bf273fcdf13ae7d2bdd1b66942aecca8af9418ccf9e38780366d60e5d7dc6b9fe4a6aa74d3b85fec769fe195a
   languageName: node
   linkType: hard
 
@@ -7277,7 +7285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"class-transformer@npm:0.5.1":
+"class-transformer@npm:0.5.1, class-transformer@npm:^0.5.1":
   version: 0.5.1
   resolution: "class-transformer@npm:0.5.1"
   checksum: f191c8b4cc4239990f5efdd790cabdd852c243ed66248e39f6616a349c910c6eed2d9fd1fbf7ee6ea89f69b4f1d0b493b27347fe0cd0ae26b47c3745a805b6d3
@@ -7291,6 +7299,17 @@ __metadata:
     libphonenumber-js: ^1.9.43
     validator: ^13.7.0
   checksum: 0deb4c29faa18345f6989fd7eaaaa07b05caae5298603fcd6485531c6daad503e5d2b24cc1342e4fc88ae5ba0acffdc24d0fc333110ef3f21a667cd8a79e1258
+  languageName: node
+  linkType: hard
+
+"class-validator@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "class-validator@npm:0.14.0"
+  dependencies:
+    "@types/validator": ^13.7.10
+    libphonenumber-js: ^1.10.14
+    validator: ^13.7.0
+  checksum: f62e4a0ad24cee68f4b2bc70d32b96de90cb598f96bde362b4dbf4234151af8eb6ae225458312a38fc49fa3959844cf61c60e731a8205e9a570454cff8de2710
   languageName: node
   linkType: hard
 
@@ -12686,6 +12705,13 @@ __metadata:
     prelude-ls: ~1.1.2
     type-check: ~0.3.2
   checksum: 0d084a524231a8246bb10fec48cdbb35282099f6954838604f3c7fc66f2e16fa66fd9cc2f3f20a541a113c4dafdf181e822c887c8a319c9195444e6c64ac395e
+  languageName: node
+  linkType: hard
+
+"libphonenumber-js@npm:^1.10.14":
+  version: 1.10.28
+  resolution: "libphonenumber-js@npm:1.10.28"
+  checksum: 3a3aac653265751822b495d30c1196a072c52612fb2b7cf0efe38b0ad25a48df2a0bf2220fb7066af1a1734b9cd9ba78ddaf758da5194422bbb57c4c592c381a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

something undone: I tried to abstract this `SubstrateRunnerNodeImpl` with a `RunnerNodeBaseModel`, which include `version` and `options`, but options failed type validation because it is still `Object` class, and It should be `RunnerNodeOptionsModel`.

However it works with current implementation, this maybe we can take a look later.



Fixes https://github.com/subquery/subql/issues/1634

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
