### PR TITLE
fix jump buffer height issue

### DIFF
--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -31,7 +31,7 @@ export type ProcessBlockResponse = {
 };
 
 export interface IBlockDispatcher {
-  enqueueBlocks(heights: number[], latestBufferHeight?: number): Promise<void>;
+  enqueueBlocks(heights: number[], latestBufferHeight?: number): void | Promise<void>;
 
   queueSize: number;
   freeSize: number;
@@ -70,7 +70,7 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS> implements IBloc
     protected dynamicDsService: DynamicDsService<any>
   ) {}
 
-  abstract enqueueBlocks(heights: number[], latestBufferHeight?: number): Promise<void>;
+  abstract enqueueBlocks(heights: number[], latestBufferHeight?: number): void | Promise<void>;
 
   async init(onDynamicDsCreated: (height: number) => Promise<void>): Promise<void> {
     this._onDynamicDsCreated = onDynamicDsCreated;
@@ -215,20 +215,6 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS> implements IBloc
       this.poiService.setLatestPoiBlockHash(poiBlock.hash);
       this.storeCacheService.metadata.set('lastPoiHeight', height);
     }
-  }
-
-  // Used when dictionary results skip a large number of blocks
-  protected async jumpBufferedHeight(height: number): Promise<void> {
-    this.updateStoreMetadata(height, false);
-    this.latestBufferedHeight = height;
-
-    // We're not actually processing this block, we just want to update health/benchmark
-    this.eventEmitter.emit(IndexerEvent.BlockProcessing, {
-      height,
-      timestamp: Date.now(),
-    });
-
-    await this.storeCacheService.flushCache(true);
   }
 
   private updateStoreMetadata(height: number, updateProcessed = true): void {

--- a/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
@@ -77,14 +77,13 @@ export abstract class BlockDispatcher<B, DS>
     this.processQueue.abort();
   }
 
-  async enqueueBlocks(heights: number[], latestBufferHeight?: number): Promise<void> {
+  enqueueBlocks(heights: number[], latestBufferHeight?: number): void {
     // In the case where factors of batchSize is equal to bypassBlock or when heights is []
-    // to ensure block is bypassed, latestBufferHeight needs to be manually set
+    // to ensure block is bypassed, we set the latestBufferHeight to the heights
+    // make sure lastProcessedHeight in metadata is updated
     if (!!latestBufferHeight && !heights.length) {
-      await this.jumpBufferedHeight(latestBufferHeight);
-      return;
+      heights = [latestBufferHeight];
     }
-
     logger.info(`Enqueueing blocks ${heights[0]}...${last(heights)}, total ${heights.length} blocks`);
 
     this.queue.putMany(heights);

--- a/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.ts
@@ -91,10 +91,10 @@ export abstract class WorkerBlockDispatcher<DS, W extends Worker>
 
   async enqueueBlocks(heights: number[], latestBufferHeight?: number): Promise<void> {
     // In the case where factors of batchSize is equal to bypassBlock or when heights is []
-    // to ensure block is bypassed, latestBufferHeight needs to be manually set
+    // to ensure block is bypassed, we set the latestBufferHeight to the heights
+    // make sure lastProcessedHeight in metadata is updated
     if (!!latestBufferHeight && !heights.length) {
-      await this.jumpBufferedHeight(latestBufferHeight);
-      return;
+      heights = [latestBufferHeight];
     }
 
     logger.info(`Enqueueing blocks ${heights[0]}...${last(heights)}, total ${heights.length} blocks`);


### PR DESCRIPTION
# Description

Rather than force update the metadata lastProcessedHeight, we just put the last buffered height (queryEndHeight) to the empty array, it will update the lastProcessedHeight automaticlly. 

Fixes #1779 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
