### PR TITLE
Fix initial dictionary check before lastBufferedHeight is set

### DIFF
--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -35,7 +35,7 @@ export interface IBlockDispatcher {
 
   queueSize: number;
   freeSize: number;
-  latestBufferedHeight: number | undefined;
+  latestBufferedHeight: number;
   smartBatchSize: number;
   minimumHeapLimit: number;
 

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -102,7 +102,7 @@ export abstract class BaseFetchService<
       !!this.project.network.dictionary &&
       this.dictionaryMetaValid &&
       !!this.dictionaryService.getDictionaryQueryEntries(
-        this.blockDispatcher.latestBufferedHeight ??
+        this.blockDispatcher.latestBufferedHeight ||
           Math.min(...this.project.dataSources.map((ds) => ds.startBlock).filter(hasValue))
       ).length
     );


### PR DESCRIPTION
# Description
The validation for using the dictionary would always be false at the start as the `lastBufferedHeight` was expected to be undefined but was 0. This would cause the logging `Dictionary start height 41191168 is beyond indexing height 801, skipping dictionary for now` to be skipped

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
