### PR TITLE
strict codegen

### DIFF
--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -22,7 +22,7 @@ export class <%= props.className %> implements Entity {
     }
 
 <% props.fields.forEach(function(field){ %>
-    public <%= field.name %><%= field.required ? "" : "?" %>: <%= field.type %><%= field.isArray ? "[]" : "" %>;
+    public <%= field.name %><%= field.required ? "!" : "?" %>: <%= field.type %><%= field.isArray ? "[]" : "" %>;
 <% }); %>
 
     get _name(): string {

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -17,12 +17,18 @@ export type <%= props.className %>Props = Omit<<%=props.className %>, NonNullabl
 
 export class <%= props.className %> implements Entity {
 
-    constructor(id: string) {
-        this.id = id;
+    constructor(
+        <% props.fields.forEach(function(field) { if (field.required) { %>
+            <%= field.name %>: <%= field.type %>,<% } %>
+        <% }) %>
+    ) {
+        <% props.fields.filter(function(field) {return field.required === true;}).forEach(function(requiredField) { %>
+            this.<%= requiredField.name %> = <%= requiredField.name %>;
+        <% }) %>
     }
 
 <% props.fields.forEach(function(field){ %>
-    public <%= field.name %><%= field.required ? "!" : "?" %>: <%= field.type %><%= field.isArray ? "[]" : "" %>;
+    public <%= field.name %><%= field.required ? "" : "?" %>: <%= field.type %><%= field.isArray ? "[]" : "" %>;
 <% }); %>
 
     get _name(): string {
@@ -67,7 +73,10 @@ export class <%= props.className %> implements Entity {
 
     static create(record: <%= props.className %>Props): <%=props.className %> {
         assert(typeof record.id === 'string', "id must be provided");
-        let entity = new this(record.id);
+        let entity = new this(
+        <% props.fields.filter(function(field) {return field.required === true;}).forEach(function(requiredField) { %>
+            record.<%= requiredField.name %>,
+        <% }) %>);
         Object.assign(entity,record);
         return entity;
     }


### PR DESCRIPTION
# Description
Update `subql codegen` code to be compatible with strict typescript
Fixes https://github.com/subquery/subql/issues/1689

This will be a breaking change,
for all project that uses

e.g.
```
  let record = new StarterEntity(block.block.header.hash.toString());
```
would not build, all required fields must be added to the constructor when using `new`

https://github.com/subquery/subql-starter/pull/80

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- Breaking change
## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
