### PR TITLE
transform undefined to null in actual entities

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update meta exports to require `MmrQueryController` and move code from node core (#1823)
 - Switch from node-fetch to cross-fetch. [See apollo issue for more](https://github.com/apollographql/apollo-client/issues/4857)
+### Fixed
+- Not being able to test with null/undefined values on entities (#1809)
 
 ## [2.6.0] - 2023-06-19
 ### Changed

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -243,7 +243,7 @@ export class NodeConfig implements IConfig {
   }
 
   get disableHistorical(): boolean {
-    return this._config.disableHistorical;
+    return this._isTest ? true : this._config.disableHistorical;
   }
 
   get multiChain(): boolean {

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -175,7 +175,7 @@ export abstract class TestingService<A, SA, B, DS> {
           const attributes = actualEntity;
           Object.keys(attributes).map((attr) => {
             const expectedAttr = (expectedEntity as Record<string, any>)[attr] ?? null;
-            const actualAttr = (actualEntity as Record<string, any>)[attr];
+            const actualAttr = (actualEntity as Record<string, any>)[attr] ?? null;
             if (!isEqual(expectedAttr, actualAttr)) {
               failedAttributes.push(
                 `\t\tattribute: "${attr}":\n\t\t\texpected: "${expectedAttr}"\n\t\t\tactual:   "${actualAttr}"\n`

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -52,10 +52,6 @@ export abstract class TestingService<A, SA, B, DS> {
     protected readonly apiService: IApi<A, SA, B>,
     protected readonly indexerManager: IIndexerManager<B, DS>
   ) {
-    if (!nodeConfig.disableHistorical) {
-      throw new Error(`Historical data not supported in testing service`);
-    }
-
     const projectPath = this.project.root;
     // find all paths to test files
     const testFiles = this.findAllTestFiles(path.join(projectPath, 'dist'));

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -52,6 +52,10 @@ export abstract class TestingService<A, SA, B, DS> {
     protected readonly apiService: IApi<A, SA, B>,
     protected readonly indexerManager: IIndexerManager<B, DS>
   ) {
+    if (!nodeConfig.disableHistorical) {
+      throw new Error(`Historical data not supported in testing service`);
+    }
+
     const projectPath = this.project.root;
     // find all paths to test files
     const testFiles = this.findAllTestFiles(path.join(projectPath, 'dist'));
@@ -176,6 +180,7 @@ export abstract class TestingService<A, SA, B, DS> {
           Object.keys(attributes).map((attr) => {
             const expectedAttr = (expectedEntity as Record<string, any>)[attr] ?? null;
             const actualAttr = (actualEntity as Record<string, any>)[attr] ?? null;
+
             if (!isEqual(expectedAttr, actualAttr)) {
               failedAttributes.push(
                 `\t\tattribute: "${attr}":\n\t\t\texpected: "${expectedAttr}"\n\t\t\tactual:   "${actualAttr}"\n`


### PR DESCRIPTION
# Description
Records that gets stored in getCache at the time of `set` will remain undefined while TestingService expects null values from database instead of undefined. Undefined values must be transformed to null before entity checks happen in TestingService. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
