### PR TITLE
Fix Poi random missing mmr issue

### DIFF
--- a/packages/node-core/src/indexer/mmr.service.ts
+++ b/packages/node-core/src/indexer/mmr.service.ts
@@ -99,6 +99,9 @@ export class MmrService implements OnApplicationShutdown {
     }
     logger.info(`MMR database start with next block height at ${this.nextMmrBlockHeight}`);
     while (!this.isShutdown) {
+      console.log(
+        `const poiBlocks = await this.poi.getPoiBlocksByRange(this.nextMmrBlockHeight ${this.nextMmrBlockHeight})`
+      );
       const poiBlocks = await this.poi.getPoiBlocksByRange(this.nextMmrBlockHeight);
       if (poiBlocks.length !== 0) {
         for (const block of poiBlocks) {
@@ -108,6 +111,7 @@ export class MmrService implements OnApplicationShutdown {
               this._nextMmrBlockHeight = i + 1;
             }
           }
+          console.log(`this.appendMmrNode(${block.id})`);
           await this.appendMmrNode(block);
         }
       } else {
@@ -115,7 +119,6 @@ export class MmrService implements OnApplicationShutdown {
           'lastPoiHeight',
           'lastProcessedHeight',
         ]);
-
         // this.nextMmrBlockHeight means block before nextMmrBlockHeight-1 already exist in filebase mmr
         if (this.nextMmrBlockHeight > Number(lastPoiHeight) && this.nextMmrBlockHeight <= Number(lastProcessedHeight)) {
           for (let i = this.nextMmrBlockHeight; i <= Number(lastProcessedHeight); i++) {
@@ -159,6 +162,7 @@ export class MmrService implements OnApplicationShutdown {
   }
 
   private updatePoiMmrRoot(poiBlock: ProofOfIndex, mmrValue: Uint8Array): void {
+    console.log(`updatePoiMmrRoot ${poiBlock.id}, mmrValue: ${u8aToHex(mmrValue)}`);
     if (!poiBlock.mmrRoot) {
       poiBlock.mmrRoot = mmrValue;
       this.poi.set(poiBlock);

--- a/packages/node-core/src/indexer/mmr.service.ts
+++ b/packages/node-core/src/indexer/mmr.service.ts
@@ -99,9 +99,6 @@ export class MmrService implements OnApplicationShutdown {
     }
     logger.info(`MMR database start with next block height at ${this.nextMmrBlockHeight}`);
     while (!this.isShutdown) {
-      console.log(
-        `const poiBlocks = await this.poi.getPoiBlocksByRange(this.nextMmrBlockHeight ${this.nextMmrBlockHeight})`
-      );
       const poiBlocks = await this.poi.getPoiBlocksByRange(this.nextMmrBlockHeight);
       if (poiBlocks.length !== 0) {
         for (const block of poiBlocks) {
@@ -111,7 +108,6 @@ export class MmrService implements OnApplicationShutdown {
               this._nextMmrBlockHeight = i + 1;
             }
           }
-          console.log(`this.appendMmrNode(${block.id})`);
           await this.appendMmrNode(block);
         }
       } else {
@@ -162,7 +158,6 @@ export class MmrService implements OnApplicationShutdown {
   }
 
   private updatePoiMmrRoot(poiBlock: ProofOfIndex, mmrValue: Uint8Array): void {
-    console.log(`updatePoiMmrRoot ${poiBlock.id}, mmrValue: ${u8aToHex(mmrValue)}`);
     if (!poiBlock.mmrRoot) {
       poiBlock.mmrRoot = mmrValue;
       this.poi.set(poiBlock);

--- a/packages/node-core/src/indexer/storeCache/cachePoi.ts
+++ b/packages/node-core/src/indexer/storeCache/cachePoi.ts
@@ -26,11 +26,6 @@ export class CachePoiModel implements ICachedModelControl {
     if (this.setCache[proof.id] === undefined) {
       this.flushableRecordCounter += 1;
     }
-    if (proof.mmrRoot !== undefined) {
-      console.log(`------[cachePoi] update ${proof.id}`);
-    } else {
-      console.log(`------[cachePoi] set ${proof.id}`);
-    }
     this.setCache[proof.id] = proof;
   }
 


### PR DESCRIPTION
# Description

The issue is due to when we fetch `getPoiBlocksByRange`, we have to merge result from poi table and cache.

Then we update mmr value on the result (array of poi blocks)

During query the poi table, cache got flushed, and merged result are missing those data from cache.

This fixes make a copy of cache before query the table. 


draft fix, remove the logs later

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
