### PR TITLE
fix metadata missing construct

### DIFF
--- a/packages/node/src/meta/meta.service.ts
+++ b/packages/node/src/meta/meta.service.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Injectable } from '@nestjs/common';
-import { BaseMetaService } from '@subql/node-core';
+import {
+  BaseMetaService,
+  NodeConfig,
+  StoreCacheService,
+} from '@subql/node-core';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version: polkadotSdkVersion } = require('@polkadot/api/package.json');
@@ -14,5 +18,8 @@ export class MetaService extends BaseMetaService {
   protected packageVersion = packageVersion;
   protected sdkVersion(): { name: string; version: string } {
     return { name: 'polkadotSdkVersion', version: polkadotSdkVersion };
+  }
+  constructor(storeCacheService: StoreCacheService, config: NodeConfig) {
+    super(storeCacheService, config);
   }
 }


### PR DESCRIPTION
# Description

Found the reason of targetHeight in metadata table never been update is due to metaService construct missing in the node package.

Also change update metadata interval to match with cache flush interval

Fixes #1802 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
