### PR TITLE
add custom PgConnection OrderBy function to enable unique orderBy

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Custom OrderBy plugin
+- Custom OrderBy plugin to improve dictionary query performance (#1907)
 
 ## [2.3.0] - 2023-07-04
 ### Changed

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Custom OrderBy plugin
 
 ## [2.3.0] - 2023-07-04
 ### Changed

--- a/packages/query/src/graphql/plugins/PgOrderByUnique.ts
+++ b/packages/query/src/graphql/plugins/PgOrderByUnique.ts
@@ -1,0 +1,177 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {PgClass, SQL} from '@subql/x-graphile-build-pg';
+import {Plugin} from 'graphile-build';
+import {GraphQLEnumType} from 'graphql';
+import isString from 'lodash/isString';
+import {argv} from '../../yargs';
+
+const PgConnectionArgOrderBy: Plugin = (builder, {orderByNullsLast}) => {
+  builder.hook(
+    'init',
+    (_, build) => {
+      const {
+        describePgEntity,
+        graphql: {GraphQLEnumType},
+        inflection,
+        newWithHooks,
+        pgIntrospectionResultsByKind: introspectionResultsByKind,
+        pgOmit: omit,
+        sqlCommentByAddingTags,
+      } = build;
+
+      introspectionResultsByKind.class.forEach((table: PgClass) => {
+        // PERFORMANCE: These used to be .filter(...) calls
+        if (!table.isSelectable || omit(table, 'order')) return;
+        if (!table.namespace) return;
+        const tableTypeName = inflection.tableType(table);
+        // const TableOrderByType =
+        newWithHooks(
+          GraphQLEnumType,
+          {
+            name: inflection.orderByType(tableTypeName),
+            description: build.wrapDescription(`Methods to use when ordering \`${tableTypeName}\`.`, 'type'),
+            values: {
+              [inflection.builtin('NATURAL')]: {
+                value: {
+                  alias: null,
+                  specs: [],
+                },
+              },
+            },
+          },
+          {
+            __origin: `Adding connection "orderBy" argument for ${describePgEntity(
+              table
+            )}. You can rename the table's GraphQL type via a 'Smart Comment':\n\n  ${sqlCommentByAddingTags(table, {
+              name: 'newNameHere',
+            })}`,
+            pgIntrospection: table,
+            isPgRowSortEnum: true,
+          }
+        );
+      });
+
+      return _;
+    },
+    ['PgConnectionArgOrderBy']
+  );
+
+  builder.hook(
+    'GraphQLObjectType:fields:field:args',
+    (args, build, context) => {
+      const {
+        extend,
+        getTypeByName,
+        graphql: {GraphQLList, GraphQLNonNull},
+        inflection,
+        pgGetGqlTypeByTypeIdAndModifier,
+        pgOmit: omit,
+        pgSql: sql,
+      } = build;
+      const {
+        Self,
+        addArgDataGenerator,
+        scope: {
+          fieldName,
+          isPgFieldConnection,
+          isPgFieldSimpleCollection,
+          pgFieldIntrospection,
+          pgFieldIntrospectionTable,
+        },
+      } = context;
+
+      if (!isPgFieldConnection && !isPgFieldSimpleCollection) {
+        return args;
+      }
+
+      const proc = pgFieldIntrospection.kind === 'procedure' ? pgFieldIntrospection : null;
+      const table: PgClass | null =
+        pgFieldIntrospection.kind === 'class' ? pgFieldIntrospection : proc ? pgFieldIntrospectionTable : null;
+
+      if (!table || !table.namespace || !table.isSelectable || omit(table, 'order')) {
+        return args;
+      }
+
+      if (proc) {
+        if (!proc.tags.sortable) {
+          return args;
+        }
+      }
+
+      const TableType = pgGetGqlTypeByTypeIdAndModifier(table.type.id, null);
+      const tableTypeName = TableType.name;
+      const TableOrderByType = getTypeByName(inflection.orderByType(tableTypeName)) as GraphQLEnumType;
+
+      const cursorPrefixFromOrderBy = (orderBy: any) => {
+        if (orderBy) {
+          const cursorPrefixes = [];
+
+          for (let itemIndex = 0, itemCount = orderBy.length; itemIndex < itemCount; itemIndex++) {
+            const item = orderBy[itemIndex];
+
+            if (item.alias) {
+              cursorPrefixes.push(sql.literal(item.alias));
+            }
+          }
+
+          if (cursorPrefixes.length > 0) {
+            return cursorPrefixes;
+          }
+        }
+
+        return null;
+      };
+
+      addArgDataGenerator(function connectionOrderBy({orderBy: rawOrderBy}: any) {
+        const orderBy = rawOrderBy ? (Array.isArray(rawOrderBy) ? rawOrderBy : [rawOrderBy]) : null;
+        return {
+          pgCursorPrefix: cursorPrefixFromOrderBy(orderBy),
+          pgQuery: (queryBuilder) => {
+            if (orderBy !== null) {
+              orderBy.forEach((item) => {
+                console.log('item: ', item);
+                const {specs, unique} = item;
+                const orders = Array.isArray(specs[0]) || specs.length === 0 ? specs : [specs];
+                orders.forEach(([col, ascending, specNullsFirst]) => {
+                  const expr = isString(col)
+                    ? sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(col)}`
+                    : col;
+
+                  // If the enum specifies null ordering, use that
+                  // Otherwise, use the orderByNullsLast option if present
+                  const nullsFirst =
+                    specNullsFirst !== null
+                      ? specNullsFirst
+                      : orderByNullsLast !== null
+                      ? !orderByNullsLast
+                      : undefined;
+                  queryBuilder.orderBy(expr, ascending, nullsFirst);
+                });
+
+                if (argv('dictionary-optimisation')) {
+                  queryBuilder.setOrderIsUnique();
+                }
+              });
+            }
+          },
+        };
+      });
+
+      return extend(
+        args,
+        {
+          orderBy: {
+            description: build.wrapDescription(`The method to use when ordering \`${tableTypeName}\`.`, 'arg'),
+            type: new GraphQLList(new GraphQLNonNull(TableOrderByType)),
+          },
+        },
+        `Adding 'orderBy' argument to field '${fieldName}' of '${Self.name}'`
+      );
+    },
+    ['PgConnectionArgOrderBy']
+  );
+};
+
+export default PgConnectionArgOrderBy;

--- a/packages/query/src/graphql/plugins/PgOrderByUnique.ts
+++ b/packages/query/src/graphql/plugins/PgOrderByUnique.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {PgClass, SQL} from '@subql/x-graphile-build-pg';
+import {PgClass} from '@subql/x-graphile-build-pg';
 import {Plugin} from 'graphile-build';
 import {GraphQLEnumType} from 'graphql';
 import isString from 'lodash/isString';
@@ -150,7 +150,7 @@ const PgConnectionArgOrderBy: Plugin = (builder, {orderByNullsLast}) => {
                   queryBuilder.orderBy(expr, ascending, nullsFirst);
                 });
 
-                if (argv('dictionary-optimisation')) {
+                if (argv('dictionary-optimisation') || unique) {
                   queryBuilder.setOrderIsUnique();
                 }
               });

--- a/packages/query/src/graphql/plugins/index.ts
+++ b/packages/query/src/graphql/plugins/index.ts
@@ -18,7 +18,6 @@ import PgBasicsPlugin from '@subql/x-graphile-build-pg/node8plus/plugins/PgBasic
 import PgIntrospectionPlugin from '@subql/x-graphile-build-pg/node8plus/plugins/PgIntrospectionPlugin';
 import PgTypesPlugin from '@subql/x-graphile-build-pg/node8plus/plugins/PgTypesPlugin';
 import PgTablesPlugin from '@subql/x-graphile-build-pg/node8plus/plugins/PgTablesPlugin';
-import PgConnectionArgOrderBy from '@subql/x-graphile-build-pg/node8plus/plugins/PgConnectionArgOrderBy';
 import PgConnectionArgOrderByDefaultValue from '@subql/x-graphile-build-pg/node8plus/plugins/PgConnectionArgOrderByDefaultValue';
 import PgConditionComputedColumnPlugin from '@subql/x-graphile-build-pg/node8plus/plugins/PgConditionComputedColumnPlugin';
 import PgAllRows from '@subql/x-graphile-build-pg/node8plus/plugins/PgAllRows';
@@ -53,6 +52,8 @@ import PgAggregationPlugin from './PgAggregationPlugin';
 import {PgBlockHeightPlugin} from './PgBlockHeightPlugin';
 import {PgRowByVirtualIdPlugin} from './PgRowByVirtualIdPlugin';
 import {PgDistinctPlugin} from './PgDistinctPlugin';
+import {makeAddPgTableOrderByPlugin, orderByAscDesc} from 'postgraphile';
+import PgConnectionArgOrderBy from './PgOrderByUnique';
 
 /* eslint-enable */
 
@@ -76,7 +77,6 @@ export const pgDefaultPlugins = [
   // PgJWTPlugin,
   PgTablesPlugin,
   PgConnectionArgFirstLastBeforeAfter,
-  PgConnectionArgOrderBy,
   PgConnectionArgOrderByDefaultValue,
   PgConditionComputedColumnPlugin,
   PgAllRows,
@@ -102,6 +102,7 @@ export const pgDefaultPlugins = [
 const plugins = [
   ...defaultPlugins,
   ...pgDefaultPlugins,
+  PgConnectionArgOrderBy,
   PgSimplifyInflectorPlugin,
   PgManyToManyPlugin,
   ConnectionFilterPlugin,


### PR DESCRIPTION
# Description
Add a custom PgConnectionArgOrderBy function to replace 
https://github.com/graphile/graphile-engine/blob/561606fb2af2003edf114b8f522b7a0e3ae1e13a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js#L5

as when attempting to utilise provided `makeAddPgTableOrderByPlugin` PgConnectionArgOrderBy will overwrite the unique value on provided entities.

Fixes #1904

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
