### PR TITLE
Add cache layer to postgres mmr db

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add cache layer to postgres mmr db (#1762)
 
 ## [2.3.1] - 2023-05-26
 ### Fixed

--- a/packages/node-core/src/indexer/entities/Mmr.entitiy.ts
+++ b/packages/node-core/src/indexer/entities/Mmr.entitiy.ts
@@ -69,7 +69,23 @@ export class PgBasedMMRDB implements Db {
     }
   }
 
-  async delete(key: string): Promise<void> {
+  async bulkSet(entries: Record<number, any>): Promise<void> {
+    const data = Object.entries(entries).map(([key, value]) => {
+      if (value === null || value === undefined) {
+        throw new Error(`Cannot set a null or undefined value for key: ${key}`);
+      }
+      // Parse to work around Object.entries converting all keys to string
+      return {key: parseInt(key, 10), value};
+    });
+
+    try {
+      await this.mmrIndexValueStore.bulkCreate(data);
+    } catch (error) {
+      throw new Error(`Failed to bulk store MMR Node: ${error}`);
+    }
+  }
+
+  async delete(key: number): Promise<void> {
     try {
       await this.mmrIndexValueStore.destroy({where: {key}});
     } catch (error) {

--- a/packages/node-core/src/indexer/entities/index.ts
+++ b/packages/node-core/src/indexer/entities/index.ts
@@ -3,3 +3,4 @@
 
 export * from './Poi.entity';
 export * from './Metadata.entity';
+export * from './Mmr.entitiy';

--- a/packages/node-core/src/indexer/index.ts
+++ b/packages/node-core/src/indexer/index.ts
@@ -15,7 +15,6 @@ export * from './dictionary.service';
 export * from './sandbox';
 export * from './smartBatch.service';
 export * from './blockDispatcher';
-export * from './postgresMmrDb';
 export * from './dynamic-ds.service';
 export * from './testing.service';
 export * from './project.service';

--- a/packages/node-core/src/indexer/mmr.service.ts
+++ b/packages/node-core/src/indexer/mmr.service.ts
@@ -14,9 +14,8 @@ import {MmrPayload, MmrProof} from '../events';
 import {ensureProofOfIndexId, PlainPoiModel, PoiInterface} from '../indexer/poi';
 import {getLogger} from '../logger';
 import {delay, getExistingProjectSchema} from '../utils';
-import {ProofOfIndex} from './entities';
-import {PgBasedMMRDB} from './postgresMmrDb';
-import {StoreCacheService} from './storeCache';
+import {ProofOfIndex, PgBasedMMRDB} from './entities';
+import {StoreCacheService, CachePgMmrDb} from './storeCache';
 const logger = getLogger('mmr');
 
 const keccak256Hash = (...nodeValues: Uint8Array[]) => Buffer.from(keccak256(Buffer.concat(nodeValues)), 'hex');
@@ -259,8 +258,8 @@ export class MmrService implements OnApplicationShutdown {
   private async ensurePostgresBasedMmr(): Promise<MMR> {
     const schema = await getExistingProjectSchema(this.nodeConfig, this.sequelize);
     assert(schema, 'Unable to check for MMR table, schema is undefined');
-    const postgresBasedDb = await PgBasedMMRDB.create(this.sequelize, schema);
-    return new MMR(keccak256Hash, postgresBasedDb);
+    const db = await CachePgMmrDb.create(this.sequelize, schema);
+    return new MMR(keccak256Hash, db);
   }
 
   async getMmr(blockHeight: number): Promise<MmrPayload> {

--- a/packages/node-core/src/indexer/storeCache/cacheMmr.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMmr.spec.ts
@@ -1,0 +1,92 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {PgBasedMMRDB} from '../entities/Mmr.entitiy';
+import {CachePgMmrDb} from './cacheMmr';
+
+const getMockDb = () => {
+  let leafLength = 0;
+  let nodes: Record<number, Uint8Array> = {};
+
+  return {
+    getLeafLength: () => Promise.resolve(leafLength),
+    setLeafLength: (length: number) => Promise.resolve((leafLength = length)),
+    get: (key: number) => Promise.resolve(nodes[key]),
+    set: (value: Uint8Array, key: number) => Promise.resolve((nodes[key] = value)),
+    bulkSet: (entries: Record<string, Uint8Array>) => {
+      nodes = {...nodes, ...entries};
+    },
+    getNodes: () => Promise.resolve(nodes),
+    delete: (key: number) => delete nodes[key],
+  } as any as PgBasedMMRDB;
+};
+
+describe('CacheMMR', () => {
+  let cacheDb: CachePgMmrDb;
+  let db: PgBasedMMRDB;
+
+  beforeEach(() => {
+    db = getMockDb();
+    cacheDb = new CachePgMmrDb(db);
+  });
+
+  it('can getLeafLength', async () => {
+    const spy = jest.spyOn(db, 'getLeafLength');
+
+    expect(await cacheDb.getLeafLength()).toBe(0);
+    expect(spy).toBeCalledTimes(1);
+
+    await cacheDb.setLeafLength(100);
+
+    expect(await cacheDb.getLeafLength()).toBe(100);
+    expect(spy).toBeCalledTimes(1);
+  });
+
+  it('can setLeafLength', async () => {
+    const spy = jest.spyOn(db, 'setLeafLength');
+
+    await cacheDb.setLeafLength(100);
+    expect(spy).toBeCalledTimes(1);
+  });
+
+  it('can get from cache', async () => {
+    const spy = jest.spyOn(db, 'get');
+
+    await cacheDb.set(new Uint8Array(4), 100);
+
+    expect(await cacheDb.get(100)).toBeDefined();
+    expect(spy).toBeCalledTimes(0);
+  });
+
+  it('can get from db', async () => {
+    const spy = jest.spyOn(db, 'get');
+
+    await db.set(new Uint8Array(4), 100);
+
+    expect(await cacheDb.get(100)).toBeDefined();
+    expect(spy).toBeCalledTimes(1);
+  });
+
+  it('can get nodes from db', async () => {
+    const spy = jest.spyOn(db, 'getNodes');
+
+    await db.getNodes();
+    expect(spy).toBeCalledTimes(1);
+  });
+
+  it('can set to db', async () => {
+    const spy = jest.spyOn(db, 'set');
+    const spyBulk = jest.spyOn(db, 'bulkSet');
+
+    // Nothing will be set on the first entry
+    await cacheDb.set(new Uint8Array(0), 0);
+    expect(spy).toBeCalledTimes(0);
+
+    // We bulk set every 10 items so we add 9 more
+    for (let i = 1; i < 10; i++) {
+      await cacheDb.set(new Uint8Array(i), i);
+    }
+
+    expect(spyBulk).toBeCalledTimes(1);
+  });
+});

--- a/packages/node-core/src/indexer/storeCache/cacheMmr.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMmr.spec.ts
@@ -70,7 +70,7 @@ describe('CacheMMR', () => {
   it('can get nodes from db', async () => {
     const spy = jest.spyOn(db, 'getNodes');
 
-    await db.getNodes();
+    await cacheDb.getNodes();
     expect(spy).toBeCalledTimes(1);
   });
 
@@ -88,5 +88,34 @@ describe('CacheMMR', () => {
     }
 
     expect(spyBulk).toBeCalledTimes(1);
+  });
+
+  it('can delete nodes from caches', async () => {
+    const spy = jest.spyOn(db, 'getNodes');
+
+    for (let i = 0; i < 10; i++) {
+      await db.set(new Uint8Array(i), i);
+    }
+
+    // Inserts from db into cache
+    await cacheDb.get(1);
+    // Insert into set cache
+    await cacheDb.set(new Uint8Array(11), 11);
+
+    await cacheDb.delete(1);
+    await cacheDb.delete(11);
+
+    expect(await cacheDb.get(1)).not.toBeDefined();
+    expect(await cacheDb.get(11)).not.toBeDefined();
+
+    expect(await db.get(1)).not.toBeDefined();
+  });
+
+  it('can get cached items when getting all nodes', async () => {
+    for (let i = 1; i <= 15; i++) {
+      await cacheDb.set(new Uint8Array(i), i);
+    }
+
+    expect(Object.keys(await cacheDb.getNodes()).length).toBe(15);
   });
 });

--- a/packages/node-core/src/indexer/storeCache/cacheMmr.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMmr.ts
@@ -1,0 +1,78 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {Db} from '@subql/x-merkle-mountain-range';
+import LRUCache from 'lru-cache';
+import {Sequelize} from 'sequelize';
+import {PgBasedMMRDB} from '../entities/Mmr.entitiy';
+
+const cacheOptions = {
+  max: 100, // default value
+  ttl: 1000 * 60 * 60, // in ms
+  updateAgeOnGet: true, // we want to keep most used record in cache longer
+};
+
+export class CachePgMmrDb implements Db {
+  private leafLength?: number;
+
+  private cacheData = new LRUCache<number, Uint8Array>(cacheOptions);
+  private setData: Record<number, Uint8Array> = {};
+
+  constructor(
+    private db: PgBasedMMRDB,
+    // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+    public readonly setThreshold = 10
+  ) {}
+
+  static async create(sequelize: Sequelize, schema: string): Promise<CachePgMmrDb> {
+    const db = await PgBasedMMRDB.create(sequelize, schema);
+
+    return new CachePgMmrDb(db);
+  }
+
+  async set(value: Uint8Array, key: number): Promise<void> {
+    this.cacheData.set(key, value);
+    this.setData[key] = value;
+
+    if (Object.keys(this.setData).length >= this.setThreshold) {
+      const data = {...this.setData};
+      this.setData = {};
+      await this.db.bulkSet(data);
+    }
+  }
+
+  async get(key: number): Promise<Uint8Array | null> {
+    const result = this.cacheData.get(key);
+
+    if (result) return result;
+
+    const dbResult = await this.db.get(key);
+    if (dbResult) {
+      this.cacheData.set(key, dbResult);
+    }
+    return dbResult;
+  }
+
+  async delete(key: number): Promise<void> {
+    await this.db.delete(key);
+    this.cacheData.delete(key);
+  }
+
+  async getLeafLength(): Promise<number> {
+    if (this.leafLength === undefined) {
+      this.leafLength = await this.db.getLeafLength();
+    }
+    return this.leafLength;
+  }
+
+  async setLeafLength(length: number): Promise<number> {
+    this.leafLength = length;
+
+    await this.db.setLeafLength(length);
+    return length;
+  }
+
+  async getNodes(): Promise<Record<number, Uint8Array>> {
+    return this.db.getNodes();
+  }
+}

--- a/packages/node-core/src/indexer/storeCache/cacheMmr.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMmr.ts
@@ -56,6 +56,7 @@ export class CachePgMmrDb implements Db {
   async delete(key: number): Promise<void> {
     await this.db.delete(key);
     this.cacheData.delete(key);
+    delete this.setData[key];
   }
 
   async getLeafLength(): Promise<number> {
@@ -73,6 +74,6 @@ export class CachePgMmrDb implements Db {
   }
 
   async getNodes(): Promise<Record<number, Uint8Array>> {
-    return this.db.getNodes();
+    return {...(await this.db.getNodes()), ...this.setData};
   }
 }

--- a/packages/node-core/src/indexer/storeCache/index.ts
+++ b/packages/node-core/src/indexer/storeCache/index.ts
@@ -5,3 +5,4 @@ export * from './storeCache.service';
 export * from './types';
 export * from './cacheModel';
 export * from './cacheMetadata';
+export * from './cacheMmr';


### PR DESCRIPTION
# Description
Adds a cache layer to the MMR DB to improve performance when there is network latency. 

- LRU cache for getting nodes 
- Cache length of leaves
- Cache set items are flushed in bulk (defaults to 10 items)

Part 1 of https://github.com/subquery/subql/issues/1758

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
