### PR TITLE
don't intialize store and indexer inside testing service

### DIFF
--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -69,8 +69,6 @@ export abstract class TestingService<B, DS> {
   abstract indexBlock(block: B, handler: string): Promise<void>;
 
   async init() {
-    await this.indexerManager.start();
-
     logger.info(`Found ${this.testSandboxes.length} test files`);
 
     await Promise.all(
@@ -134,8 +132,6 @@ export abstract class TestingService<B, DS> {
         await this.sequelize.createSchema(`"${schema}"`, {});
       }
 
-      const modelRelations = getAllEntitiesRelations(this.project.schema);
-      await this.storeService.init(modelRelations, schema);
       this.storeService.setBlockHeight(test.blockHeight);
       const store = this.storeService.getStore();
       sandbox.freeze(store, 'store');


### PR DESCRIPTION
# Description
IndexerManager and StoreService are initalized by default when nestjs app starts. Initializing them once again manually inside TestingService leads to Schedule Registry Intervals being duplicated and throws error.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
