### PR TITLE
allow url in sandbox and set URL global

### DIFF
--- a/packages/node-core/src/indexer/sandbox.ts
+++ b/packages/node-core/src/indexer/sandbox.ts
@@ -53,6 +53,7 @@ export class Sandbox extends NodeVM {
       })
     );
 
+    // polkadot api uses URL global
     this.setGlobal('URL', require('url').URL);
     this.root = config.subquery.startsWith('ipfs://') ? '' : option.root;
     this.entry = option.entry;

--- a/packages/node-core/src/indexer/sandbox.ts
+++ b/packages/node-core/src/indexer/sandbox.ts
@@ -25,7 +25,7 @@ const DEFAULT_OPTION = (unsafe = false): NodeVMOptions => {
     wasm: unsafe,
     sandbox: {},
     require: {
-      builtin: unsafe ? ['*'] : ['assert', 'buffer', 'crypto', 'util', 'path'],
+      builtin: unsafe ? ['*'] : ['assert', 'buffer', 'crypto', 'util', 'path', 'url'],
       external: true,
       context: 'sandbox',
     },
@@ -52,6 +52,8 @@ export class Sandbox extends NodeVM {
         },
       })
     );
+
+    this.setGlobal('URL', require('url').URL);
     this.root = config.subquery.startsWith('ipfs://') ? '' : option.root;
     this.entry = option.entry;
 


### PR DESCRIPTION
# Description
polkadot api uses URL global and the sandbox does not expose it. Expose URL global in sandbox to be consistent with polkadot api

Fixes #1701 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
