### PR TITLE
upgrade @subql/apollo-links

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -90,11 +90,14 @@ module.exports = {
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   // moduleNameMapper: {},
   moduleNameMapper: {
+    '^@subql/common-substrate$': '<rootDir>/packages/common-substrate/src/',
     '^@subql/common-substrate/(.*)$': '<rootDir>/packages/common-substrate/src/$1',
+    '^@subql/common$': '<rootDir>/packages/common/src/',
     '^@subql/common/(.*)$': '<rootDir>/packages/common/src/$1',
+    '^@subql/node-core$': '<rootDir>/packages/node-core/src/',
     '^@subql/node-core/(.*)$': '<rootDir>/packages/node-core/src/$1',
+    '^@subql/utils$': '<rootDir>/packages/utils/src/',
     '^@subql/utils/(.*)$': '<rootDir>/packages/utils/src/$1',
-    '^@subql/node-core/logger': '<rootDir>/packages/node-core/logger',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -21,7 +21,7 @@
     "@nestjs/common": "^8.2.6",
     "@nestjs/event-emitter": "^1.3.0",
     "@nestjs/schedule": "^1.0.2",
-    "@subql/apollo-links": "^0.3.3-2",
+    "@subql/apollo-links": "^0.5.1",
     "@subql/common": "workspace:*",
     "@subql/testing": "workspace:*",
     "@subql/types": "workspace:*",

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -28,7 +28,7 @@ export interface IConfig {
   readonly preferRange: boolean;
   readonly networkEndpoint?: string[];
   readonly networkDictionary?: string;
-  readonly dictionaryResolver?: string;
+  readonly dictionaryResolver?: string | false;
   readonly outputFmt?: 'json';
   readonly logLevel: LevelWithSilent;
   readonly queryLimit: number;
@@ -159,8 +159,11 @@ export class NodeConfig implements IConfig {
     return this._config.storeFlushInterval;
   }
 
-  get dictionaryResolver(): string | undefined {
-    return this._config.dictionaryResolver;
+  get dictionaryResolver(): string | false {
+    if (this._config.dictionaryResolver === 'false') {
+      return false;
+    }
+    return this._config.dictionaryResolver ?? 'https://kepler-auth.subquery.network';
   }
 
   get timeout(): number {

--- a/packages/node-core/src/indexer/dictionary.service.test.ts
+++ b/packages/node-core/src/indexer/dictionary.service.test.ts
@@ -112,7 +112,6 @@ const nodeConfig = new NodeConfig({
 describe('DictionaryService', () => {
   it('return dictionary query result', async () => {
     const dictionaryService = new DictionaryService(DICTIONARY_ENDPOINT, DICTIONARY_CHAINID, nodeConfig);
-    await dictionaryService.init();
 
     const batchSize = 30;
     const startBlock = 1;
@@ -128,7 +127,6 @@ describe('DictionaryService', () => {
       '0x21121',
       nodeConfig
     );
-    await dictionaryService.init();
 
     const batchSize = 30;
     const startBlock = 1;
@@ -139,7 +137,6 @@ describe('DictionaryService', () => {
 
   it('should return meta even startblock height greater than dictionary last processed height', async () => {
     const dictionaryService = new DictionaryService(DICTIONARY_ENDPOINT, DICTIONARY_CHAINID, nodeConfig);
-    await dictionaryService.init();
 
     const batchSize = 30;
     const startBlock = 400000000;
@@ -150,7 +147,6 @@ describe('DictionaryService', () => {
 
   it('test query the correct range', async () => {
     const dictionaryService = new DictionaryService(DICTIONARY_ENDPOINT, DICTIONARY_CHAINID, nodeConfig);
-    await dictionaryService.init();
 
     const batchSize = 30;
     const startBlock = 1;
@@ -169,7 +165,6 @@ describe('DictionaryService', () => {
 
   it('use minimum value of event/extrinsic returned block as batch end block', async () => {
     const dictionaryService = new DictionaryService(DICTIONARY_ENDPOINT, DICTIONARY_CHAINID, nodeConfig);
-    await dictionaryService.init();
 
     const batchSize = 50;
     const startBlock = 333300;
@@ -216,9 +211,8 @@ describe('DictionaryService', () => {
     expect(dic?.batchBlocks[dic.batchBlocks.length - 1]).toBe(339186);
   }, 500000);
 
-  it('able to build queryEntryMap', async () => {
+  it('able to build queryEntryMap', () => {
     const dictionaryService = new DictionaryService(DICTIONARY_ENDPOINT, DICTIONARY_CHAINID, nodeConfig);
-    await dictionaryService.init();
 
     dictionaryService.buildDictionaryEntryMap(mockDS, () => HAPPY_PATH_CONDITIONS);
     const _map = (dictionaryService as any).mappedDictionaryQueryEntries;
@@ -227,9 +221,8 @@ describe('DictionaryService', () => {
     expect(_map.size).toEqual(mockDS.length);
   });
 
-  it('able to getDicitonaryQueryEntries', async () => {
+  it('able to getDicitonaryQueryEntries', () => {
     const dictionaryService = new DictionaryService(DICTIONARY_ENDPOINT, DICTIONARY_CHAINID, nodeConfig);
-    await dictionaryService.init();
     const dictionaryQueryMap = new Map();
 
     // Mocks a Map object that where key == dataSource.startBlock and mocked DictionaryQueryEntries[] values
@@ -267,9 +260,8 @@ describe('DictionaryService', () => {
     expect(dictionaryService.getDictionaryQueryEntries(queryEndBlock)).toEqual([]);
   });
 
-  it('sort map', async () => {
+  it('sort map', () => {
     const dictionaryService = new DictionaryService(DICTIONARY_ENDPOINT, DICTIONARY_CHAINID, nodeConfig);
-    await dictionaryService.init();
 
     const unorderedDs = [mockDS[2], mockDS[0], mockDS[1]];
     dictionaryService.buildDictionaryEntryMap(unorderedDs, (startBlock) => startBlock as any);

--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -167,7 +167,7 @@ export class DictionaryService implements OnApplicationShutdown {
     this.init();
   }
 
-  init(): void {
+  private init(): void {
     let link: ApolloLink;
 
     if (this.nodeConfig.dictionaryResolver) {

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -21,8 +21,11 @@ const logger = getLogger('subql-testing');
 
 declare global {
   //const api: ApiAt;
+  // @ts-ignore
   const logger: Pino.Logger;
+  // @ts-ignore
   const store: Store;
+  // @ts-ignore
   const createDynamicDatasource: DynamicDatasourceCreator;
 }
 

--- a/packages/node/src/indexer/dictionary.service.test.ts
+++ b/packages/node/src/indexer/dictionary.service.test.ts
@@ -31,7 +31,6 @@ describe('DictionaryService', () => {
   it('should return all specVersion', async () => {
     const project = testSubqueryProject();
     const dictionaryService = new DictionaryService(project, nodeConfig);
-    await dictionaryService.init();
 
     const specVersions = await dictionaryService.getSpecVersions();
 

--- a/packages/node/src/indexer/fetch.module.ts
+++ b/packages/node/src/indexer/fetch.module.ts
@@ -102,13 +102,7 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
     },
     FetchService,
     BenchmarkService,
-    {
-      provide: DictionaryService,
-      useFactory: (project: SubqueryProject, nodeConfig: NodeConfig) => {
-        return new DictionaryService(project, nodeConfig);
-      },
-      inject: ['ISubqueryProject', NodeConfig],
-    },
+    DictionaryService,
     SandboxService,
     DsProcessorService,
     DynamicDsService,

--- a/packages/node/src/indexer/fetch.module.ts
+++ b/packages/node/src/indexer/fetch.module.ts
@@ -104,10 +104,8 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
     BenchmarkService,
     {
       provide: DictionaryService,
-      useFactory: async (project: SubqueryProject, nodeConfig: NodeConfig) => {
-        const dictionaryService = new DictionaryService(project, nodeConfig);
-        await dictionaryService.init();
-        return dictionaryService;
+      useFactory: (project: SubqueryProject, nodeConfig: NodeConfig) => {
+        return new DictionaryService(project, nodeConfig);
       },
       inject: ['ISubqueryProject', NodeConfig],
     },

--- a/packages/node/src/indexer/fetch.service.test.ts
+++ b/packages/node/src/indexer/fetch.service.test.ts
@@ -215,10 +215,8 @@ async function createApp(
       ProjectService,
       {
         provide: DictionaryService,
-        useFactory: async () => {
-          const dictionaryService = new DictionaryService(project, nodeConfig);
-          await dictionaryService.init();
-          return dictionaryService;
+        useFactory: () => {
+          return new DictionaryService(project, nodeConfig);
         },
       },
       SchedulerRegistry,

--- a/packages/node/src/indexer/fetch.service.test.ts
+++ b/packages/node/src/indexer/fetch.service.test.ts
@@ -213,12 +213,7 @@ async function createApp(
         inject: [DsProcessorService, 'ISubqueryProject'],
       },
       ProjectService,
-      {
-        provide: DictionaryService,
-        useFactory: () => {
-          return new DictionaryService(project, nodeConfig);
-        },
-      },
+      DictionaryService,
       SchedulerRegistry,
       UnfinalizedBlocksService,
       FetchService,

--- a/packages/node/src/indexer/fetch.service.test.ts
+++ b/packages/node/src/indexer/fetch.service.test.ts
@@ -109,6 +109,7 @@ const nodeConfig = new NodeConfig({
   dictionaryTimeout: 10,
   batchSize: 5,
   storeCacheAsync: false,
+  dictionaryResolver: false,
 });
 
 async function createApp(

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -154,7 +154,6 @@ export const yargsOptions = yargs(hideBin(process.argv))
             demandOption: false,
             describe: 'Use SubQuery Network dictionary resolver',
             type: 'string',
-            default: false,
           },
           'dictionary-timeout': {
             demandOption: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3926,11 +3926,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/apollo-links@npm:^0.3.3-2":
-  version: 0.3.3-2
-  resolution: "@subql/apollo-links@npm:0.3.3-2"
+"@subql/apollo-links@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "@subql/apollo-links@npm:0.5.1"
   dependencies:
     "@metamask/eth-sig-util": 4.0.1
+    apollo-link-error: ^1.1.13
     axios: ^0.27.2
     buffer: ^6.0.3
     ethers: ^5.6.8
@@ -3938,7 +3939,7 @@ __metadata:
   peerDependencies:
     "@apollo/client": "*"
     graphql: "*"
-  checksum: 4456c08f561e7b4d160b6e1676aaeaec26bbe0b62a94a0ade6ed8334e9139c3825596f776576c4d88d7ebf6e4f4a9138324bdd38c205be0711ccbbf84a0242bc
+  checksum: cbb073362053c91200fbb4d414bf342295df94930813af0bd8abdb5da6de94001f79e95e5e71a37c877ca90b3f2f9cdc236fa7e811d78d3697c948ae90427993
   languageName: node
   linkType: hard
 
@@ -4178,7 +4179,7 @@ __metadata:
     "@nestjs/common": ^8.2.6
     "@nestjs/event-emitter": ^1.3.0
     "@nestjs/schedule": ^1.0.2
-    "@subql/apollo-links": ^0.3.3-2
+    "@subql/apollo-links": ^0.5.1
     "@subql/common": "workspace:*"
     "@subql/testing": "workspace:*"
     "@subql/types": "workspace:*"
@@ -5668,6 +5669,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wry/equality@npm:^0.1.2":
+  version: 0.1.11
+  resolution: "@wry/equality@npm:0.1.11"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 1a26a0fd11e3e3a6a197d9a54a5bec523caf693daa24ad2709f496e43dd3cd12290a0d17df81f8a783437795f6c64a1ca2717cdac6e79022bde4450c11e705c9
+  languageName: node
+  linkType: hard
+
 "@wry/equality@npm:^0.5.0":
   version: 0.5.2
   resolution: "@wry/equality@npm:0.5.2"
@@ -6094,6 +6104,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"apollo-link-error@npm:^1.1.13":
+  version: 1.1.13
+  resolution: "apollo-link-error@npm:1.1.13"
+  dependencies:
+    apollo-link: ^1.2.14
+    apollo-link-http-common: ^0.2.16
+    tslib: ^1.9.3
+  checksum: b417b77acbf464d8246eb79312c6d755f9d398c6c9f560c9e2270260519df639c3f0a8b9454ccc55c7f54eb57490706275ede120ecd7f475ec4627012feaf4b2
+  languageName: node
+  linkType: hard
+
+"apollo-link-http-common@npm:^0.2.16":
+  version: 0.2.16
+  resolution: "apollo-link-http-common@npm:0.2.16"
+  dependencies:
+    apollo-link: ^1.2.14
+    ts-invariant: ^0.4.0
+    tslib: ^1.9.3
+  peerDependencies:
+    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+  checksum: 46672f2b10a01f495ed91d32b9d21ed0747bf23c8c23a2041ca41dd92a05e0e18d7842d29c958f6ddfaee03bd89202788f593cdcb96d4167191aff125f109c67
+  languageName: node
+  linkType: hard
+
+"apollo-link@npm:^1.2.14":
+  version: 1.2.14
+  resolution: "apollo-link@npm:1.2.14"
+  dependencies:
+    apollo-utilities: ^1.3.0
+    ts-invariant: ^0.4.0
+    tslib: ^1.9.3
+    zen-observable-ts: ^0.8.21
+  peerDependencies:
+    graphql: ^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0
+  checksum: ad8d051ffceb270cdbbcc71d499bce2fda437a65fac6edc859a9e2dc0dbcb10b6a3f4da41789e786270aa358719c8b71315f383a698a74957df0d7aeea042918
+  languageName: node
+  linkType: hard
+
 "apollo-reporting-protobuf@npm:^3.3.1":
   version: 3.3.1
   resolution: "apollo-reporting-protobuf@npm:3.3.1"
@@ -6205,6 +6253,20 @@ __metadata:
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
   checksum: 5b8ec05b2a80f7acddb5de4d558ef4927425edb171b49293cd61300b72dafbe335d1d10225c52188b135609d51b8f623fe5362817550ce0a6f470515dfeff564
+  languageName: node
+  linkType: hard
+
+"apollo-utilities@npm:^1.3.0":
+  version: 1.3.4
+  resolution: "apollo-utilities@npm:1.3.4"
+  dependencies:
+    "@wry/equality": ^0.1.2
+    fast-json-stable-stringify: ^2.0.0
+    ts-invariant: ^0.4.0
+    tslib: ^1.10.0
+  peerDependencies:
+    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+  checksum: 6e0192a3420782909c930f5230808d7fbbdbcdfccddd960120e19bab251b77a16e590b05dbb4a7da2c27c59077fbfd53e56819a9fae694debe7f898e8b0ec1e9
   languageName: node
   linkType: hard
 
@@ -17276,6 +17338,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-invariant@npm:^0.4.0":
+  version: 0.4.4
+  resolution: "ts-invariant@npm:0.4.4"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 58b32fb6b7c479e602e55b9eb63bb99a203c5db09367d3aa7c3cbe000ba62f919eea7f031f55172df9b6d362a6f1a87e906df84b04b8c74c88e507ac58f7a554
+  languageName: node
+  linkType: hard
+
 "ts-invariant@npm:^0.9.4":
   version: 0.9.4
   resolution: "ts-invariant@npm:0.9.4"
@@ -17408,7 +17479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1, tslib@npm:^1.9.0":
+"tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -18749,6 +18820,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zen-observable-ts@npm:^0.8.21":
+  version: 0.8.21
+  resolution: "zen-observable-ts@npm:0.8.21"
+  dependencies:
+    tslib: ^1.9.3
+    zen-observable: ^0.8.0
+  checksum: 2931628598937effcc77acf88ac8d3468c0584bbc4488726ae2c94f6a02615ff80e9d6dc0943b71bc874466ab371837737ce8245eed3bfea38daa466a2fdc6ce
+  languageName: node
+  linkType: hard
+
 "zen-observable-ts@npm:^1.2.0":
   version: 1.2.3
   resolution: "zen-observable-ts@npm:1.2.3"
@@ -18758,7 +18839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zen-observable@npm:0.8.15":
+"zen-observable@npm:0.8.15, zen-observable@npm:^0.8.0":
   version: 0.8.15
   resolution: "zen-observable@npm:0.8.15"
   checksum: b7289084bc1fc74a559b7259faa23d3214b14b538a8843d2b001a35e27147833f4107590b1b44bf5bc7f6dfe6f488660d3a3725f268e09b3925b3476153b7821


### PR DESCRIPTION
* upgrade @subql/apollo-links to v0.5.1
* enable dictionary-resolver by default

# Description
Can be tested use `yarn start -f QmNYsNZvM9XZuzkF3n6XcqFVxvMLfWYtEQHzszMFfNCkgt --network-endpoint wss://polkadot.api.onfinality.io/public-ws --output-fmt=colored --log-level=debug`

The console output should show the actual network indexer that dictionary queries were made to.
<img width="1181" alt="image" src="https://github.com/subquery/subql/assets/39037239/5735b1c5-2638-4998-974c-e9bcac5455b9">


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
