### PR TITLE
Fix metadata check, allow base indexer manager to parse abis with eth

### DIFF
--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -183,8 +183,7 @@ export abstract class BaseProjectService<DS extends {startBlock?: number}> imple
     } else {
       // Check if the configured genesisHash matches the currently stored genesisHash
       assert(
-        // Configured project yaml genesisHash only exists in specVersion v0.2.0, fallback to api fetched genesisHash on v0.0.1
-        (this.project.network.chainId ?? genesisHash) === existing.genesisHash,
+        genesisHash === existing.genesisHash,
         'Specified project manifest chain id / genesis hash does not match database stored genesis hash, consider cleaning project schema using --force-clean'
       );
     }

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -175,6 +175,14 @@ export class IndexerManager extends BaseIndexerManager<
     }
   }
 
+  protected prepareFilteredData<T = any>(
+    kind: SubstrateHandlerKind,
+    data: T,
+  ): T {
+    // Substrate doesn't need to do anything here
+    return data;
+  }
+
   protected baseCustomHandlerFilter(
     kind: SubstrateHandlerKind,
     data: any,


### PR DESCRIPTION
# Description
Make `BaseIndexerManager` more configurable so that we can parse ABIs with Ethereum

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
