### PR TITLE
Add the ability to get all metadata tables with multichain projects

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose all the multi-chain metadatas from query service, this helps to identify multi-chain project and networks been indexed within the project, a proper improvement will be complete in [#1817](https://github.com/subquery/subql/issues/1817). (#1818)
 - Update apollo server with security fixes (#1834)
 
+### Added
+- Add the ability to get all metadata tables with multichain projects (#1839)
+
 ## [2.1.0] - 2023-05-24
 ### Changed
 - Tidy up commands and their args (#1741)
@@ -213,7 +216,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2021-04-20
 ### Added
 - Remove `condition` in query schema, please use `filter` instead (#260)
-- `@jsonField` annotation is now supported in `graphql.schema` which allows you to store structured data JSON data in a single database field
+-  annotation is now supported in 
   - We'll automatically generate coresponding JSON interfaces when querying this data (#275)
   - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
 

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -216,7 +216,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2021-04-20
 ### Added
 - Remove `condition` in query schema, please use `filter` instead (#260)
--  annotation is now supported in 
+- `@jsonField` annotation is now supported in `graphql.schema` which allows you to store structured data JSON data in a single database field
   - We'll automatically generate coresponding JSON interfaces when querying this data (#275)
   - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
 

--- a/packages/query/src/graphql/plugins/GetMetadataPlugin.ts
+++ b/packages/query/src/graphql/plugins/GetMetadataPlugin.ts
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {URL} from 'url';
-import {getMetadataTableName, MetaData, METADATA_REGEX, MULTI_METADATA_REGEX} from '@subql/utils';
+import {getMetadataTableName, MetaData, METADATA_REGEX, MULTI_METADATA_REGEX, TableEstimate} from '@subql/utils';
+import {PgIntrospectionResultsByKind} from '@subql/x-graphile-build-pg';
 import {makeExtendSchemaPlugin, gql} from 'graphile-utils';
+import {FieldNode, SelectionNode} from 'graphql';
+import {uniq} from 'lodash';
 import fetch, {Response} from 'node-fetch';
+import {Client} from 'pg';
 import {Build} from 'postgraphile-core';
 import {setAsyncInterval} from '../../utils/asyncInterval';
 import {argv} from '../../yargs';
@@ -27,9 +31,17 @@ const METADATA_TYPES = {
   deployments: 'string',
 };
 
+const METADATA_KEYS = Object.keys(METADATA_TYPES);
+
 type MetaType = number | string | boolean;
 
 type MetaEntry = {key: string; value: MetaType};
+
+type MetadatasConnection = {
+  totalCount?: number;
+  nodes?: MetaData[];
+  // edges?: any; // TODO
+};
 
 const metaCache = {
   queryNodeVersion: packageVersion,
@@ -59,38 +71,26 @@ async function fetchFromApi(): Promise<void> {
   }
 }
 
-async function fetchFromTable(
-  pgClient,
+function matchMetadataTableName(name: string): boolean {
+  return METADATA_REGEX.test(name) || MULTI_METADATA_REGEX.test(name);
+}
+
+async function fetchMetadataFromTable(
+  pgClient: Client,
   schemaName: string,
-  chainId: string | undefined,
+  tableName: string,
   useRowEst: boolean
 ): Promise<MetaData> {
-  const metadata = {} as MetaData;
-  const keys = Object.keys(METADATA_TYPES);
-
-  let metadataTableName: string;
-
-  if (!chainId) {
-    // return first metadata entry you find.
-    const {rows} = await pgClient.query(
-      `SELECT table_name FROM information_schema.tables where table_schema='${schemaName}'`
-    );
-    const {table_name} = rows.find(
-      (obj: {table_name: string}) => METADATA_REGEX.test(obj.table_name) || MULTI_METADATA_REGEX.test(obj.table_name)
-    );
-    metadataTableName = table_name;
-  } else {
-    metadataTableName = getMetadataTableName(chainId);
-  }
-
-  const {rows} = await pgClient.query(`select * from "${schemaName}".${metadataTableName} WHERE key = ANY ($1)`, [
-    keys,
+  const {rows} = await pgClient.query(`select * from "${schemaName}".${tableName} WHERE key = ANY ($1)`, [
+    METADATA_KEYS,
   ]);
 
   const dbKeyValue = rows.reduce((array: MetaEntry[], curr: MetaEntry) => {
     array[curr.key] = curr.value;
     return array;
   }, {}) as {[key: string]: MetaType};
+
+  const metadata = {} as MetaData;
 
   for (const key in METADATA_TYPES) {
     if (typeof dbKeyValue[key] === METADATA_TYPES[key]) {
@@ -106,7 +106,7 @@ async function fetchFromTable(
 
   if (useRowEst) {
     const tableEstimates = await pgClient
-      .query(
+      .query<TableEstimate>(
         `select relname as table , reltuples::bigint as estimate from pg_class
       where relnamespace in
             (select oid from pg_namespace where nspname = $1)
@@ -124,14 +124,57 @@ async function fetchFromTable(
   return metadata;
 }
 
+async function fetchFromTable(
+  pgClient: Client,
+  schemaName: string,
+  chainId: string | undefined,
+  useRowEst: boolean
+): Promise<MetaData> {
+  let metadataTableName: string;
+
+  if (!chainId) {
+    // return first metadata entry you find.
+    const {rows} = await pgClient.query(
+      `SELECT table_name FROM information_schema.tables where table_schema='${schemaName}'`
+    );
+    const {table_name} = rows.find((obj: {table_name: string}) => matchMetadataTableName(obj.table_name));
+    metadataTableName = table_name;
+  } else {
+    metadataTableName = getMetadataTableName(chainId);
+  }
+
+  return fetchMetadataFromTable(pgClient, schemaName, metadataTableName, useRowEst);
+}
+
 function metadataTableSearch(build: Build): boolean {
-  return build.pgIntrospectionResultsByKind.attribute.find(
-    (attr: {class: {name: string}}) =>
-      MULTI_METADATA_REGEX.test(attr.class.name) || METADATA_REGEX.test(attr.class.name)
+  return !!(build.pgIntrospectionResultsByKind as PgIntrospectionResultsByKind).attribute.find((attr) =>
+    matchMetadataTableName(attr.class.name)
   );
 }
 
-export const GetMetadataPlugin = makeExtendSchemaPlugin((build, options) => {
+function isFieldNode(node: SelectionNode): node is FieldNode {
+  return node.kind === 'Field';
+}
+
+/* Recursively work down the AST to find a node with a matching path */
+function findNodePath(nodes: readonly SelectionNode[], path: string[]): FieldNode | undefined {
+  if (!path.length) {
+    throw new Error('Path must have a length');
+  }
+
+  const currentPath = path[0];
+  const found = nodes.find((node) => isFieldNode(node) && node.name.value === currentPath);
+
+  if (found && isFieldNode(found)) {
+    const newPath = path.slice(1);
+
+    if (!newPath.length) return found;
+
+    return findNodePath(found.selectionSet.selections, newPath);
+  }
+}
+
+export const GetMetadataPlugin = makeExtendSchemaPlugin((build: Build, options) => {
   const [schemaName] = options.pgSchemas;
 
   if (argv(`indexer`)) {
@@ -161,8 +204,28 @@ export const GetMetadataPlugin = makeExtendSchemaPlugin((build, options) => {
         evmChainId: String
         deployments: JSON
       }
+
+      type _MetadatasEdge {
+        cursor: Cursor
+        node: _Metadata
+      }
+
+      type _Metadatas {
+        totalCount: Int!
+        nodes: [_Metadata]!
+        # edges: [_MetadatasEdge]
+      }
+
       extend type Query {
         _metadata(chainId: String): _Metadata
+
+        _metadatas(after: Cursor, before: Cursor): # distinct: [_mmr_distinct_enum] = null
+        # filter: _MetadataFilter
+        # first: Int
+        # last: Int
+        # offset: Int
+        # orderBy: [_MetadatasOrderBy!] = [PRIMARY_KEY_ASC]
+        _Metadatas
       }
     `,
     resolvers: {
@@ -172,10 +235,7 @@ export const GetMetadataPlugin = makeExtendSchemaPlugin((build, options) => {
           if (tableExists) {
             let rowCountFound = false;
             if (info.fieldName === '_metadata') {
-              for (const node of info.fieldNodes) {
-                const queryFields = node.selectionSet.selections;
-                rowCountFound = queryFields.findIndex((field) => (field as any).name.value === 'rowCountEstimate') > -1;
-              }
+              rowCountFound = !!findNodePath(info.fieldNodes, ['_metadata', 'rowCountEstimate']);
             }
             const metadata = await fetchFromTable(context.pgClient, schemaName, args.chainId, rowCountFound);
             if (Object.keys(metadata).length > 0) {
@@ -186,6 +246,30 @@ export const GetMetadataPlugin = makeExtendSchemaPlugin((build, options) => {
             return metaCache;
           }
           return;
+        },
+        _metadatas: async (_parentObject, args, context, info): Promise<MetadatasConnection> => {
+          const tableNames = uniq<string>(
+            (build.pgIntrospectionResultsByKind as PgIntrospectionResultsByKind).attribute
+              .filter((attr) => attr.class.namespaceName === schemaName && matchMetadataTableName(attr.class.name))
+              .map((attr) => attr.class.name)
+          );
+
+          let totalCount = false;
+          let rowCountEstimate = false;
+
+          if (info.fieldName === '_metadatas') {
+            totalCount = !!findNodePath(info.fieldNodes, ['_metadatas', 'totalCount']);
+            rowCountEstimate = !!findNodePath(info.fieldNodes, ['_metadatas', 'nodes', 'rowCountEstimate']);
+          }
+
+          const metadatas = await Promise.all(
+            tableNames.map((name) => fetchMetadataFromTable(context.pgClient, schemaName, name, rowCountEstimate))
+          );
+
+          return {
+            totalCount: totalCount ? tableNames.length : undefined,
+            nodes: metadatas,
+          };
         },
       },
     },

--- a/packages/query/src/graphql/plugins/smartTagsPlugin.ts
+++ b/packages/query/src/graphql/plugins/smartTagsPlugin.ts
@@ -9,7 +9,7 @@ export const smartTagsPlugin = makePgSmartTagsPlugin([
   {
     //Rule 1, omit `_metadata` from node
     kind: PgEntityKind.CLASS,
-    match: ({name}: PgEntity) => METADATA_REGEX.test(name),
+    match: ({name}: PgEntity) => METADATA_REGEX.test(name) || MULTI_METADATA_REGEX.test(name),
     tags: {
       omit: true,
     },

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Incorrect type for rowCountEstimate on metadata, remove terra metadata type (#1839)
 
 ## [2.4.1] - 2023-06-09
 ### Changed

--- a/packages/utils/src/query/types.ts
+++ b/packages/utils/src/query/types.ts
@@ -17,16 +17,6 @@ export type MetaData = {
   indexerNodeVersion: string;
   queryNodeVersion: string;
   startHeight?: number;
-  rowCountEstimate: [TableEstimate];
+  rowCountEstimate: TableEstimate[];
   deployments: Record<number, string>;
-};
-
-export type TerraMetaData = {
-  lastProcessedHeight: number;
-  lastProcessedTimestamp: number;
-  targetHeight: number;
-  chain: string; // Was a bug in the dictionary, should have been chainId
-  indexerHealthy: boolean;
-  indexerNodeVersion: string;
-  queryNodeVersion: string;
 };


### PR DESCRIPTION
# Description
Introduce `_metadata` entity on query service to be able to query all metadata tables and know what chains are indexed. For normal projects that aren't multichain it will just return the 1 result.

This is very basic and doesn't allow any filtering. As we don't expect there to be a large number of metadatas this doesn't seem necessary at this stage.

Also reverses https://github.com/subquery/subql/pull/1818 now that we have an alternative way of querying 

Fixes https://github.com/subquery/subql/issues/1817

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/353
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
