### PR TITLE
Fix IPFS repeat cat same cid

### DIFF
--- a/packages/common/src/project/readers/ipfs-reader.spec.ts
+++ b/packages/common/src/project/readers/ipfs-reader.spec.ts
@@ -16,4 +16,11 @@ describe('IPFSReader', () => {
 
     expect(data.network.chainId).toBe('43114');
   });
+
+  it('ipfs should only fetch once when cache found', async () => {
+    reader = new IPFSReader('QmNbkA1fJpV2gCAWCBjgUQ8xBTwkLZHuzx4EkUoKx7VYaD', IPFSGateway);
+    const spyIpfsCat = jest.spyOn((reader as any).ipfs, 'cat');
+    await Promise.all([reader.getProjectSchema(), reader.getProjectSchema(), reader.getProjectSchema()]);
+    expect(spyIpfsCat).toBeCalledTimes(1);
+  });
 });


### PR DESCRIPTION
# Description

We have an implementation in project service, some file has fetched and saved into local. However we still face when use promise.all fetch multiple assets within multiple datasource, it could fetch same cid simultaneously.

We add a cache to save promises and if it is waiting to be fetched we can avoid to fetch it again. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
