### PR TITLE
Dont exit when dictionary resolver fails

### DIFF
--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -164,7 +164,7 @@ export class DictionaryService implements OnApplicationShutdown {
   ) {}
 
   async init(): Promise<void> {
-    let link: ApolloLink;
+    let link: ApolloLink = new HttpLink({uri: this.dictionaryEndpoint, fetch});
 
     if (this.nodeConfig.dictionaryResolver) {
       try {
@@ -174,11 +174,8 @@ export class DictionaryService implements OnApplicationShutdown {
           httpOptions: {fetch},
         });
       } catch (e: any) {
-        logger.error(e.message);
-        process.exit(1);
+        logger.error(e, 'Failed to resolve network dictionary');
       }
-    } else {
-      link = new HttpLink({uri: this.dictionaryEndpoint, fetch});
     }
 
     this._client = new ApolloClient({

--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -156,7 +156,7 @@ export class DictionaryService implements OnApplicationShutdown {
   protected _startHeight?: number;
 
   constructor(
-    readonly dictionaryEndpoint: string,
+    readonly dictionaryEndpoint: string | undefined,
     readonly chainId: string,
     protected readonly nodeConfig: NodeConfig,
     protected readonly metadataKeys = ['lastProcessedHeight', 'genesisHash'], // Cosmos uses chain instead of genesisHash


### PR DESCRIPTION
# Description
Instead of exiting the indexer when authHttpLink fails, we will use the centralised dictionary instead.

This is a quick fix, longer term auth link will not throw an error and instead handle falling back to a centralized endpoint.

Fixes https://github.com/subquery/subql/issues/1720

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
