### PR TITLE
Fix datasource processors base filters not working

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix datasource processors base filters not working (#1745)
 
 ## [2.2.2] - 2023-05-19
 ### Fixed

--- a/packages/node-core/src/indexer/indexer.manager.ts
+++ b/packages/node-core/src/indexer/indexer.manager.ts
@@ -183,7 +183,9 @@ export abstract class BaseIndexerManager<
       }
     } else if (this.isCustomDs(ds)) {
       const handlers = this.filterCustomDsHandlers<K>(ds, data, this.processorMap[kind], (data, baseFilter) => {
-        return this.filterMap[kind](data, baseFilter, ds);
+        if (!baseFilter.length) return true;
+
+        return baseFilter.find((filter) => this.filterMap[kind](data, filter, ds));
       });
 
       for (const handler of handlers) {
@@ -198,7 +200,7 @@ export abstract class BaseIndexerManager<
     ds: CDS, //SubstrateCustomDataSource<string, SubstrateNetworkFilter>,
     data: HandlerInputMap[K],
     baseHandlerCheck: ProcessorMap[K],
-    baseFilter: (data: HandlerInputMap[K], baseFilter: any) => boolean
+    baseFilter: (data: HandlerInputMap[K], baseFilter: any[]) => boolean
   ): CustomHandler[] {
     const plugin = this.dsProcessorService.getDsProcessor(ds);
 
@@ -206,7 +208,6 @@ export abstract class BaseIndexerManager<
       .filter((handler) => {
         const processor = plugin.handlerProcessors[handler.kind];
         if (baseHandlerCheck(processor)) {
-          processor.baseFilter;
           return baseFilter(data, processor.baseFilter);
         }
         return false;


### PR DESCRIPTION
# Description
In a recent change we generalised base filters for datasource processors. Because the types are not strong in this area we accidentally shifted from filtering many to filtering one. This corrects the problem

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
