### PR TITLE
wait for `connected` event from ApiPromise while reconnecting

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Fix reconnection issues in connection pool
 
 ## [2.6.0] - 2023-06-19
 ### Changed

--- a/packages/node-core/src/indexer/connectionPool.service.spec.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.spec.ts
@@ -1,0 +1,83 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {IApiConnectionSpecific} from '..';
+import {ConnectionPoolService} from './connectionPool.service';
+
+async function waitFor(conditionFn: () => boolean, timeout = 30000, interval = 100): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const startTime = Date.now();
+    const checkCondition = () => {
+      if (conditionFn()) {
+        resolve();
+      } else if (Date.now() - startTime > timeout) {
+        reject(new Error(`Timed out waiting for ${conditionFn.name} after ${timeout}ms`));
+      } else {
+        setTimeout(checkCondition, interval);
+      }
+    };
+    checkCondition();
+  });
+}
+
+const mockApiConnection: IApiConnectionSpecific = {
+  apiConnect: jest.fn(),
+  apiDisconnect: jest.fn(),
+  handleError: jest.fn(),
+  safeApi: jest.fn(),
+  unsafeApi: jest.fn(),
+  fetchBlocks: jest.fn(),
+  networkMeta: {
+    chain: '',
+    specName: '',
+    genesisHash: '',
+  },
+};
+
+describe('ConnectionPoolService', () => {
+  let connectionPoolService: ConnectionPoolService<typeof mockApiConnection>;
+
+  beforeEach(() => {
+    connectionPoolService = new ConnectionPoolService<typeof mockApiConnection>();
+    connectionPoolService.addToConnections(mockApiConnection, 'https://example.com/api');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('handleApiDisconnects', () => {
+    it('should handle successful reconnection on the first attempt', async () => {
+      (mockApiConnection.apiConnect as any).mockImplementation(() => Promise.resolve());
+
+      connectionPoolService.handleApiDisconnects(0);
+
+      await waitFor(() => (mockApiConnection.apiConnect as any).mock.calls.length === 1);
+      expect(mockApiConnection.apiConnect).toHaveBeenCalledTimes(1);
+      expect(connectionPoolService.numConnections).toBe(1);
+    }, 10000);
+
+    it('should handle successful reconnection after multiple attempts', async () => {
+      (mockApiConnection.apiConnect as any)
+        .mockImplementationOnce(() => Promise.reject(new Error('Reconnection failed')))
+        .mockImplementationOnce(() => Promise.reject(new Error('Reconnection failed')))
+        .mockImplementation(() => Promise.resolve());
+
+      connectionPoolService.handleApiDisconnects(0);
+
+      await waitFor(() => (mockApiConnection.apiConnect as any).mock.calls.length === 3);
+      expect(mockApiConnection.apiConnect).toHaveBeenCalledTimes(3);
+      expect(connectionPoolService.numConnections).toBe(1);
+    }, 20000);
+
+    it('should handle failed reconnection after max attempts', async () => {
+      (mockApiConnection.apiConnect as any).mockImplementation(() => Promise.reject(new Error('Reconnection failed')));
+
+      connectionPoolService.handleApiDisconnects(0);
+
+      await waitFor(() => (mockApiConnection.apiConnect as any).mock.calls.length === 5);
+      expect(mockApiConnection.apiConnect).toHaveBeenCalledTimes(5);
+      expect(connectionPoolService.numConnections).toBe(0);
+    }, 31000);
+  });
+});

--- a/packages/node-core/src/indexer/connectionPool.service.spec.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.spec.ts
@@ -51,7 +51,7 @@ describe('ConnectionPoolService', () => {
     it('should handle successful reconnection on the first attempt', async () => {
       (mockApiConnection.apiConnect as any).mockImplementation(() => Promise.resolve());
 
-      connectionPoolService.handleApiDisconnects(0);
+      (connectionPoolService as any).handleApiDisconnects(0);
 
       await waitFor(() => (mockApiConnection.apiConnect as any).mock.calls.length === 1);
       expect(mockApiConnection.apiConnect).toHaveBeenCalledTimes(1);
@@ -64,7 +64,7 @@ describe('ConnectionPoolService', () => {
         .mockImplementationOnce(() => Promise.reject(new Error('Reconnection failed')))
         .mockImplementation(() => Promise.resolve());
 
-      connectionPoolService.handleApiDisconnects(0);
+      (connectionPoolService as any).handleApiDisconnects(0);
 
       await waitFor(() => (mockApiConnection.apiConnect as any).mock.calls.length === 3);
       expect(mockApiConnection.apiConnect).toHaveBeenCalledTimes(3);
@@ -74,7 +74,7 @@ describe('ConnectionPoolService', () => {
     it('should handle failed reconnection after max attempts', async () => {
       (mockApiConnection.apiConnect as any).mockImplementation(() => Promise.reject(new Error('Reconnection failed')));
 
-      connectionPoolService.handleApiDisconnects(0);
+      (connectionPoolService as any).handleApiDisconnects(0);
 
       await waitFor(() => (mockApiConnection.apiConnect as any).mock.calls.length === 5);
       expect(mockApiConnection.apiConnect).toHaveBeenCalledTimes(5);
@@ -83,15 +83,13 @@ describe('ConnectionPoolService', () => {
   });
 
   describe('handleApiDisconnects', () => {
-    // ...
-
     it('should call handleApiDisconnects only once when multiple connection errors are triggered', async () => {
       // Mock apiConnection.apiConnect() to not resolve for a considerable time
       (mockApiConnection.apiConnect as any).mockImplementation(
         () => new Promise((resolve) => setTimeout(resolve, 10000))
       );
 
-      const handleApiDisconnectsSpy = jest.spyOn(connectionPoolService, 'handleApiDisconnects');
+      const handleApiDisconnectsSpy = jest.spyOn(connectionPoolService as any, 'handleApiDisconnects');
 
       // Trigger handleApiError with connection issue twice
       connectionPoolService.handleApiError(0, {

--- a/packages/node-core/src/indexer/connectionPool.service.spec.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.spec.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import {delay} from '@subql/common';
 import {ApiErrorType, IApiConnectionSpecific} from '..';
 import {ConnectionPoolService} from './connectionPool.service';
 
@@ -105,7 +106,7 @@ describe('ConnectionPoolService', () => {
       });
 
       // Wait for a while to see if handleApiDisconnects gets called multiple times
-      await new Promise((resolve) => setTimeout(resolve, 5000));
+      await delay(5);
 
       expect(handleApiDisconnectsSpy).toHaveBeenCalledTimes(1);
     }, 15000);

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -193,7 +193,7 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
     return Object.keys(this.pool).length;
   }
 
-  handleApiDisconnects(index: number) {
+  async handleApiDisconnects(index: number) {
     logger.warn(`disconnected from ${this.pool[index].endpoint}`);
     this.pool[index].connected = false;
 
@@ -226,9 +226,7 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
       }
     };
 
-    (async () => {
-      await tryReconnect();
-    })();
+    await tryReconnect();
   }
 
   private calculatePerformanceScore(responseTime: number, failureCount: number): number {

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -242,7 +242,6 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
       .filter((index) => this.pool[index].backoffDelay !== 0);
 
     if (suspendedIndices.length === 0) {
-      logger.info(chalk.green('No suspended endpoints.'));
       return;
     }
 
@@ -301,6 +300,14 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
         this.pool[apiIndex].rateLimited = false;
         this.pool[apiIndex].failed = false;
         this.pool[apiIndex].timeoutId = undefined; // Clear the timeout ID
+
+        const suspendedIndices = Object.keys(this.pool)
+          .map(toNumber)
+          .filter((index) => this.pool[index].backoffDelay !== 0);
+
+        if (suspendedIndices.length === 0) {
+          logger.info(chalk.green('No suspended endpoints.'));
+        }
       }, nextDelay);
 
       logger.warn(

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -266,6 +266,10 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
   }
 
   handleApiError(apiIndex: number, error: ApiConnectionError): void {
+    if (this.pool[apiIndex].failed || this.pool[apiIndex].rateLimited) {
+      //if this api was used again then it must be in the same batch of blocks
+      return;
+    }
     const adjustment = this.errorTypeToScoreAdjustment[error.errorType] || this.errorTypeToScoreAdjustment.default;
     this.pool[apiIndex].performanceScore += adjustment;
     this.pool[apiIndex].failureCount++;

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -193,7 +193,7 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
     return Object.keys(this.pool).length;
   }
 
-  async handleApiDisconnects(index: number) {
+  private async handleApiDisconnects(index: number) {
     logger.warn(`disconnected from ${this.pool[index].endpoint}`);
     this.pool[index].connected = false;
 

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -271,7 +271,10 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
     this.pool[apiIndex].failureCount++;
 
     if (error.errorType === ApiErrorType.Connection) {
-      this.handleApiDisconnects(apiIndex);
+      if (this.pool[apiIndex].connected) {
+        //handleApiDisconnects was already called if this is false
+        this.handleApiDisconnects(apiIndex);
+      }
       return;
     }
 

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -103,7 +103,9 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
   get api(): T {
     const index = this.getNextConnectedApiIndex();
     if (index === undefined) {
-      throw new Error('All of the endpoints are suspended at the moment');
+      throw new Error(
+        'All endpoints in the pool are either suspended due to rate limits or attempting to reconnect. Please wait or add healthier endpoints.'
+      );
     }
     const api = this.pool[index].connection;
 
@@ -141,7 +143,7 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
 
   private getNextConnectedApiIndex(): number | undefined {
     if (Object.keys(this.pool).length === 0) {
-      throw new Error(`No connected endpoints available`);
+      throw new Error(`No endpoints are available in the pool. Please check for connection issues.`);
     }
 
     const indices = Object.keys(this.pool)

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix apiConnect issues in ApiPromiseConnection
 
 ## [2.7.0] - 2023-06-19
 ### Changed

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -122,7 +122,6 @@ export class ApiService
             apiIndex: i,
             endpoint: endpoint,
           });
-          this.connectionPoolService.handleApiDisconnects(i, endpoint);
         });
 
         if (!this.networkMeta) {

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ApiPromise, WsProvider } from '@polkadot/api';
+import { ApiOptions } from '@polkadot/api/types';
 import { ProviderInterface } from '@polkadot/rpc-provider/types';
 import { RegisteredTypes } from '@polkadot/types/types';
 import {
@@ -29,6 +30,8 @@ export class ApiPromiseConnection
 
   constructor(
     public unsafeApi: ApiPromise,
+    private apiOptions: ApiOptions,
+    private endpoint: string,
     private fetchBlocksBatches: FetchFunc,
   ) {
     this.networkMeta = {
@@ -66,7 +69,12 @@ export class ApiPromiseConnection
       ...args.chainTypes,
     };
     const api = await ApiPromise.create(apiOption);
-    return new ApiPromiseConnection(api, fetchBlocksBatches);
+    return new ApiPromiseConnection(
+      api,
+      apiOption,
+      endpoint,
+      fetchBlocksBatches,
+    );
   }
 
   safeApi(height: number): ApiAt {
@@ -86,7 +94,21 @@ export class ApiPromiseConnection
   }
 
   async apiConnect(): Promise<void> {
-    await this.unsafeApi.connect();
+    const headers = {
+      'User-Agent': `SubQuery-Node ${packageVersion}`,
+    };
+
+    let provider: ProviderInterface;
+
+    if (this.endpoint.startsWith('ws')) {
+      provider = createCachedProvider(
+        new WsProvider(this.endpoint, RETRY_DELAY, headers),
+      );
+    } else if (this.endpoint.startsWith('http')) {
+      provider = createCachedProvider(new HttpProvider(this.endpoint, headers));
+    }
+    this.apiOptions.provider = provider;
+    this.unsafeApi = await ApiPromise.create(this.apiOptions);
   }
 
   async apiDisconnect(): Promise<void> {

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -94,21 +94,19 @@ export class ApiPromiseConnection
   }
 
   async apiConnect(): Promise<void> {
-    const headers = {
-      'User-Agent': `SubQuery-Node ${packageVersion}`,
-    };
+    return new Promise<void>((resolve) => {
+      if (this.unsafeApi.isConnected) {
+        resolve();
+      }
 
-    let provider: ProviderInterface;
+      this.unsafeApi.on('connected', () => {
+        resolve();
+      });
 
-    if (this.endpoint.startsWith('ws')) {
-      provider = createCachedProvider(
-        new WsProvider(this.endpoint, RETRY_DELAY, headers),
-      );
-    } else if (this.endpoint.startsWith('http')) {
-      provider = createCachedProvider(new HttpProvider(this.endpoint, headers));
-    }
-    this.apiOptions.provider = provider;
-    this.unsafeApi = await ApiPromise.create(this.apiOptions);
+      if (!this.unsafeApi.isConnected) {
+        this.unsafeApi.connect();
+      }
+    });
   }
 
   async apiDisconnect(): Promise<void> {

--- a/packages/node/src/utils/substrate.ts
+++ b/packages/node/src/utils/substrate.ts
@@ -328,7 +328,6 @@ export async function fetchBlocksBatches(
   blockArray: number[],
   overallSpecVer?: number,
 ): Promise<BlockContent[]> {
-  //await api.disconnect();
   const blocks = await fetchBlocksArray(api, blockArray);
   const blockHashs = blocks.map((b) => b.block.header.hash);
   const parentBlockHashs = blocks.map((b) => b.block.header.parentHash);


### PR DESCRIPTION
# Description
Wait for `connected` event from ApiPromise before resolving apiConnect()

Fixes #1812 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
