### PR TITLE
Fix subcommand escaped issue

### DIFF
--- a/packages/node/src/main.ts
+++ b/packages/node/src/main.ts
@@ -16,14 +16,33 @@ initLogger(
 // Lazy import, to allow logger to be initialised before bootstrap()
 // As bootstrap runs services that requires logger
 const { bootstrap } = require('./init');
-if (
-  !(
-    argv._[0] === 'test' ||
-    argv._[0] === 'mmr-migrate' ||
-    argv._[0] === 'mmr-regen' ||
-    argv._[0] === 'force-clean' ||
-    argv._[0] === 'reindex'
-  )
-) {
-  void bootstrap();
+const { forceCleanInit } = require('./subcommands/forceClean.init');
+const { mmrMigrateInit } = require('./subcommands/mmrMigrate.init');
+const { mmrRegenerateInit } = require('./subcommands/mmrRegenerate.init');
+const { reindexInit } = require('./subcommands/reindex.init');
+const { testingInit } = require('./subcommands/testing.init');
+
+switch (argv._[0]) {
+  case 'test':
+    void testingInit();
+    break;
+  case 'mmr-migrate':
+    void mmrMigrateInit(argv.direction);
+    break;
+  case 'mmr-regen':
+    void mmrRegenerateInit(
+      argv.probe,
+      argv.resetOnly,
+      argv.unsafe,
+      argv.targetHeight,
+    );
+    break;
+  case 'force-clean':
+    void forceCleanInit();
+    break;
+  case 'reindex':
+    void reindexInit(argv.targetHeight);
+    break;
+  default:
+    void bootstrap();
 }

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -1,10 +1,8 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { initLogger } from '@subql/node-core/logger';
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
-import { mmrRegenerateInit } from './subcommands/mmrRegenerate.init';
 
 export const yargsOptions = yargs(hideBin(process.argv))
   .env('SUBQL_NODE')
@@ -12,16 +10,8 @@ export const yargsOptions = yargs(hideBin(process.argv))
     command: 'test',
     describe: 'Run tests for a SubQuery application',
     builder: {},
-    handler: (argv) => {
-      initLogger(
-        argv.debug as boolean,
-        argv.outputFmt as 'json' | 'colored',
-        argv.logLevel as string | undefined,
-      );
-      // lazy import to make sure logger is instantiated before all other services
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { testingInit } = require('./subcommands/testing.init');
-      return testingInit();
+    handler: () => {
+      // handled in main.ts
     },
   })
   .command({
@@ -29,17 +19,8 @@ export const yargsOptions = yargs(hideBin(process.argv))
     describe:
       'Clean the database dropping project schemas and tables. Once the command is executed, the application would exit upon completion.',
     builder: {},
-    handler: (argv) => {
-      initLogger(
-        argv.debug as boolean,
-        argv.outputFmt as 'json' | 'colored',
-        argv.logLevel as string | undefined,
-      );
-
-      // lazy import to make sure logger is instantiated before all other services
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { forceCleanInit } = require('./subcommands/forceClean.init');
-      return forceCleanInit();
+    handler: () => {
+      // handled in main.ts
     },
   })
   .command({
@@ -52,16 +33,8 @@ export const yargsOptions = yargs(hideBin(process.argv))
         description: 'set targetHeight',
         require: true,
       }),
-    handler: (argv) => {
-      initLogger(
-        argv.debug as boolean,
-        argv.outputFmt as 'json' | 'colored',
-        argv.logLevel as string | undefined,
-      );
-      // lazy import to make sure logger is instantiated before all other services
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { reindexInit } = require('./subcommands/reindex.init');
-      return reindexInit(argv.targetHeight);
+    handler: () => {
+      // handled in main.ts
     },
   })
   .command({
@@ -96,22 +69,8 @@ export const yargsOptions = yargs(hideBin(process.argv))
           default: false,
         },
       }),
-    handler: (argv) => {
-      initLogger(
-        argv.debug as boolean,
-        argv.outputFmt as 'json' | 'colored',
-        argv.logLevel as string | undefined,
-      );
-
-      // lazy import to make sure logger is instantiated before all other services
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { mmrRegenerateInit } = require('./subcommands/mmrRegenerate.init');
-      return mmrRegenerateInit(
-        argv.probe,
-        argv.resetOnly,
-        argv.unsafe,
-        argv.targetHeight,
-      );
+    handler: () => {
+      // handled in main.ts
     },
   })
   .command({
@@ -127,16 +86,8 @@ export const yargsOptions = yargs(hideBin(process.argv))
           default: 'dbToFile',
         },
       }),
-    handler: (argv) => {
-      initLogger(
-        argv.debug as boolean,
-        argv.outputFmt as 'json' | 'colored',
-        argv.logLevel as string | undefined,
-      );
-      // lazy import to make sure logger is instantiated before all other services
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { mmrMigrateInit } = require('./subcommands/mmrMigrate.init');
-      return mmrMigrateInit(argv.direction);
+    handler: () => {
+      // handled in main.ts
     },
   })
   // Note we must have default command $0 at last to avoid override


### PR DESCRIPTION
# Description

Fix issue app skipped subcommand issue. This was due to require yargsOptions in main.ts, suppose trigger handler first, but got escaped with if conditions. 



<img width="1473" alt="image" src="https://github.com/subquery/subql/assets/10431657/3e0fcac5-31da-4665-9d84-25eb76d03e65">



Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
