### PR TITLE
Add tests for different poi block hash encodings

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Base58 encoding check for POI (#1788)
 
 ## [2.4.3] - 2023-06-02
 ### Fixed

--- a/packages/node-core/src/indexer/poi/PoiBlock.spec.ts
+++ b/packages/node-core/src/indexer/poi/PoiBlock.spec.ts
@@ -1,0 +1,77 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {base58Validate} from '@polkadot/util-crypto';
+import {PoiBlock} from './PoiBlock';
+
+describe('Poi Block', () => {
+  it('supports hex block hashes', () => {
+    // Shiden
+    // https://polkadot.js.org/apps/#/explorer/query/0xe1858e5710e2a60caad17505d799baafa8bc58a49bb52b9b9009427e9dc764ee
+    const poiBlock = PoiBlock.create(
+      1,
+      '0xe1858e5710e2a60caad17505d799baafa8bc58a49bb52b9b9009427e9dc764ee',
+      new Uint8Array(),
+      new Uint8Array(),
+      'test'
+    );
+
+    expect(poiBlock.chainBlockHash).toBeDefined();
+  });
+
+  it('supports u8a block hashes', () => {
+    const hash = new Uint8Array([
+      225, 133, 142, 87, 16, 226, 166, 12, 170, 209, 117, 5, 215, 153, 186, 175, 168, 188, 88, 164, 155, 181, 43, 155,
+      144, 9, 66, 126, 157, 199, 100, 238,
+    ]);
+    const poiBlock = PoiBlock.create(1, hash, new Uint8Array(), new Uint8Array(), 'test');
+    expect(poiBlock.chainBlockHash).toBeDefined();
+  });
+
+  it('supports base58 block hashes', () => {
+    // https://explorer.near.org/blocks/8gBy5MhHUAg2gVv5Uu9A8mTJF4hpDXteoKykgJiwSFZS
+    const poiBlock = PoiBlock.create(
+      1,
+      '8gBy5MhHUAg2gVv5Uu9A8mTJF4hpDXteoKykgJiwSFZS',
+      new Uint8Array(),
+      new Uint8Array(),
+      'test'
+    );
+    expect(poiBlock.chainBlockHash).toBeDefined();
+  });
+
+  it('supports base64 block hashes', () => {
+    // https://algoexplorer.io/block/100798
+    let poiBlock = PoiBlock.create(
+      1,
+      'KDG6EJ7FUMNFWZJLHDIJQICOZZ4PORTW5OZPUPRJRGOOM63WQ74A',
+      new Uint8Array(),
+      new Uint8Array(),
+      'test'
+    );
+    expect(poiBlock.chainBlockHash).toBeDefined();
+
+    poiBlock = PoiBlock.create(
+      1,
+      '7mxLwnp5sElF3ZtZaR2Pe/28+ytwwVNn3hfcQnSurV4=',
+      new Uint8Array(),
+      new Uint8Array(),
+      'test'
+    );
+    expect(poiBlock.chainBlockHash).toBeDefined();
+
+    // https://github.com/polkadot-js/common/issues/1841
+    poiBlock = PoiBlock.create(
+      1,
+      'a1UbyspTdnyZXLUQaQbciCxrCWWxz24kgSwGXSQnkbs=',
+      new Uint8Array(),
+      new Uint8Array(),
+      'test'
+    );
+    expect(poiBlock.chainBlockHash).toBeDefined();
+  });
+
+  it('throws on unsupported block hash format', () => {
+    expect(() => PoiBlock.create(1, '!@#$%^&', new Uint8Array(), new Uint8Array(), 'test')).toThrow();
+  });
+});

--- a/packages/node-core/src/indexer/poi/PoiBlock.ts
+++ b/packages/node-core/src/indexer/poi/PoiBlock.ts
@@ -67,7 +67,8 @@ export class PoiBlock implements ProofOfIndex {
       _chainBlockHash = hexToU8a(chainBlockHash);
     } else if (isU8a(chainBlockHash)) {
       _chainBlockHash = chainBlockHash;
-    } else if (isBase58(chainBlockHash)) {
+      // needs release with to remove second check https://github.com/polkadot-js/common/pull/1842
+    } else if (isBase58(chainBlockHash) && !chainBlockHash.includes('=')) {
       // Near block hashes are base58 encoded
       _chainBlockHash = base58Decode(chainBlockHash);
     } else if (isBase64(chainBlockHash)) {


### PR DESCRIPTION
# Description
Adds tests for PoiBlock and different block hash encodings. It found an issue with polkadot dependency that can be tracked here https://github.com/polkadot-js/common/issues/1841

We can merge this once the underlying issue is fixed.

This is blocking Algorand from working with POI

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
