### PR TITLE
fix poi operationHash and miss poi blocks

### DIFF
--- a/packages/node-core/src/indexer/mmr.service.ts
+++ b/packages/node-core/src/indexer/mmr.service.ts
@@ -69,8 +69,6 @@ export class MmrService extends baseMmrService implements OnApplicationShutdown 
   // This is the next block height that suppose to calculate its mmr value
   private _nextMmrBlockHeight?: number;
   private _poi?: PlainPoiModel;
-  private _syncPoiJob?: Promise<void>;
-
   constructor(
     nodeConfig: NodeConfig,
     private readonly storeCacheService: StoreCacheService,
@@ -108,7 +106,7 @@ export class MmrService extends baseMmrService implements OnApplicationShutdown 
     this._poi = poi;
   }
 
-  async syncPoiJob(logging?: boolean): Promise<void> {
+  private async syncPoiJob(logging?: boolean): Promise<void> {
     const poiBlocks = await this.poi.getPoiBlocksByRange(this.nextMmrBlockHeight);
     if (poiBlocks.length !== 0) {
       if (logging) {
@@ -162,10 +160,7 @@ export class MmrService extends baseMmrService implements OnApplicationShutdown 
     }
     logger.info(`MMR database start with next block height at ${this.nextMmrBlockHeight}`);
     while (!this.isShutdown) {
-      if (this._syncPoiJob !== undefined) {
-        await this._syncPoiJob;
-      }
-      this._syncPoiJob = this.syncPoiJob(logging);
+      await this.syncPoiJob(logging);
       if (exitHeight !== undefined && this.nextMmrBlockHeight > exitHeight) {
         break;
       }

--- a/packages/node-core/src/indexer/mmr.service.ts
+++ b/packages/node-core/src/indexer/mmr.service.ts
@@ -69,6 +69,7 @@ export class MmrService extends baseMmrService implements OnApplicationShutdown 
   // This is the next block height that suppose to calculate its mmr value
   private _nextMmrBlockHeight?: number;
   private _poi?: PlainPoiModel;
+  private _syncPoiJob?: Promise<void>;
 
   constructor(
     nodeConfig: NodeConfig,
@@ -107,6 +108,36 @@ export class MmrService extends baseMmrService implements OnApplicationShutdown 
     this._poi = poi;
   }
 
+  async syncPoiJob(logging?: boolean): Promise<void> {
+    const poiBlocks = await this.poi.getPoiBlocksByRange(this.nextMmrBlockHeight);
+    if (poiBlocks.length !== 0) {
+      if (logging) {
+        syncingMsg(poiBlocks[0].id, poiBlocks[poiBlocks.length - 1].id, poiBlocks.length);
+      }
+      const appendedBlocks: ProofOfIndex[] = [];
+      for (const block of poiBlocks) {
+        if (this.nextMmrBlockHeight < block.id) {
+          await this.addDefaultLeafWithRange(this.nextMmrBlockHeight, block.id);
+        }
+        // it is a single mmr node, safe to append without flush here
+        appendedBlocks.push(await this.appendMmrNode(block));
+        this.eventEmitter.emit(PoiEvent.LastPoiWithMmr, {
+          height: block.id,
+          timestamp: Date.now(),
+        });
+        this._nextMmrBlockHeight = block.id + 1;
+      }
+      // This should be safe, even poi bulkUpsert faild, filebased/postgres db node should already been written and accurate.
+      if (appendedBlocks.length) {
+        await this.poi.bulkUpsert(appendedBlocks);
+        this.storeCacheService.metadata.set(
+          'latestPoiWithMmr',
+          JSON.stringify(appendedBlocks[appendedBlocks.length - 1])
+        );
+      }
+    }
+  }
+
   // Exit option allow exit when POI is fully sync
   async syncFileBaseFromPoi(blockOffset: number, exitHeight?: number, logging?: boolean): Promise<void> {
     if (this.isSyncing) return;
@@ -131,50 +162,10 @@ export class MmrService extends baseMmrService implements OnApplicationShutdown 
     }
     logger.info(`MMR database start with next block height at ${this.nextMmrBlockHeight}`);
     while (!this.isShutdown) {
-      const poiBlocks = await this.poi.getPoiBlocksByRange(this.nextMmrBlockHeight);
-      if (poiBlocks.length !== 0) {
-        if (logging) {
-          syncingMsg(poiBlocks[0].id, poiBlocks[poiBlocks.length - 1].id, poiBlocks.length);
-        }
-        const appendedBlocks: ProofOfIndex[] = [];
-        for (const block of poiBlocks) {
-          if (this.nextMmrBlockHeight < block.id) {
-            await this.addDefaultLeafWithRange(this.nextMmrBlockHeight, block.id);
-          }
-          // it is a single mmr node, safe to append without flush here
-          appendedBlocks.push(await this.appendMmrNode(block));
-          this.eventEmitter.emit(PoiEvent.LastPoiWithMmr, {
-            height: block.id,
-            timestamp: Date.now(),
-          });
-          this._nextMmrBlockHeight = block.id + 1;
-        }
-        // This should be safe, even poi bulkUpsert faild, filebased/postgres db node should already been written and accurate.
-        if (appendedBlocks.length) {
-          await this.poi.bulkUpsert(appendedBlocks);
-          this.storeCacheService.metadata.set(
-            'latestPoiWithMmr',
-            JSON.stringify(appendedBlocks[appendedBlocks.length - 1])
-          );
-        }
-      } else {
-        const {lastPoiHeight, lastProcessedHeight} = await this.storeCacheService.metadata.findMany([
-          'lastPoiHeight',
-          'lastProcessedHeight',
-        ]);
-        // this.nextMmrBlockHeight means block before nextMmrBlockHeight-1 already exist in filebase mmr
-        if (this.nextMmrBlockHeight > Number(lastPoiHeight) && this.nextMmrBlockHeight <= Number(lastProcessedHeight)) {
-          if (logging) {
-            syncingMsg(
-              this.nextMmrBlockHeight,
-              Number(lastProcessedHeight),
-              Math.max(1, Number(lastProcessedHeight) - this.nextMmrBlockHeight)
-            );
-          }
-          await this.addDefaultLeafWithRange(this.nextMmrBlockHeight, Number(lastProcessedHeight) + 1);
-        }
-        await delay(MMR_AWAIT_TIME);
+      if (this._syncPoiJob !== undefined) {
+        await this._syncPoiJob;
       }
+      this._syncPoiJob = this.syncPoiJob(logging);
       if (exitHeight !== undefined && this.nextMmrBlockHeight > exitHeight) {
         break;
       }

--- a/packages/node-core/src/indexer/storeCache/cacheModel.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.spec.ts
@@ -25,6 +25,14 @@ jest.mock('@subql/x-sequelize', () => {
     query: () => [{nextval: 1}],
     showAllSchemas: () => ['subquery_1'],
     model: (entity: string) => ({
+      getTableName: () => 'table1',
+      sequelize: {
+        escape: (key: any) => key,
+        query: (sql: string, option?: any) => jest.fn(),
+        fn: jest.fn().mockImplementation(() => {
+          return {fn: 'int8range', args: [41204769, null]};
+        }),
+      },
       upsert: jest.fn(),
       associations: [{}, {}],
       count: 5,
@@ -135,5 +143,50 @@ describe('cacheModel', () => {
       const finalEntity = await testModel.get('entity1_id_0x01');
       expect(finalEntity?.field1).toEqual(3);
     });
+  });
+
+  describe('historical', () => {
+    let testModel: CachedModel<{id: string; field1: number}>;
+    let sequelize: Sequelize;
+
+    const flush = async () => {
+      const tx = await sequelize.transaction();
+
+      await testModel.flush(tx);
+
+      return tx.commit();
+    };
+
+    beforeEach(() => {
+      let i = 0;
+      sequelize = new Sequelize();
+      testModel = new CachedModel(sequelize.model('entity1'), true, {} as NodeConfig);
+      testModel.init(() => i++);
+    });
+
+    // it should keep same behavior as hook we used
+    it('when get data after flushed, it should exclude block range', async () => {
+      const spyDbGet = jest.spyOn(testModel.model, 'findOne');
+      const sypOnApplyBlockRange = jest.spyOn(testModel.model, 'applyBlockRange');
+      testModel.set(
+        'entity1_id_0x01',
+        {
+          id: 'entity1_id_0x01',
+          field1: 1,
+        },
+        1
+      );
+      await flush();
+      // the block range has been set
+      expect(sypOnApplyBlockRange).toBeCalledTimes(1);
+
+      const entity = await testModel.get('entity1_id_0x01');
+      if (!entity) {
+        throw new Error('Entity should exist');
+      }
+      // should read from get cache, and entity should exclude __block_range
+      expect(spyDbGet).not.toBeCalled();
+      expect(JSON.stringify(entity)).not.toContain('__block_range');
+    }, 500000);
   });
 });

--- a/packages/node-core/src/indexer/storeCache/cacheModel.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.ts
@@ -4,7 +4,7 @@
 import {CreationAttributes, Model, ModelStatic, Op, Sequelize, Transaction} from '@subql/x-sequelize';
 import {Fn} from '@subql/x-sequelize/types/utils';
 import {Mutex} from 'async-mutex';
-import {flatten, includes, isEqual, uniq} from 'lodash';
+import {flatten, includes, isEqual, uniq, cloneDeep} from 'lodash';
 import {NodeConfig} from '../../configure';
 import {SetValueModel} from './setValueModel';
 import {
@@ -322,12 +322,14 @@ export class CachedModel<
   }
 
   // Add blockRange to historical record
-  private applyBlockRange(setRecords: SetData<T>) {
+  private applyBlockRange(_setRecords: SetData<T>) {
+    const setRecords = cloneDeep(_setRecords);
     return flatten(
       Object.values(setRecords).map((v) => {
         if (!this.historical) {
           return v.getLatest()?.data;
         }
+
         // Historical
         return v.getValues().map((historicalValue) => {
           // Alternative: historicalValue.data.__block_range = [historicalValue.startHeight, historicalValue.endHeight];

--- a/packages/node-core/src/indexer/storeCache/cachePoi.ts
+++ b/packages/node-core/src/indexer/storeCache/cachePoi.ts
@@ -72,6 +72,13 @@ export class CachePoiModel implements ICachedModelControl, PoiInterface {
 
   async getPoiBlocksByRange(startHeight: number): Promise<ProofOfIndex[]> {
     await this.mutex.waitForUnlock();
+    const poiBlocks = await this.plainPoiModel.getPoiBlocksByRange(startHeight);
+    return poiBlocks.length !== 0 ? poiBlocks : [];
+  }
+
+  // Deprecated, due to data merged from cache is missing, see test case
+  async getPoiBlocksByRangeWithCache(startHeight: number): Promise<ProofOfIndex[]> {
+    await this.mutex.waitForUnlock();
     let poiBlocks = await this.plainPoiModel.getPoiBlocksByRange(startHeight);
     if (poiBlocks.length < DEFAULT_FETCH_RANGE) {
       // means less than DEFAULT_FETCH_RANGE size blocks in database, it has reach the end of poi in db,
@@ -138,7 +145,6 @@ export class CachePoiModel implements ICachedModelControl, PoiInterface {
     if (order === 'asc') {
       return ascending;
     }
-
     return ascending.reverse();
   }
 

--- a/packages/node-core/src/indexer/storeCache/cachePoi.ts
+++ b/packages/node-core/src/indexer/storeCache/cachePoi.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {DEFAULT_FETCH_RANGE} from '@subql/common';
-import {u8aToBuffer, u8aToHex} from '@subql/utils';
+import {u8aToBuffer} from '@subql/utils';
 import {Transaction} from '@subql/x-sequelize';
 import {Mutex} from 'async-mutex';
 import {getLogger} from '../../logger';
@@ -72,8 +72,7 @@ export class CachePoiModel implements ICachedModelControl, PoiInterface {
 
   async getPoiBlocksByRange(startHeight: number): Promise<ProofOfIndex[]> {
     await this.mutex.waitForUnlock();
-    const poiBlocks = await this.plainPoiModel.getPoiBlocksByRange(startHeight);
-    return poiBlocks.length !== 0 ? poiBlocks : [];
+    return this.plainPoiModel.getPoiBlocksByRange(startHeight);
   }
 
   // Deprecated, due to data merged from cache is missing, see test case


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1908 , instead of merge with data, we use data from plainModel only.  see this test case here to reproduce the issue. 
Fixes #1903 

Also, because change of `getPoiBlocksByRange` we removed this feature here, this is to avoid we skipped sync poi blocks within the cache. This also reduce the code complexity https://github.com/subquery/subql/blob/f30ff52b9b1a1b64ea02903dca8b261b85a348e5/packages/node-core/src/indexer/mmr.service.ts#L161


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
