### PR TITLE
Fix indexed column check with historical

### DIFF
--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -598,6 +598,7 @@ export class StoreService {
         exclude: ['__id', '__block_range'],
       },
     });
+
     sequelizeModel.addHook('beforeFind', (options) => {
       (options.where as any).__block_range = {
         [Op.contains]: this.blockHeight as any,
@@ -787,9 +788,10 @@ group by
               (indexField) =>
                 upperFirst(camelCase(indexField.entityName)) === entity &&
                 camelCase(indexField.fieldName) === field &&
-                indexField.isUnique
+                // With historical indexes are not unique
+                (this.historical || indexField.isUnique)
             ) > -1;
-          assert(indexed, `to query by field ${String(field)}, an unique index must be created on model ${entity}`);
+          assert(indexed, `to query by field ${String(field)}, a unique index must be created on model ${entity}`);
           return this.storeCache.getModel<T>(entity).getOneByField(field, value);
         } catch (e) {
           throw new Error(`Failed to getOneByField Entity ${entity} with field ${String(field)}: ${e}`);


### PR DESCRIPTION
# Description
With historical enabled, any indexes use GiST which doesn't support unique. We had an assertion expecting a unique index, this change removes the unique check when historical is enabled

Fixes https://github.com/subquery/subql/issues/1518

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
