### PR TITLE
fix project _startHeight been blocked by poiSync

### DIFF
--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -89,12 +89,6 @@ export abstract class BaseProjectService<DS extends {startBlock?: number}> imple
 
       await this.initHotSchemaReload();
 
-      if (this.nodeConfig.proofOfIndex) {
-        const blockOffset = await this.getMetadataBlockOffset();
-        void this.setBlockOffset(Number(blockOffset));
-        await this.poiService.init();
-      }
-
       this._startHeight = await this.getStartHeight();
 
       const reindexedTo = await this.initUnfinalized();
@@ -102,9 +96,18 @@ export abstract class BaseProjectService<DS extends {startBlock?: number}> imple
       if (reindexedTo !== undefined) {
         this._startHeight = reindexedTo;
       }
-
-      // Flush any pending operations to setup DB
+      // Flush any pending operations to set up DB
       await this.storeService.storeCache.flushCache(true);
+
+      if (this.nodeConfig.proofOfIndex) {
+        const blockOffset = await this.getMetadataBlockOffset();
+        await this.poiService.init();
+        // Flush cache to setup rest of POI related meta
+        await this.storeService.storeCache.flushCache(true);
+        // syncFileBaseFromPoi at the bottom, avoid DB be blocked lead project init not completed,
+        // And fetch service have to keep waiting
+        void this.setBlockOffset(Number(blockOffset));
+      }
     } else {
       this._schema = await this.getExistingProjectSchema();
 


### PR DESCRIPTION
# Description

after mmr reset, the syncFileBaseFromPoi will flush large amount data into mmr and poi, and this start happen before project service init startHeight initilized, so it been blocking fetching service start until first few sql done flush

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
