### PR TITLE
Use bulkCreate instead of upsert to improve perf with cockroach

### DIFF
--- a/packages/node-core/src/indexer/storeCache/cacheModel.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.ts
@@ -251,15 +251,11 @@ export class CachedModel<
       }
 
       dbOperation = Promise.all([
-        // We need to use upsert instead of bulkCreate for cockroach db
-        // see this https://github.com/subquery/subql/issues/1606
         records.length &&
-          (this.useCockroachDb
-            ? records.map((r) => this.model.upsert(r, {transaction: tx}))
-            : this.model.bulkCreate(records, {
-                transaction: tx,
-                updateOnDuplicate: Object.keys(records[0]) as unknown as (keyof T)[],
-              })),
+          this.model.bulkCreate(records, {
+            transaction: tx,
+            updateOnDuplicate: Object.keys(records[0]) as unknown as (keyof T)[],
+          }),
         Object.keys(removeRecords).length &&
           this.model.destroy({where: {id: Object.keys(removeRecords)} as any, transaction: tx}),
       ]);


### PR DESCRIPTION
# Description
Uses `bulkCreate` instead of `upsert` when using cockroach db. Currently this path will only happen when an entity has no relation. Entities with relations are inserted in order of their operation and that currently uses `flushOperation` rather than `flush`.

Operations:
![Screenshot 2023-05-17 at 2 34 47 PM](https://github.com/subquery/subql/assets/3432810/0af6ae68-c38d-4cd1-afa3-174edcd7f151)

There is also another minor change that when force flushing we will check if there is anything to flush.

Fixes https://github.com/subquery/subql/issues/1606

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
