### PR TITLE
fix metadata missing storeService with its cache

### DIFF
--- a/packages/node-core/src/meta/meta.service.ts
+++ b/packages/node-core/src/meta/meta.service.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {Injectable} from '@nestjs/common';
 import {OnEvent} from '@nestjs/event-emitter';
 import {Interval} from '@nestjs/schedule';
 import {
@@ -15,7 +14,7 @@ import {
 } from '../events';
 import {StoreService} from '../indexer';
 
-const UPDATE_HEIGHT_INTERVAL = 60000;
+const UPDATE_HEIGHT_INTERVAL = 6000;
 
 export abstract class BaseMetaService {
   private currentProcessingHeight?: number;
@@ -28,8 +27,18 @@ export abstract class BaseMetaService {
   private lastProcessedHeight?: number;
   private lastProcessedTimestamp?: number;
   private processedBlockCount?: number;
+  private _storeService?: StoreService;
 
-  constructor(private storeService: StoreService) {}
+  init(_storeService: StoreService): void {
+    this._storeService = _storeService;
+  }
+
+  get storeService(): StoreService {
+    if (this._storeService === undefined) {
+      throw new Error(`MetaService failed to get storeService`);
+    }
+    return this._storeService;
+  }
 
   protected abstract packageVersion: string;
 

--- a/packages/node/src/init.ts
+++ b/packages/node/src/init.ts
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { NestFactory } from '@nestjs/core';
-import { getLogger, getValidPort, NestLogger } from '@subql/node-core';
+import {
+  getLogger,
+  getValidPort,
+  NestLogger,
+  StoreService,
+} from '@subql/node-core';
 import { AppModule } from './app.module';
 import { ApiService } from './indexer/api.service';
 import { FetchService } from './indexer/fetch.service';
 import { ProjectService } from './indexer/project.service';
+import { MetaService } from './meta/meta.service';
 import { yargsOptions } from './yargs';
 const pjson = require('../package.json');
 
@@ -37,6 +43,13 @@ export async function bootstrap(): Promise<void> {
     // Initialise async services, we do this here rather than in factories, so we can capture one off events
     await apiService.init();
     await projectService.init();
+
+    // metaService need to inject a storeService that has completed initDbSchema() from project service
+    // it will be able to access metadata cache
+    const storeService = app.get(StoreService);
+    const metaService = app.get(MetaService);
+    metaService.init(storeService);
+
     await fetchService.init(projectService.startHeight);
 
     app.enableShutdownHooks();


### PR DESCRIPTION
# Description


I found the reason of targetHeight in metadata table never been update is metaService constructed within MetaModule and storeService got undefined.

So I attempt to injected the storeService into metaService within MetaModule. However, due to storeCache service haven't `setRepos` for metadata yet, access `metadata` from storeCache will always get undefined. 

In this fix, we need to wait storeCacheService completed `setRepos` first (projectService.initDbSchema->storeService.init->storeCache.setRepos), then we should be safe to init metaService. 

Fixes #1802 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
