### PR TITLE
Update to latest vm2

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add cache layer to postgres mmr db (#1762)
 
+### Changed
+- Update vm2 past problimatic version
+
 ## [2.3.1] - 2023-05-26
 ### Fixed
 - Improve mmr error and expose ready status (#1752)

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -39,7 +39,7 @@
     "sequelize": "6.28.0",
     "source-map": "^0.7.4",
     "tar": "^6.1.11",
-    "vm2": "3.9.17",
+    "vm2": "^3.9.19",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4197,7 +4197,7 @@ __metadata:
     sequelize: 6.28.0
     source-map: ^0.7.4
     tar: ^6.1.11
-    vm2: 3.9.17
+    vm2: ^3.9.19
     yargs: ^16.2.0
   languageName: unknown
   linkType: soft
@@ -17914,15 +17914,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vm2@npm:3.9.17":
-  version: 3.9.17
-  resolution: "vm2@npm:3.9.17"
+"vm2@npm:^3.9.19":
+  version: 3.9.19
+  resolution: "vm2@npm:3.9.19"
   dependencies:
     acorn: ^8.7.0
     acorn-walk: ^8.2.0
   bin:
     vm2: bin/vm2
-  checksum: 9a03740a40ab2be5e3348a95fb31512da1a3c85318febb07e5299fa103ff05bcd7b6f458211fa38a1281dc27beccd04ff90355fc1d34fe2ee6ca10d0bb8c6f35
+  checksum: fc6cf553134145cd7bb5246985bf242b056e3fb5ea71e2eef6710b2a5d6c6119cc6bc960435ff62480ee82efb43369be8f4db07b6690916ae7d3b2e714f395d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
VM2 had a release with a breaking bug in it https://github.com/patriksimek/vm2/releases/tag/3.9.18

They have since fixed the issue with https://github.com/patriksimek/vm2/releases/tag/3.9.19

Fixes https://github.com/subquery/subql/issues/1710

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
