### PR TITLE
fix postMmrDb.get and mmrMigrate node sort

### DIFF
--- a/packages/node-core/src/indexer/mmrMigrate.service.ts
+++ b/packages/node-core/src/indexer/mmrMigrate.service.ts
@@ -88,7 +88,7 @@ export class MMRMigrateService {
         direction === MigrationDirection.FileToDb ? [fileBasedMMRDb, pgBasedMMRDb] : [pgBasedMMRDb, fileBasedMMRDb];
 
       const nodes = await source.getNodes();
-      const sortedEntries = Object.entries(nodes).sort(([a], [b]) => a.localeCompare(b));
+      const sortedEntries = Object.entries(nodes).sort(([a], [b]) => parseInt(a) - parseInt(b));
 
       const totalNodes = sortedEntries.length;
       let completedNodes = 0;

--- a/packages/node-core/src/indexer/postgresMmrDb.ts
+++ b/packages/node-core/src/indexer/postgresMmrDb.ts
@@ -51,7 +51,7 @@ export class PgBasedMMRDB implements Db {
   async get(key: number): Promise<any | null> {
     try {
       const record = await this.mmrIndexValueStore.findByPk(key);
-      return record ? record.toJSON() : null;
+      return record ? record.value : null;
     } catch (error) {
       throw new Error(`Failed to get MMR node ${key}: ${error}`);
     }


### PR DESCRIPTION
# Description
PostgresMmrDb.get() returns {key, value} object instead of the value buffer, fix it to return only the value. Also, fix the node sorting method in MmrMigrateService to sort numbers instead of string

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
