### PR TITLE
Fixes workers each creating their own temp dir to pull content from ifps

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update vm2 past problimatic version
+- Add optional root option to config (#1771)
 
 ## [2.3.1] - 2023-05-26
 ### Fixed

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -55,6 +55,7 @@ export interface IConfig {
   readonly storeCacheAsync: boolean;
   readonly scaleBatchSize?: boolean;
   readonly storeFlushInterval: number;
+  readonly root?: string;
 }
 
 export type MinConfig = Partial<Omit<IConfig, 'subquery'>> & Pick<IConfig, 'subquery'>;
@@ -289,6 +290,10 @@ export class NodeConfig implements IConfig {
       logger.error(e, 'Unable to get postgres client cert');
       throw e;
     }
+  }
+
+  get root(): string | undefined {
+    return this._config.root;
   }
 
   merge(config: Partial<IConfig>): this {

--- a/packages/node-core/src/indexer/worker/worker.builder.ts
+++ b/packages/node-core/src/indexer/worker/worker.builder.ts
@@ -187,7 +187,7 @@ export class Worker<T extends AsyncMethods> extends WorkerIO {
     path: string,
     workerFns: (keyof T)[],
     hostFns: H,
-    root?: string
+    root: string
   ): Worker<T> & T {
     const argv = argsWithRoot(root);
     const worker = new Worker(

--- a/packages/node-core/src/indexer/worker/worker.builder.ts
+++ b/packages/node-core/src/indexer/worker/worker.builder.ts
@@ -189,10 +189,9 @@ export class Worker<T extends AsyncMethods> extends WorkerIO {
     hostFns: H,
     root: string
   ): Worker<T> & T {
-    const argv = argsWithRoot(root);
     const worker = new Worker(
       new workers.Worker(path, {
-        argv,
+        argv: [...process.argv, '--root', root],
       }),
       workerFns,
       hostFns
@@ -209,12 +208,4 @@ export class Worker<T extends AsyncMethods> extends WorkerIO {
   async terminate(): Promise<number> {
     return this.worker.terminate();
   }
-}
-
-// Replaces the project path with a root.
-// This is so that workers can used the local temp files if its originally from IPFS or GitHub
-function argsWithRoot(root?: string) {
-  if (!root) return process.argv;
-
-  return [...process.argv, '--root', root];
 }

--- a/packages/node-core/src/indexer/worker/worker.builder.ts
+++ b/packages/node-core/src/indexer/worker/worker.builder.ts
@@ -186,11 +186,13 @@ export class Worker<T extends AsyncMethods> extends WorkerIO {
   static create<T extends AsyncMethods, H extends AsyncMethods>(
     path: string,
     workerFns: (keyof T)[],
-    hostFns: H
+    hostFns: H,
+    root?: string
   ): Worker<T> & T {
+    const argv = argsWithRoot(root);
     const worker = new Worker(
       new workers.Worker(path, {
-        argv: process.argv,
+        argv,
       }),
       workerFns,
       hostFns
@@ -207,4 +209,12 @@ export class Worker<T extends AsyncMethods> extends WorkerIO {
   async terminate(): Promise<number> {
     return this.worker.terminate();
   }
+}
+
+// Replaces the project path with a root.
+// This is so that workers can used the local temp files if its originally from IPFS or GitHub
+function argsWithRoot(root?: string) {
+  if (!root) return process.argv;
+
+  return [...process.argv, '--root', root];
 }

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -4,7 +4,16 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import {DEFAULT_PORT, findAvailablePort, GithubReader, IPFSReader, LocalReader, Reader} from '@subql/common';
+import {
+  BaseCustomDataSource,
+  BaseDataSource,
+  DEFAULT_PORT,
+  findAvailablePort,
+  GithubReader,
+  IPFSReader,
+  LocalReader,
+  Reader,
+} from '@subql/common';
 import {getAllEntitiesRelations} from '@subql/utils';
 import {isNumber, range, uniq, without, flatten} from 'lodash';
 import {QueryTypes, Sequelize} from 'sequelize';
@@ -100,6 +109,49 @@ export async function getEnumDeprecated(sequelize: Sequelize, enumTypeNameDeprec
   return resultsDeprecated;
 }
 
+type IsCustomDs<DS, CDS> = (x: DS | CDS) => x is CDS;
+export type SubqlProjectDs<DS extends BaseDataSource> = DS & {
+  mapping: DS['mapping'] & {entryScript: string};
+};
+
+export async function updateDataSourcesV1_0_0<DS extends BaseDataSource, CDS extends DS & BaseCustomDataSource>(
+  _dataSources: (DS | CDS)[],
+  reader: Reader,
+  root: string,
+  isCustomDs: IsCustomDs<DS, CDS>
+): Promise<SubqlProjectDs<DS | CDS>[]> {
+  // force convert to updated ds
+  return Promise.all(
+    _dataSources.map(async (dataSource) => {
+      const entryScript = await loadDataSourceScript(reader, dataSource.mapping.file);
+      const file = await updateDataSourcesEntry(reader, dataSource.mapping.file, root, entryScript);
+      if (isCustomDs(dataSource)) {
+        if (dataSource.processor) {
+          dataSource.processor.file = await updateProcessor(reader, root, dataSource.processor.file);
+        }
+        if (dataSource.assets) {
+          for (const [, asset] of dataSource.assets) {
+            if (reader instanceof LocalReader) {
+              asset.file = path.resolve(root, asset.file);
+            } else {
+              asset.file = await saveFile(reader, root, asset.file, '');
+            }
+          }
+        }
+        return {
+          ...dataSource,
+          mapping: {...dataSource.mapping, entryScript, file},
+        };
+      } else {
+        return {
+          ...dataSource,
+          mapping: {...dataSource.mapping, entryScript, file},
+        };
+      }
+    })
+  );
+}
+
 export async function updateDataSourcesEntry(
   reader: Reader,
   file: string,
@@ -108,9 +160,7 @@ export async function updateDataSourcesEntry(
 ): Promise<string> {
   if (reader instanceof LocalReader) return file;
   else if (reader instanceof IPFSReader || reader instanceof GithubReader) {
-    const outputPath = `${path.resolve(root, file.replace('ipfs://', ''))}.js`;
-    await fs.promises.writeFile(outputPath, script);
-    return outputPath;
+    return saveFile(reader, root, file, script);
   }
   throw new Error('Un-known reader type');
 }
@@ -119,14 +169,32 @@ export async function updateProcessor(reader: Reader, root: string, file: string
   if (reader instanceof LocalReader) {
     return path.resolve(root, file);
   } else {
-    const res = await reader.getFile(file);
-    if (!res) {
-      throw new Error(`Unable to read file ${file}`);
-    }
-    const outputPath = `${path.resolve(root, file.replace('ipfs://', ''))}.js`;
-    await fs.promises.writeFile(outputPath, res);
+    return fetchAndSaveFile(reader, root, file);
+  }
+}
+
+export async function fetchAndSaveFile(reader: Reader, root: string, file: string, ext = 'js'): Promise<string> {
+  if (!(reader instanceof IPFSReader || reader instanceof GithubReader)) {
+    throw new Error('Only IPFS and Github readers can save remote files');
+  }
+  const res = await reader.getFile(file);
+  if (!res) {
+    throw new Error(`Unable to read file ${file}`);
+  }
+  return saveFile(reader, root, file, res, ext);
+}
+
+export async function saveFile(reader: Reader, root: string, file: string, data: string, ext = 'js'): Promise<string> {
+  if (!(reader instanceof IPFSReader || reader instanceof GithubReader)) {
+    throw new Error('Only IPFS and Github readers can save remote files');
+  }
+  const resolved = path.resolve(root, file.replace('ipfs://', ''));
+  const outputPath = ext ? `${resolved}.${ext}` : resolved;
+  if (fs.existsSync(outputPath)) {
     return outputPath;
   }
+  await fs.promises.writeFile(outputPath, data);
+  return outputPath;
 }
 
 export async function loadDataSourceScript(reader: Reader, file?: string): Promise<string> {

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Workers creating their own temp dir for IPFS based projects (#1771)
 
 ## [2.4.1] - 2023-05-26
 ### Fixed

--- a/packages/node/src/configure/configure.module.ts
+++ b/packages/node/src/configure/configure.module.ts
@@ -113,6 +113,7 @@ export class ConfigureModule {
           },
           isNil,
         ),
+        config.root,
       ).catch((err) => {
         logger.error(err, 'Create Subquery project from given path failed!');
         process.exit(1);

--- a/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
@@ -35,7 +35,7 @@ async function createIndexerWorker(
   store: Store,
   dynamicDsService: IDynamicDsService<SubstrateDatasource>,
   unfinalizedBlocksService: IUnfinalizedBlocksService<BlockContent>,
-  root?: string,
+  root: string,
 ): Promise<IndexerWorker> {
   const indexerWorker = Worker.create<
     IInitIndexerWorker,

--- a/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
@@ -35,6 +35,7 @@ async function createIndexerWorker(
   store: Store,
   dynamicDsService: IDynamicDsService<SubstrateDatasource>,
   unfinalizedBlocksService: IUnfinalizedBlocksService<BlockContent>,
+  root?: string,
 ): Promise<IndexerWorker> {
   const indexerWorker = Worker.create<
     IInitIndexerWorker,
@@ -71,6 +72,7 @@ async function createIndexerWorker(
           unfinalizedBlocksService,
         ),
     },
+    root,
   );
 
   await indexerWorker.initWorker();
@@ -113,6 +115,7 @@ export class WorkerBlockDispatcherService
           storeService.getStore(),
           dynamicDsService,
           unfinalizedBlocksSevice,
+          project.root,
         ),
     );
   }

--- a/packages/node/src/utils/project.ts
+++ b/packages/node/src/utils/project.ts
@@ -6,25 +6,15 @@ import path from 'path';
 import { LocalReader, Reader, loadFromJsonOrYaml } from '@subql/common';
 import {
   ChainTypes,
-  isCustomDs,
   parseChainTypes,
   SubstrateRuntimeHandler,
   SubstrateCustomHandler,
   SubstrateHandler,
   SubstrateHandlerKind,
 } from '@subql/common-substrate';
-import {
-  loadDataSourceScript,
-  updateDataSourcesEntry,
-  updateProcessor,
-} from '@subql/node-core';
-import {
-  SubstrateCustomDatasource,
-  SubstrateRuntimeDatasource,
-} from '@subql/types';
+import { saveFile } from '@subql/node-core';
 import yaml from 'js-yaml';
 import { NodeVM, VMScript } from 'vm2';
-import { SubqlProjectDs } from '../configure/SubqueryProject';
 
 export function isBaseHandler(
   handler: SubstrateHandler,
@@ -36,61 +26,6 @@ export function isCustomHandler(
   handler: SubstrateHandler,
 ): handler is SubstrateCustomHandler {
   return !isBaseHandler(handler);
-}
-
-export async function updateDataSourcesV1_0_0(
-  _dataSources: (SubstrateRuntimeDatasource | SubstrateCustomDatasource)[],
-  reader: Reader,
-  root: string,
-): Promise<SubqlProjectDs[]> {
-  // force convert to updated ds
-  return Promise.all(
-    _dataSources.map(async (dataSource) => {
-      const entryScript = await loadDataSourceScript(
-        reader,
-        dataSource.mapping.file,
-      );
-      const file = await updateDataSourcesEntry(
-        reader,
-        dataSource.mapping.file,
-        root,
-        entryScript,
-      );
-      if (isCustomDs(dataSource)) {
-        if (dataSource.processor) {
-          dataSource.processor.file = await updateProcessor(
-            reader,
-            root,
-            dataSource.processor.file,
-          );
-        }
-        if (dataSource.assets) {
-          for (const [, asset] of dataSource.assets) {
-            if (reader instanceof LocalReader) {
-              asset.file = path.resolve(root, asset.file);
-            } else {
-              const res = await reader.getFile(asset.file);
-              const outputPath = path.resolve(
-                root,
-                asset.file.replace('ipfs://', ''),
-              );
-              await fs.promises.writeFile(outputPath, res as string);
-              asset.file = outputPath;
-            }
-          }
-        }
-        return {
-          ...dataSource,
-          mapping: { ...dataSource.mapping, entryScript, file },
-        };
-      } else {
-        return {
-          ...dataSource,
-          mapping: { ...dataSource.mapping, entryScript, file },
-        };
-      }
-    }),
-  );
 }
 
 export async function getChainTypes(
@@ -113,11 +48,7 @@ export async function getChainTypes(
       raw = yaml.load(res);
       return parseChainTypes(raw);
     } catch (e) {
-      const chainTypesPath = `${path.resolve(
-        root,
-        file.replace('ipfs://', ''),
-      )}.js`;
-      await fs.promises.writeFile(chainTypesPath, res);
+      const chainTypesPath = await saveFile(reader, root, file, res);
       raw = loadChainTypesFromJs(chainTypesPath); //root not required, as it been packed in single js
       return parseChainTypes(raw);
     }

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -143,142 +143,150 @@ export const yargsOptions = yargs(hideBin(process.argv))
     command: '$0', //default command
     describe: 'Index a SubQuery application',
     builder: (yargs) =>
-      yargs.options({
-        'batch-size': {
-          demandOption: false,
-          describe: 'Batch size of blocks to fetch in one round',
-          type: 'number',
-        },
-        'dictionary-resolver': {
-          demandOption: false,
-          describe: 'Use SubQuery Network dictionary resolver',
-          type: 'string',
-          default: false,
-        },
-        'dictionary-timeout': {
-          demandOption: false,
-          describe: 'Max timeout for dictionary query',
-          type: 'number',
-        },
-        'disable-historical': {
-          demandOption: false,
-          default: false,
-          describe: 'Disable storing historical state entities',
-          type: 'boolean',
-        },
-        'log-level': {
-          demandOption: false,
-          describe: 'Specify log level to print. Ignored when --debug is used',
-          type: 'string',
-          choices: [
-            'fatal',
-            'error',
-            'warn',
-            'info',
-            'debug',
-            'trace',
-            'silent',
-          ],
-        },
-        'multi-chain': {
-          demandOption: false,
-          default: false,
-          describe:
-            'Enables indexing multiple subquery projects into the same database schema',
-          type: 'boolean',
-        },
-        'network-dictionary': {
-          alias: 'd',
-          demandOption: false,
-          describe: 'Specify the dictionary api for this network',
-          type: 'string',
-        },
-        'network-endpoint': {
-          demandOption: false,
-          type: 'string',
-          describe: 'Blockchain network endpoint to connect',
-        },
-        'output-fmt': {
-          demandOption: false,
-          describe: 'Print log as json or plain text',
-          type: 'string',
-          choices: ['json', 'colored'],
-        },
-        'query-limit': {
-          demandOption: false,
-          describe:
-            'The limit of items a project can query with store.getByField at once',
-          type: 'number',
-          default: 100,
-        },
-        'scale-batch-size': {
-          type: 'boolean',
-          demandOption: false,
-          describe: 'scale batch size based on memory usage',
-          default: false,
-        },
-        'store-cache-threshold': {
-          demandOption: false,
-          describe:
-            'Store cache will flush data to the database when number of records excess this threshold',
-          type: 'number',
-        },
-        'store-get-cache-size': {
-          demandOption: false,
-          describe: 'Store get cache size for each model',
-          type: 'number',
-        },
-        'store-cache-async': {
-          demandOption: false,
-          describe:
-            'If enabled the store cache will flush data asyncronously relative to indexing data',
-          type: 'boolean',
-        },
-        'store-flush-interval': {
-          demandOption: false,
-          describe:
-            'The interval, in seconds, at which data is flushed from the cache. ' +
-            'This ensures that data is persisted regularly when there is either not much data or the project is up to date.',
-          type: 'number',
-          default: 5,
-        },
-        'subquery-name': {
-          deprecated: true,
-          demandOption: false,
-          describe: 'Name of the subquery project',
-          type: 'string',
-        },
-        subscription: {
-          demandOption: false,
-          describe: 'Enable subscription by create notification triggers',
-          type: 'boolean',
-          default: false,
-        },
-        timeout: {
-          demandOption: false,
-          describe:
-            'Timeout for indexer sandbox to execute the mapping functions',
-          type: 'number',
-        },
-        'unfinalized-blocks': {
-          demandOption: false,
-          default: false,
-          describe: 'Enable to fetch and index unfinalized blocks',
-          type: 'boolean',
-        },
-        unsafe: {
-          type: 'boolean',
-          demandOption: false,
-          describe: 'Allows usage of any built-in module within the sandbox',
-        },
-        workers: {
-          alias: 'w',
-          demandOption: false,
-          describe:
-            'Number of worker threads to use for fetching and processing blocks. Disabled by default.',
-          type: 'number',
-        },
-      }),
+      yargs
+        .options({
+          'batch-size': {
+            demandOption: false,
+            describe: 'Batch size of blocks to fetch in one round',
+            type: 'number',
+          },
+          'dictionary-resolver': {
+            demandOption: false,
+            describe: 'Use SubQuery Network dictionary resolver',
+            type: 'string',
+            default: false,
+          },
+          'dictionary-timeout': {
+            demandOption: false,
+            describe: 'Max timeout for dictionary query',
+            type: 'number',
+          },
+          'disable-historical': {
+            demandOption: false,
+            default: false,
+            describe: 'Disable storing historical state entities',
+            type: 'boolean',
+          },
+          'log-level': {
+            demandOption: false,
+            describe:
+              'Specify log level to print. Ignored when --debug is used',
+            type: 'string',
+            choices: [
+              'fatal',
+              'error',
+              'warn',
+              'info',
+              'debug',
+              'trace',
+              'silent',
+            ],
+          },
+          'multi-chain': {
+            demandOption: false,
+            default: false,
+            describe:
+              'Enables indexing multiple subquery projects into the same database schema',
+            type: 'boolean',
+          },
+          'network-dictionary': {
+            alias: 'd',
+            demandOption: false,
+            describe: 'Specify the dictionary api for this network',
+            type: 'string',
+          },
+          'network-endpoint': {
+            demandOption: false,
+            type: 'string',
+            describe: 'Blockchain network endpoint to connect',
+          },
+          'output-fmt': {
+            demandOption: false,
+            describe: 'Print log as json or plain text',
+            type: 'string',
+            choices: ['json', 'colored'],
+          },
+          'query-limit': {
+            demandOption: false,
+            describe:
+              'The limit of items a project can query with store.getByField at once',
+            type: 'number',
+            default: 100,
+          },
+          'scale-batch-size': {
+            type: 'boolean',
+            demandOption: false,
+            describe: 'scale batch size based on memory usage',
+            default: false,
+          },
+          'store-cache-threshold': {
+            demandOption: false,
+            describe:
+              'Store cache will flush data to the database when number of records excess this threshold',
+            type: 'number',
+          },
+          'store-get-cache-size': {
+            demandOption: false,
+            describe: 'Store get cache size for each model',
+            type: 'number',
+          },
+          'store-cache-async': {
+            demandOption: false,
+            describe:
+              'If enabled the store cache will flush data asyncronously relative to indexing data',
+            type: 'boolean',
+          },
+          'store-flush-interval': {
+            demandOption: false,
+            describe:
+              'The interval, in seconds, at which data is flushed from the cache. ' +
+              'This ensures that data is persisted regularly when there is either not much data or the project is up to date.',
+            type: 'number',
+            default: 5,
+          },
+          'subquery-name': {
+            deprecated: true,
+            demandOption: false,
+            describe: 'Name of the subquery project',
+            type: 'string',
+          },
+          subscription: {
+            demandOption: false,
+            describe: 'Enable subscription by create notification triggers',
+            type: 'boolean',
+            default: false,
+          },
+          timeout: {
+            demandOption: false,
+            describe:
+              'Timeout for indexer sandbox to execute the mapping functions',
+            type: 'number',
+          },
+          'unfinalized-blocks': {
+            demandOption: false,
+            default: false,
+            describe: 'Enable to fetch and index unfinalized blocks',
+            type: 'boolean',
+          },
+          unsafe: {
+            type: 'boolean',
+            demandOption: false,
+            describe: 'Allows usage of any built-in module within the sandbox',
+          },
+          workers: {
+            alias: 'w',
+            demandOption: false,
+            describe:
+              'Number of worker threads to use for fetching and processing blocks. Disabled by default.',
+            type: 'number',
+          },
+          root: {
+            describe:
+              'This is a hidden flag only used from the main thread to workers. It provides a root directory for the project. This is a temp directory with IPFS and GitHub projects.',
+            type: 'string',
+          },
+        })
+        .hide('root'), // root is hidden because its for internal use
     handler: () => {
       // boostrap trigger in main.ts
     },


### PR DESCRIPTION
# Description
To solve this we give the workers an extra argument "root" which is now common. This stops each worker creating their own temp dir and instead uses the root dir.

This had a follow on problem where the path to files didn't belong in the root so they were unable to be resolved.

Changes also include tidying up managing the temp files.

Fixes https://github.com/subquery/subql/issues/1765

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
