### PR TITLE
move indexBlock to base TestingService

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- moved `indexBlock` to base `TestingService` (#1913)
 
 ## [4.0.1] - 2023-07-31
 ### Fixed

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -60,12 +60,15 @@ export abstract class TestingService<A, SA, B, DS> {
   }
 
   abstract getTestRunner(): Promise<TestRunner<A, SA, B, DS>>; // TestRunner will be create with a new app instance
-  abstract indexBlock(
+
+  async indexBlock(
     block: B,
     handler: string,
     indexerManager: IIndexerManager<B, DS>,
     apiService?: IApi<A, SA, B>
-  ): Promise<void>;
+  ): Promise<void> {
+    await indexerManager.indexBlock(block, this.getDsWithHandler(handler));
+  }
 
   async init() {
     logger.info(`Found ${this.testSandboxes.length} test files`);


### PR DESCRIPTION
# Description
Moved indexBlock function to base TestingService. only substrate sdk will override this function.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
