### PR TITLE
Add profiler to flushing cache, timeout flush on shutdown

### DIFF
--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -10,6 +10,8 @@ import {Deferrable, Sequelize, Transaction} from 'sequelize';
 import {NodeConfig} from '../../configure';
 import {EventPayload, IndexerEvent} from '../../events';
 import {getLogger} from '../../logger';
+import {profiler} from '../../profiler';
+import {timeout} from '../../utils';
 import {MetadataRepo, PoiRepo} from '../entities';
 import {CacheMetadataModel} from './cacheMetadata';
 import {CachePgMmrDb} from './cacheMmr';
@@ -131,6 +133,7 @@ export class StoreCacheService implements BeforeApplicationShutdown {
     this._lastFlushedOperationIndex = flushToIndex;
   }
 
+  @profiler()
   private async _flushCache(flushAll?: boolean): Promise<void> {
     logger.debug('Flushing cache');
     // With historical disabled we defer the constraints check so that it doesn't matter what order entities are modified
@@ -203,7 +206,7 @@ export class StoreCacheService implements BeforeApplicationShutdown {
 
   async beforeApplicationShutdown(): Promise<void> {
     this.schedulerRegistry.deleteInterval(INTERVAL_NAME);
-    await this.flushCache(true);
+    await timeout(this.flushCache(true), 5);
     logger.info(`Force flush cache successful!`);
   }
 }


### PR DESCRIPTION
# Description
Timeout flushing cache when exiting application.

Also adds profiler to flushig cache 
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
