### PR TITLE
handle large block error

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handle RPC error for oversized block responses (#1876)
 
 ## [2.9.1] - 2023-07-06
 ### Fixed

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -123,6 +123,8 @@ export class ApiPromiseConnection
       formatted_error = ApiPromiseConnection.handleDisconnectionError(e);
     } else if (e.message.startsWith(`-32029: Too Many Requests`)) {
       formatted_error = ApiPromiseConnection.handleRateLimitError(e);
+    } else if (e.message.includes(`Exceeded max limit of`)) {
+      formatted_error = ApiPromiseConnection.handleLargeResponseError(e);
     } else {
       formatted_error = new ApiConnectionError(
         e.name,
@@ -158,5 +160,15 @@ export class ApiPromiseConnection
       ApiErrorType.Connection,
     );
     return formatted_error;
+  }
+
+  static handleLargeResponseError(e: Error): ApiConnectionError {
+    const newMessage = `Oversized RPC node response. This issue is related to the network's RPC nodes configuration, not your application. You may report it to the network's maintainers or try a different RPC node.\n\n${e.message}`;
+
+    return new ApiConnectionError(
+      'RpcInternalError',
+      newMessage,
+      ApiErrorType.Default,
+    );
   }
 }


### PR DESCRIPTION
# Description
Certain endpoints will throw this error when the block is too large:
Failed to fetch blocks from queue RpcError: -32702: Response is too big: Exceeded max limit of 1048576 at checkError (/usr/local/lib/node_modules/@subql/node/node_modules/@polkadot/rpc-provider/cjs/coder/index.js:30:11) at RpcCoder.decodeResponse

This error looks like its something wrong with subquery rather than the endpoint. We should handle this specific error code and provide a better error message. 

Fixes #1621 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
