### PR TITLE
fix unable query latest mmr issue

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix mmrQuery should always read mmr leaf length from Db. 
+
 ## [4.0.0] - 2023-07-17
 ### Changed
 - **Breaking**: Inti DB schema manually during test run (#1870)

--- a/packages/node-core/src/meta/mmrQuery.service.spec.ts
+++ b/packages/node-core/src/meta/mmrQuery.service.spec.ts
@@ -1,0 +1,71 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {delay} from '@subql/common';
+import {MmrQueryService, PgMmrQueryDb} from '@subql/node-core';
+import {Sequelize} from '@subql/x-sequelize';
+import {NodeConfig} from '../configure/NodeConfig';
+
+jest.mock('@subql/x-sequelize', () => {
+  const mSequelize = {
+    authenticate: jest.fn(),
+    Op: {
+      in: jest.fn(),
+      notIn: jest.fn(),
+    },
+    define: () => ({
+      findOne: jest.fn(),
+      create: (input: any) => input,
+      sync: jest.fn(),
+      findByPk: () => undefined,
+    }),
+    query: (input: string, option: any) => {
+      if (input === 'SELECT schema_name FROM information_schema.schemata') {
+        return [{schema_name: 'testSchema'}];
+      }
+    },
+    showAllSchemas: () => ['subquery_1'],
+    model: (entity: string) => ({
+      upsert: jest.fn(),
+      associations: [{}, {}],
+      count: 5,
+      bulkCreate: jest.fn(),
+      destroy: jest.fn(),
+    }),
+    sync: jest.fn(),
+    transaction: () => ({
+      commit: jest.fn(() => delay(1)), // Delay of 1s is used to test whether we wait for cache to flush
+      rollback: jest.fn(),
+      afterCommit: jest.fn(),
+    }),
+    // createSchema: jest.fn(),
+  };
+  const actualSequelize = jest.requireActual('@subql/x-sequelize');
+  return {
+    Sequelize: jest.fn(() => mSequelize),
+    DataTypes: actualSequelize.DataTypes,
+    QueryTypes: actualSequelize.QueryTypes,
+    Deferrable: actualSequelize.Deferrable,
+  };
+});
+
+jest.setTimeout(200000);
+
+describe('mmrQuery', () => {
+  const sequilize = new Sequelize();
+  const nodeConfig: NodeConfig = {mmrStoreType: 'postgres', dbSchema: 'testSchema'} as any;
+
+  it('mmrQuery with postgresDb, should always read leafLength from db', async () => {
+    const mmrQuery = new MmrQueryService(nodeConfig, sequilize);
+    (mmrQuery as any)._db = await PgMmrQueryDb.create(sequilize, 'testSchema');
+    await mmrQuery.init(0);
+    const mmrIndexValueStore = (mmrQuery as any)._db.mmrIndexValueStore;
+    const spyDbGet = jest.spyOn(mmrIndexValueStore, 'findByPk');
+    await mmrQuery.mmrDb.getLeafLength();
+    // read again
+    await mmrQuery.mmrDb.getLeafLength();
+    // total read twice
+    expect(spyDbGet).toBeCalledTimes(2);
+    expect(spyDbGet).toHaveBeenLastCalledWith(-1);
+  });
+});

--- a/packages/node-core/src/meta/mmrQuery.service.spec.ts
+++ b/packages/node-core/src/meta/mmrQuery.service.spec.ts
@@ -55,7 +55,7 @@ describe('mmrQuery', () => {
   const sequilize = new Sequelize();
   const nodeConfig: NodeConfig = {mmrStoreType: 'postgres', dbSchema: 'testSchema'} as any;
 
-  it('mmrQuery with postgresDb, should always read leafLength from db', async () => {
+  it('mmrQuery should always read leafLength from db', async () => {
     const mmrQuery = new MmrQueryService(nodeConfig, sequilize);
     (mmrQuery as any)._db = await PgMmrQueryDb.create(sequilize, 'testSchema');
     await mmrQuery.init(0);


### PR DESCRIPTION
# Description

Fixed previous issue `MMR is completing,please try again later` when use `get` method from MMR.

This is due to getLeafLength always use dirty length https://github.com/subquery/merkle-mountain-range/blob/9d0f2fdf7fcf4e1c8a7231f4d41f7474ec403758/merkleMountainRange.js#L142

And it never get update after this mmr instance inited in mmrQuery service, therefore, each time when `get`, it will return [Error. ](https://github.com/subquery/merkle-mountain-range/blob/9d0f2fdf7fcf4e1c8a7231f4d41f7474ec403758/merkleMountainRange.js#L66)

This fix instead use current instance, but construct a new one to avoid this problem. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
