### PR TITLE
Inject the chain id into sandboxes

### DIFF
--- a/packages/node-core/src/indexer/ds-processor.service.ts
+++ b/packages/node-core/src/indexer/ds-processor.service.ts
@@ -76,6 +76,7 @@ export abstract class BaseDsProcessorService<
         {
           root: this.project.root,
           entry: ds.processor.file,
+          chainId: this.project.network.chainId,
         },
         this.nodeConfig
       );

--- a/packages/node-core/src/indexer/sandbox.spec.ts
+++ b/packages/node-core/src/indexer/sandbox.spec.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import fs from 'fs';
 import * as path from 'path';
 import {NodeConfig} from '../configure/NodeConfig';
 import {IndexerSandbox} from './sandbox';
@@ -21,6 +20,7 @@ describe('sandbox for subql-node', () => {
         store: undefined,
         root,
         entry,
+        chainId: '1',
         // script: fs.readFileSync(path.join(root, entry)).toString(),
       },
       new NodeConfig({subquery: ' ', subqueryName: ' '})

--- a/packages/node-core/src/indexer/sandbox.ts
+++ b/packages/node-core/src/indexer/sandbox.ts
@@ -16,6 +16,7 @@ export interface SandboxOption {
   store?: Store;
   root: string;
   entry: string;
+  chainId: string;
 }
 
 const DEFAULT_OPTION = (unsafe = false): NodeVMOptions => {
@@ -53,6 +54,8 @@ export class Sandbox extends NodeVM {
     );
     this.root = config.subquery.startsWith('ipfs://') ? '' : option.root;
     this.entry = option.entry;
+
+    this.freeze(option.chainId, 'chainId');
 
     const sourceMapFile = path.join(this.root, this.entry);
 

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -59,6 +59,7 @@ export abstract class TestingService<B, DS> {
       const option: SandboxOption = {
         root: this.project.root,
         entry: file,
+        chainId: this.project.network.chainId,
       };
 
       return new TestSandbox(option, this.nodeConfig);

--- a/packages/node/src/indexer/sandbox.service.ts
+++ b/packages/node/src/indexer/sandbox.service.ts
@@ -39,6 +39,7 @@ export class SandboxService<Api> {
           store,
           root: this.project.root,
           entry,
+          chainId: this.project.network.chainId,
         },
         this.nodeConfig,
       );
@@ -48,6 +49,7 @@ export class SandboxService<Api> {
     if (this.nodeConfig.unsafe) {
       processor.freeze(this.apiService.api, 'unsafeApi');
     }
+    processor.freeze(this.project.network.chainId, 'chainId');
     return processor;
   }
 

--- a/packages/types/src/global.ts
+++ b/packages/types/src/global.ts
@@ -12,5 +12,6 @@ declare global {
   const api: ApiAt;
   const logger: Pino.Logger;
   const store: Store;
+  const chainId: string;
   const createDynamicDatasource: DynamicDatasourceCreator;
 }


### PR DESCRIPTION
# Description
For multichain projects it is common to need to know what chain a handler is run on so that it can associate data to that chain. To do this we now set the chainId globally within the sandbox.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation (https://github.com/subquery/documentation/pull/330)
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
