### PR TITLE
Dont cache rpc requests for latest chain data

### DIFF
--- a/packages/node/src/indexer/apiPromise.connection.spec.ts
+++ b/packages/node/src/indexer/apiPromise.connection.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { WsProvider } from '@polkadot/rpc-provider';
+import { delay } from '@subql/common';
 import { createCachedProvider } from './x-provider/cachedProvider';
 import { HttpProvider } from './x-provider/http';
 
@@ -61,4 +62,16 @@ describe('ApiPromiseConnection', () => {
     ]);
     expect(httpProvider.send).toHaveBeenCalledTimes(1);
   });
+
+  it('should not cache requests if there are no args', async () => {
+    const cachedProvider = createCachedProvider(httpProvider);
+
+    const result1 = await cachedProvider.send('chain_getHeader', []);
+    // Enough time for a new block
+    await delay(7);
+    const result2 = await cachedProvider.send('chain_getHeader', []);
+
+    expect(httpProvider.send).toHaveBeenCalledTimes(2);
+    expect(result1).not.toEqual(result2);
+  }, 10000);
 });


### PR DESCRIPTION
# Description
RPC requests that are cached shouldn't cache requests that have no parameters, these requests are getting the latest values so shouldn't rely on old data

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
