### PR TITLE
Handle entitiy not found, flush cache after running handler

### DIFF
--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -119,7 +119,7 @@ export abstract class TestingService<B, DS> {
 
   private async runTest(test: SubqlTest, sandbox: TestSandbox) {
     logger.info(`Starting test: ${test.name}`);
-    const schema = `test-${this.nodeConfig.dbSchema}`;
+    const schema = this.nodeConfig.dbSchema;
 
     try {
       // Fetch block

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -119,7 +119,7 @@ export abstract class TestingService<B, DS> {
 
   private async runTest(test: SubqlTest, sandbox: TestSandbox) {
     logger.info(`Starting test: ${test.name}`);
-    const schema = `test-${this.nodeConfig.subqueryName}`;
+    const schema = `test-${this.nodeConfig.dbSchema}`;
 
     try {
       // Fetch block

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -144,6 +144,7 @@ export abstract class TestingService<B, DS> {
 
       try {
         await this.indexBlock(block, test.handler);
+        await this.storeService.storeCache.flushCache(true, true);
       } catch (e: any) {
         this.totalFailedTests += test.expectedEntities.length;
         logger.warn(`Test: ${test.name} field due to runtime error`, e);
@@ -164,21 +165,24 @@ export abstract class TestingService<B, DS> {
         const expectedEntity = test.expectedEntities[i];
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const actualEntity = await store.get(expectedEntity._name!, expectedEntity.id);
-        const attributes = actualEntity as unknown as CreationAttributes<Model>;
-        const failedAttributes: string[] = [];
-        let passed = true;
-        Object.keys(attributes).map((attr) => {
-          const expectedAttr = (expectedEntity as Record<string, any>)[attr] ?? null;
-          const actualAttr = (actualEntity as Record<string, any>)[attr];
-          if (!isEqual(expectedAttr, actualAttr)) {
-            passed = false;
-            failedAttributes.push(
-              `\t\tattribute: "${attr}":\n\t\t\texpected: "${expectedAttr}"\n\t\t\tactual:   "${actualAttr}"\n`
-            );
-          }
-        });
 
-        if (passed) {
+        const failedAttributes: string[] = [];
+        if (!actualEntity) {
+          failedAttributes.push(`\t\tExpected entity was not found`);
+        } else {
+          const attributes = actualEntity;
+          Object.keys(attributes).map((attr) => {
+            const expectedAttr = (expectedEntity as Record<string, any>)[attr] ?? null;
+            const actualAttr = (actualEntity as Record<string, any>)[attr];
+            if (!isEqual(expectedAttr, actualAttr)) {
+              failedAttributes.push(
+                `\t\tattribute: "${attr}":\n\t\t\texpected: "${expectedAttr}"\n\t\t\tactual:   "${actualAttr}"\n`
+              );
+            }
+          });
+        }
+
+        if (!failedAttributes.length) {
           logger.info(`Entity check PASSED (Entity ID: ${expectedEntity.id})`);
           passedTests++;
         } else {

--- a/packages/node/src/configure/configure.module.ts
+++ b/packages/node/src/configure/configure.module.ts
@@ -120,12 +120,25 @@ export class ConfigureModule {
       return p;
     };
 
+    //append `test-` dbSchema if test sub-command is called
+    const proxyConfig = new Proxy(config, {
+      get: function (target, property, receiver) {
+        if (property === 'dbSchema') {
+          if (argv._[0] === 'test') {
+            const originalGetter = Reflect.get(target, property, receiver);
+            return `test-${originalGetter}`;
+          }
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
     return {
       module: ConfigureModule,
       providers: [
         {
           provide: NodeConfig,
-          useValue: config,
+          useValue: proxyConfig,
         },
         {
           provide: 'ISubqueryProject',

--- a/packages/node/src/configure/configure.module.ts
+++ b/packages/node/src/configure/configure.module.ts
@@ -61,18 +61,20 @@ export class ConfigureModule {
     let rawManifest: unknown;
     let reader: Reader;
 
+    const isTest = argv._[0] === 'test';
+
     // Override order : Sub-command/Args/Flags > Manifest Runner options > Default configs
     // Therefore, we should rebase the manifest runner options with args first but not the config in the end
     if (argv.config) {
       // get manifest options
-      config = NodeConfig.fromFile(argv.config, yargsToIConfig(argv));
+      config = NodeConfig.fromFile(argv.config, yargsToIConfig(argv), isTest);
       reader = await ReaderFactory.create(config.subquery, {
         ipfs: config.ipfs,
       });
       rawManifest = await reader.getProjectSchema();
       rebaseArgsWithManifest(argv, rawManifest);
       // use rebased argv generate config to override current config
-      config = NodeConfig.rebaseWithArgs(config, yargsToIConfig(argv));
+      config = NodeConfig.rebaseWithArgs(config, yargsToIConfig(argv), isTest);
     } else {
       if (!argv.subquery) {
         logger.error(
@@ -90,7 +92,10 @@ export class ConfigureModule {
       rawManifest = await reader.getProjectSchema();
       rebaseArgsWithManifest(argv, rawManifest);
       // Create new nodeConfig with rebased argv
-      config = new NodeConfig(defaultSubqueryName(yargsToIConfig(argv)));
+      config = new NodeConfig(
+        defaultSubqueryName(yargsToIConfig(argv)),
+        isTest,
+      );
     }
 
     if (!validDbSchemaName(config.dbSchema)) {
@@ -120,25 +125,12 @@ export class ConfigureModule {
       return p;
     };
 
-    //append `test-` dbSchema if test sub-command is called
-    const proxyConfig = new Proxy(config, {
-      get: function (target, property, receiver) {
-        if (property === 'dbSchema') {
-          if (argv._[0] === 'test') {
-            const originalGetter = Reflect.get(target, property, receiver);
-            return `test-${originalGetter}`;
-          }
-        }
-        return Reflect.get(target, property, receiver);
-      },
-    });
-
     return {
       module: ConfigureModule,
       providers: [
         {
           provide: NodeConfig,
-          useValue: proxyConfig,
+          useValue: config,
         },
         {
           provide: 'ISubqueryProject',


### PR DESCRIPTION
# Description
Handles when an entity doesn't exist in the DB and returns an appropriate error. It also will flush the cache to ensure the data exists in the DB so that constraint checks are run

Fixes https://github.com/subquery/subql/issues/1763

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
