### PR TITLE
Add interval to flush the store cache

### DIFF
--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -54,6 +54,7 @@ export interface IConfig {
   readonly storeGetCacheSize: number;
   readonly storeCacheAsync: boolean;
   readonly scaleBatchSize?: boolean;
+  readonly storeFlushInterval: number;
 }
 
 export type MinConfig = Partial<Omit<IConfig, 'subquery'>> & Pick<IConfig, 'subquery'>;
@@ -79,6 +80,7 @@ const DEFAULT_CONFIG = {
   storeCacheThreshold: 1000,
   storeGetCacheSize: 500,
   storeCacheAsync: true,
+  storeFlushInterval: 5,
 };
 
 export class NodeConfig implements IConfig {
@@ -147,6 +149,10 @@ export class NodeConfig implements IConfig {
 
   get storeCacheAsync(): boolean {
     return !!this._config.storeCacheAsync;
+  }
+
+  get storeFlushInterval(): number {
+    return this.storeFlushInterval;
   }
 
   get dictionaryResolver(): string | undefined {

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -152,7 +152,7 @@ export class NodeConfig implements IConfig {
   }
 
   get storeFlushInterval(): number {
-    return this.storeFlushInterval;
+    return this._config.storeFlushInterval;
   }
 
   get dictionaryResolver(): string | undefined {

--- a/packages/node-core/src/indexer/storeCache/storeCache.service.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {EventEmitter2} from '@nestjs/event-emitter';
+import {SchedulerRegistry} from '@nestjs/schedule';
 import {Sequelize} from 'sequelize';
 import {NodeConfig} from '../../configure';
 import {StoreCacheService} from './storeCache.service';
@@ -62,7 +63,7 @@ describe('Store Cache Service historical', () => {
   const nodeConfig: NodeConfig = {} as any;
 
   beforeEach(() => {
-    storeService = new StoreCacheService(sequilize, nodeConfig, eventEmitter);
+    storeService = new StoreCacheService(sequilize, nodeConfig, eventEmitter, new SchedulerRegistry());
   });
 
   it('could init store cache service and init cache for models', () => {
@@ -256,7 +257,7 @@ describe('Store Cache flush with order', () => {
   const nodeConfig: NodeConfig = {} as any;
 
   beforeEach(() => {
-    storeService = new StoreCacheService(sequilize, nodeConfig, eventEmitter);
+    storeService = new StoreCacheService(sequilize, nodeConfig, eventEmitter, new SchedulerRegistry());
     storeService.init(false, true);
   });
 

--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -41,11 +41,13 @@ export class StoreCacheService implements BeforeApplicationShutdown {
   ) {
     this.storeCacheThreshold = config.storeCacheThreshold;
 
-    const interval = setInterval(
-      () => void this.flushCache(true, false),
-      config.storeFlushInterval * 1000 // Convert to miliseconds
+    this.schedulerRegistry.addInterval(
+      INTERVAL_NAME,
+      setInterval(
+        () => void this.flushCache(true, false),
+        config.storeFlushInterval * 1000 // Convert to miliseconds
+      )
     );
-    this.schedulerRegistry.addInterval(INTERVAL_NAME, interval);
   }
 
   init(historical: boolean, useCockroachDb: boolean): void {

--- a/packages/node-core/src/indexer/unfinalizedBlocks.service.spec.ts
+++ b/packages/node-core/src/indexer/unfinalizedBlocks.service.spec.ts
@@ -3,6 +3,7 @@
 
 // import { Header } from '@polkadot/types/interfaces';
 import {EventEmitter2} from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import {CacheMetadataModel, Header, StoreCacheService} from '@subql/node-core';
 import {
   METADATA_LAST_FINALIZED_PROCESSED_KEY,
@@ -233,7 +234,12 @@ describe('UnfinalizedBlocksService', () => {
   });
 
   it('can rewind any unfinalized blocks when restarted and unfinalized blocks is disabled', async () => {
-    const storeCache = new StoreCacheService(null as any, {storeCacheThreshold: 300} as any, new EventEmitter2());
+    const storeCache = new StoreCacheService(
+      null as any,
+      {storeCacheThreshold: 300} as any,
+      new EventEmitter2(),
+      new SchedulerRegistry(),
+    );
 
     storeCache.setRepos({} as any, undefined);
 

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import {
   SubstrateDatasourceKind,
   SubstrateHandlerKind,
@@ -144,7 +145,12 @@ function createIndexerManager(
   const dsProcessorService = new DsProcessorService(project, nodeConfig);
   const dynamicDsService = new DynamicDsService(dsProcessorService, project);
 
-  const storeCache = new StoreCacheService(sequilize, nodeConfig, eventEmitter);
+  const storeCache = new StoreCacheService(
+    sequilize,
+    nodeConfig,
+    eventEmitter,
+    new SchedulerRegistry(),
+  );
   const storeService = new StoreService(
     sequilize,
     nodeConfig,

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -4,8 +4,6 @@
 import { initLogger } from '@subql/node-core/logger';
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
-import { mmrRegenerateInit } from './subcommands/mmrRegenerate.init';
-import { reindexInit } from './subcommands/reindex.init';
 
 export const yargsOptions = yargs(hideBin(process.argv))
   .env('SUBQL_NODE')
@@ -346,6 +344,14 @@ export const yargsOptions = yargs(hideBin(process.argv))
       describe:
         'If enabled the store cache will flush data asyncronously relative to indexing data',
       type: 'boolean',
+    },
+    'store-flush-interval': {
+      demandOption: false,
+      describe:
+        'The interval, in seconds, at which data is flushed from the cache. ' +
+        'This ensures that data is persisted regularly when there is either not much data or the project is up to date.',
+      type: 'number',
+      default: 5,
     },
     subquery: {
       alias: 'f',


### PR DESCRIPTION
# Description
Sometimes data can take a while to be persisted from the cache if the threshold is not reached. This can happen when there's not much data on chain or the project is fully synced.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
