### PR TITLE
Fix flush init before metadata repo set

### DIFF
--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -40,14 +40,6 @@ export class StoreCacheService implements BeforeApplicationShutdown {
     private schedulerRegistry: SchedulerRegistry
   ) {
     this.storeCacheThreshold = config.storeCacheThreshold;
-
-    this.schedulerRegistry.addInterval(
-      INTERVAL_NAME,
-      setInterval(
-        () => void this.flushCache(true, false),
-        config.storeFlushInterval * 1000 // Convert to miliseconds
-      )
-    );
   }
 
   init(historical: boolean, useCockroachDb: boolean): void {
@@ -63,6 +55,16 @@ export class StoreCacheService implements BeforeApplicationShutdown {
   setRepos(meta: MetadataRepo, poi?: PoiRepo): void {
     this.metadataRepo = meta;
     this.poiRepo = poi;
+
+    // Add flush interval after repos been set,
+    // otherwise flush could not find lastProcessHeight from metadata
+    this.schedulerRegistry.addInterval(
+      INTERVAL_NAME,
+      setInterval(
+        () => void this.flushCache(true, false),
+        this.config.storeFlushInterval * 1000 // Convert to miliseconds
+      )
+    );
   }
 
   getModel<T>(entity: string): ICachedModel<T> {


### PR DESCRIPTION
# Description

Fix issue

Database transaction failed Error: Metadata entity has not been set on store cache
(node:23076) UnhandledPromiseRejectionWarning: Error: Metadata entity has not been set on store cache


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
