### PR TITLE
Fix subcommand could escape, set profiler at init

### DIFF
--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -228,7 +228,7 @@ export class DictionaryService implements OnApplicationShutdown {
    * @param conditions
    */
 
-  @profiler(/*yargsOptions.argv.profiler*/)
+  @profiler()
   async getDictionary(
     startBlock: number,
     queryEndBlock: number,

--- a/packages/node-core/src/profiler.ts
+++ b/packages/node-core/src/profiler.ts
@@ -16,9 +16,15 @@ function printCost(start: number, end: number, target: string, method: string | 
   logger.info(`${target}, ${method.toString()}, ${end - start} ms`);
 }
 
-export function profiler(enabled = true): MethodDecorator {
+let enableProfiler = false;
+
+export function setProfiler(enabled: boolean): void {
+  enableProfiler = enabled;
+}
+
+export function profiler(): MethodDecorator {
   return (target, name: string | symbol, descriptor: PropertyDescriptor): void => {
-    if (enabled && !!descriptor && typeof descriptor.value === 'function') {
+    if (enableProfiler && !!descriptor && typeof descriptor.value === 'function') {
       const orig = descriptor.value;
       // tslint:disable no-function-expression no-invalid-this
       descriptor.value = function (...args: any[]): any {

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -30,7 +30,6 @@ import {
 } from '@subql/types';
 import { SubqlProjectDs } from '../configure/SubqueryProject';
 import * as SubstrateUtil from '../utils/substrate';
-import { yargsOptions } from '../yargs';
 import { ApiService } from './api.service';
 import {
   asSecondLayerHandlerProcessor_1_0_0,
@@ -85,7 +84,7 @@ export class IndexerManager extends BaseIndexerManager<
     logger.info('indexer manager started');
   }
 
-  @profiler(yargsOptions.argv.profiler)
+  @profiler()
   async indexBlock(
     block: BlockContent,
     dataSources: SubstrateDatasource[],

--- a/packages/node/src/indexer/runtime/base-runtime.service.ts
+++ b/packages/node/src/indexer/runtime/base-runtime.service.ts
@@ -1,13 +1,12 @@
 // Copyright 2020-2021 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { Injectable, OnApplicationShutdown } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ApiPromise } from '@polkadot/api';
 import { RuntimeVersion } from '@polkadot/types/interfaces';
 import { profiler } from '@subql/node-core';
 import { SubstrateBlock } from '@subql/types';
 import * as SubstrateUtil from '../../utils/substrate';
-import { yargsOptions } from '../../yargs';
 import { ApiService } from '../api.service';
 import { SpecVersion } from './../dictionary.service';
 export const SPEC_VERSION_BLOCK_GAP = 100;
@@ -74,7 +73,7 @@ export abstract class BaseRuntimeService {
     return specVersion;
   }
 
-  @profiler(yargsOptions.argv.profiler)
+  @profiler()
   async prefetchMeta(height: number): Promise<void> {
     const blockHash = await this.api.rpc.chain.getBlockHash(height);
     if (

--- a/packages/node/src/indexer/runtime/runtimeService.ts
+++ b/packages/node/src/indexer/runtime/runtimeService.ts
@@ -3,7 +3,6 @@
 
 import { Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { profiler } from '@subql/node-core';
-import { yargsOptions } from '../../yargs';
 import { ApiService } from '../api.service';
 import {
   DictionaryService,
@@ -73,7 +72,7 @@ export class RuntimeService
   }
 
   // the specVersion is always undefined
-  @profiler(yargsOptions.argv.profiler)
+  @profiler()
   async specChanged(height: number, specVersion?: number): Promise<boolean> {
     if (specVersion === undefined) {
       const { blockSpecVersion } = await this.getSpecVersion(height);

--- a/packages/node/src/main.ts
+++ b/packages/node/src/main.ts
@@ -1,29 +1,10 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { initLogger } from '@subql/node-core/logger';
 import { yargsOptions } from './yargs';
 
 const { argv } = yargsOptions;
 
-// initLogger is imported from true path, to make sure getLogger (or other logger values that relies on logger) isn't initialised
-initLogger(
-  argv.debug,
-  argv.outputFmt as 'json' | 'colored',
-  argv.logLevel as string | undefined,
-);
-
-// Lazy import, to allow logger to be initialised before bootstrap()
-// As bootstrap runs services that requires logger
-const { bootstrap } = require('./init');
-if (
-  !(
-    argv._[0] === 'test' ||
-    argv._[0] === 'mmr-migrate' ||
-    argv._[0] === 'mmr-regen' ||
-    argv._[0] === 'force-clean' ||
-    argv._[0] === 'reindex'
-  )
-) {
-  void bootstrap();
-}
+// Lazy import, to allow logger in yargsOptions to be initialised before setProfiler()
+const { setProfiler } = require('@subql/node-core');
+setProfiler(argv.profiler);

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -204,18 +204,6 @@ export const yargsOptions = yargs(hideBin(process.argv))
           type: 'string',
           choices: ['json', 'colored'],
         },
-        profiler: {
-          demandOption: false,
-          describe: 'Show profiler information to console output',
-          type: 'boolean',
-          default: false,
-        },
-        'proof-of-index': {
-          demandOption: false,
-          describe: 'Enable/disable proof of index',
-          type: 'boolean',
-          default: false,
-        },
         'query-limit': {
           demandOption: false,
           describe:
@@ -348,6 +336,18 @@ export const yargsOptions = yargs(hideBin(process.argv))
       describe: 'The port the service will bind to',
       type: 'number',
     },
+    profiler: {
+      demandOption: false,
+      describe: 'Show profiler information to console output',
+      type: 'boolean',
+      default: false,
+    },
+    'proof-of-index': {
+      demandOption: false,
+      describe: 'Enable/disable proof of index',
+      type: 'boolean',
+      default: false,
+    },
     'pg-ca': {
       demandOption: false,
       describe:
@@ -380,4 +380,5 @@ export const yargsOptions = yargs(hideBin(process.argv))
       type: 'boolean',
       default: false,
     },
-  });
+  })
+  .strict();

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -4,7 +4,6 @@
 import { initLogger } from '@subql/node-core/logger';
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
-import { mmrRegenerateInit } from './subcommands/mmrRegenerate.init';
 
 export const yargsOptions = yargs(hideBin(process.argv))
   .env('SUBQL_NODE')
@@ -292,8 +291,16 @@ export const yargsOptions = yargs(hideBin(process.argv))
           type: 'number',
         },
       }),
-    handler: () => {
-      // Do nothing here, main logic will be triggered from main.ts
+    handler: (argv) => {
+      initLogger(
+        argv.debug as boolean,
+        argv.outputFmt as 'json' | 'colored',
+        argv.logLevel as string | undefined,
+      );
+      // lazy import to make sure logger is instantiated before all other services
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { bootstrap } = require('./init');
+      void bootstrap();
     },
   })
   // Default options, shared with all command

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -380,5 +380,4 @@ export const yargsOptions = yargs(hideBin(process.argv))
       type: 'boolean',
       default: false,
     },
-  })
-  .strict();
+  });


### PR DESCRIPTION
# Description

Fixed subcommand could escape from app init


Also moved setup profiler from app init

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
