### PR TITLE
Move polkadot util imports to utils package, fix api type

### DIFF
--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -21,7 +21,6 @@
     "@nestjs/common": "^8.2.6",
     "@nestjs/event-emitter": "^1.3.0",
     "@nestjs/schedule": "^1.0.2",
-    "@polkadot/api": "10.1.4",
     "@subql/apollo-links": "^0.3.3-1",
     "@subql/common": "workspace:*",
     "@subql/testing": "workspace:*",

--- a/packages/node-core/src/indexer/PoiBlock.ts
+++ b/packages/node-core/src/indexer/PoiBlock.ts
@@ -1,8 +1,7 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {u8aConcat, numberToU8a, hexToU8a, isHex, isU8a} from '@polkadot/util';
-import {blake2AsU8a} from '@polkadot/util-crypto';
+import {u8aConcat, numberToU8a, hexToU8a, isHex, isU8a, blake2AsU8a} from '@subql/utils';
 import {ProofOfIndex} from './entities/Poi.entity';
 
 const poiBlockHash = (

--- a/packages/node-core/src/indexer/StoreOperations.spec.ts
+++ b/packages/node-core/src/indexer/StoreOperations.spec.ts
@@ -1,8 +1,7 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {u8aToHex} from '@polkadot/util';
-import {GraphQLJsonFieldType} from '@subql/utils';
+import {GraphQLJsonFieldType, u8aToHex} from '@subql/utils';
 import {StoreOperations} from './StoreOperations';
 import {OperationType} from './types';
 

--- a/packages/node-core/src/indexer/StoreOperations.ts
+++ b/packages/node-core/src/indexer/StoreOperations.ts
@@ -1,9 +1,8 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {u8aConcat, u8aToBuffer, isString} from '@polkadot/util';
 import {Entity} from '@subql/types';
-import {getTypeByScalarName, GraphQLModelsType} from '@subql/utils';
+import {getTypeByScalarName, GraphQLModelsType, u8aConcat, u8aToBuffer, isString} from '@subql/utils';
 import MerkleTools from 'merkle-tools';
 import {OperationEntity, OperationType} from './types';
 

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -4,7 +4,7 @@
 import assert from 'assert';
 
 import {EventEmitter2} from '@nestjs/event-emitter';
-import {hexToU8a, u8aEq} from '@polkadot/util';
+import {hexToU8a, u8aEq} from '@subql/utils';
 import {
   DynamicDsService,
   IProjectNetworkConfig,

--- a/packages/node-core/src/indexer/indexer.manager.ts
+++ b/packages/node-core/src/indexer/indexer.manager.ts
@@ -25,6 +25,7 @@ export interface CustomHandler<K extends string = string, F = Record<string, unk
 }
 
 export abstract class BaseIndexerManager<
+  AS extends ApiService,
   A, // Api Type
   B, // Block Type
   DS extends BaseDataSource,
@@ -55,7 +56,7 @@ export abstract class BaseIndexerManager<
   protected abstract baseCustomHandlerFilter(kind: keyof FilterMap, data: any, baseFilter: any): boolean;
 
   constructor(
-    protected readonly apiService: ApiService,
+    protected readonly apiService: AS,
     protected readonly nodeConfig: NodeConfig,
     private sandboxService: {getDsProcessor: (ds: DS, api: A) => IndexerSandbox},
     private dsProcessorService: IDSProcessorService<CDS>,

--- a/packages/node-core/src/indexer/mmr.service.ts
+++ b/packages/node-core/src/indexer/mmr.service.ts
@@ -4,8 +4,8 @@
 import assert from 'assert';
 import fs from 'fs';
 import {Injectable, OnApplicationShutdown} from '@nestjs/common';
-import {u8aToHex, u8aEq} from '@polkadot/util';
 import {DEFAULT_WORD_SIZE, DEFAULT_LEAF, MMR_AWAIT_TIME} from '@subql/common';
+import {u8aToHex, u8aEq} from '@subql/utils';
 import {MMR, FileBasedDb} from '@subql/x-merkle-mountain-range';
 import {keccak256} from 'js-sha3';
 import {Sequelize} from 'sequelize';

--- a/packages/node-core/src/indexer/poi.service.ts
+++ b/packages/node-core/src/indexer/poi.service.ts
@@ -3,7 +3,7 @@
 
 import {isMainThread} from 'node:worker_threads';
 import {Injectable, OnApplicationShutdown} from '@nestjs/common';
-import {hexToU8a} from '@polkadot/util';
+import {hexToU8a} from '@subql/utils';
 import {StoreCacheService} from './storeCache';
 import {CachePoiModel} from './storeCache/cachePoi';
 

--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -3,10 +3,7 @@
 
 import assert from 'assert';
 import {Inject, Injectable} from '@nestjs/common';
-import {hexToU8a} from '@polkadot/util';
-import {blake2AsHex} from '@polkadot/util-crypto';
 import {getDbType, SUPPORT_DB} from '@subql/common';
-
 import {Entity, Store} from '@subql/types';
 import {
   GraphQLModelsRelationsEnums,
@@ -16,6 +13,8 @@ import {
   IndexType,
   METADATA_REGEX,
   MULTI_METADATA_REGEX,
+  hexToU8a,
+  blake2AsHex,
 } from '@subql/utils';
 import {camelCase, flatten, isEqual, upperFirst} from 'lodash';
 import {

--- a/packages/node-core/src/indexer/storeCache/cachePoi.ts
+++ b/packages/node-core/src/indexer/storeCache/cachePoi.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {u8aToBuffer} from '@polkadot/util';
+import {u8aToBuffer} from '@subql/utils';
 import {Op, Transaction} from 'sequelize';
 import {getLogger} from '../../logger';
 import {PoiRepo, ProofOfIndex} from '../entities';

--- a/packages/node-core/src/utils/graphql.ts
+++ b/packages/node-core/src/utils/graphql.ts
@@ -1,8 +1,17 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {isHex, hexToU8a, u8aToBuffer, u8aToHex, bufferToU8a, isBuffer, isNull} from '@polkadot/util';
-import {getTypeByScalarName, GraphQLModelsType} from '@subql/utils';
+import {
+  getTypeByScalarName,
+  GraphQLModelsType,
+  isHex,
+  hexToU8a,
+  u8aToBuffer,
+  u8aToHex,
+  bufferToU8a,
+  isBuffer,
+  isNull,
+} from '@subql/utils';
 import {ModelAttributes, ModelAttributeColumnOptions} from 'sequelize';
 
 export function modelsTypeToModelAttributes(modelType: GraphQLModelsType, enums: Map<string, string>): ModelAttributes {

--- a/packages/node-core/src/utils/sync-helper.ts
+++ b/packages/node-core/src/utils/sync-helper.ts
@@ -1,8 +1,7 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {blake2AsHex} from '@polkadot/util-crypto';
-import {hashName} from '@subql/utils';
+import {hashName, blake2AsHex} from '@subql/utils';
 import {QueryTypes, Sequelize, Utils} from 'sequelize';
 
 export interface SmartTags {

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -77,7 +77,6 @@ export class IndexerManager extends BaseIndexerManager<
       FilterTypeMap,
       ProcessorTypeMap,
     );
-    logger.info('indexer manager start');
   }
 
   async start(): Promise<void> {

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -46,6 +46,7 @@ const logger = getLogger('indexer');
 
 @Injectable()
 export class IndexerManager extends BaseIndexerManager<
+  ApiService,
   ApiAt,
   BlockContent,
   SubstrateDatasource,
@@ -108,7 +109,7 @@ export class IndexerManager extends BaseIndexerManager<
     block: BlockContent,
     runtimeVersion: RuntimeVersion,
   ): Promise<ApiAt> {
-    return this.apiService.api.getPatchedApi(block, runtimeVersion);
+    return this.apiService.getPatchedApi(block.block, runtimeVersion);
   }
 
   protected async processUnfinalizedBlocks(

--- a/packages/node/src/indexer/types.ts
+++ b/packages/node/src/indexer/types.ts
@@ -3,7 +3,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { ApiDecoration } from '@polkadot/api/types';
-import { HexString } from '@polkadot/util/types';
+import type { HexString } from '@polkadot/util/types';
 import {
   SubstrateBlock,
   SubstrateEvent,

--- a/packages/node/src/indexer/unfinalizedBlocks.service.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.ts
@@ -4,7 +4,7 @@
 import { Injectable } from '@nestjs/common';
 import { ApiPromise } from '@polkadot/api';
 import { Header } from '@polkadot/types/interfaces';
-import { HexString } from '@polkadot/util/types';
+import type { HexString } from '@polkadot/util/types';
 import { getLogger, NodeConfig, StoreCacheService } from '@subql/node-core';
 import { SubstrateBlock } from '@subql/types';
 import { last } from 'lodash';

--- a/packages/utils/src/buffer/buffer.ts
+++ b/packages/utils/src/buffer/buffer.ts
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export {
+  u8aEq,
+  hexToU8a,
+  bufferToU8a,
+  numberToU8a,
+  u8aToHex,
+  u8aConcat,
+  u8aToBuffer,
+  isU8a,
+  isHex,
+  isString,
+  isBuffer,
+  isNull,
+} from '@polkadot/util';
+
+export {blake2AsHex, blake2AsU8a} from '@polkadot/util-crypto';

--- a/packages/utils/src/buffer/index.ts
+++ b/packages/utils/src/buffer/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './buffer';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -5,3 +5,4 @@ export * from './graphql';
 export {levelFilter, Logger, LoggerOption} from './logger';
 export * from './query';
 export * from './types';
+export * from './buffer';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4170,7 +4170,6 @@ __metadata:
     "@nestjs/common": ^8.2.6
     "@nestjs/event-emitter": ^1.3.0
     "@nestjs/schedule": ^1.0.2
-    "@polkadot/api": 10.1.4
     "@subql/apollo-links": ^0.3.3-1
     "@subql/common": "workspace:*"
     "@subql/testing": "workspace:*"


### PR DESCRIPTION
# Description
Moves polkadot utils and utils-crypto from node-core to utils package to reduce chance of conflicting versions. 

Also fixes issue with api types resulting in not being able to get patched api