### PR TITLE
fix workers failed to start

### DIFF
--- a/packages/node/src/main.ts
+++ b/packages/node/src/main.ts
@@ -1,10 +1,31 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { initLogger } from '@subql/node-core/logger';
 import { yargsOptions } from './yargs';
 
 const { argv } = yargsOptions;
 
-// Lazy import, to allow logger in yargsOptions to be initialised before setProfiler()
+// initLogger is imported from true path, to make sure getLogger (or other logger values that relies on logger) isn't initialised
+initLogger(
+  argv.debug,
+  argv.outputFmt as 'json' | 'colored',
+  argv.logLevel as string | undefined,
+);
+
 const { setProfiler } = require('@subql/node-core');
 setProfiler(argv.profiler);
+
+// Lazy import, to allow logger to be initialised before bootstrap()
+// As bootstrap runs services that requires logger
+const { bootstrap } = require('./init');
+if (
+  !(
+    argv._[0] === 'test' ||
+    argv._[0] === 'mmr-migrate' ||
+    argv._[0] === 'mmr-regen' ||
+    argv._[0] === 'force-clean'
+  )
+) {
+  void bootstrap();
+}

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -279,16 +279,8 @@ export const yargsOptions = yargs(hideBin(process.argv))
           type: 'number',
         },
       }),
-    handler: (argv) => {
-      initLogger(
-        argv.debug as boolean,
-        argv.outputFmt as 'json' | 'colored',
-        argv.logLevel as string | undefined,
-      );
-      // lazy import to make sure logger is instantiated before all other services
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { bootstrap } = require('./init');
-      void bootstrap();
+    handler: () => {
+      // boostrap trigger in main.ts
     },
   })
   // Default options, shared with all command


### PR DESCRIPTION
# Description

Fixes workers failed to start, due to worker thread also called configure module and it import yargsOption. 
And it get into default command bootstrap again.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
