### PR TITLE
[SKIP CI] publish subql node under subquerynetwork org

### DIFF
--- a/.github/workflows/node-docker.yml
+++ b/.github/workflows/node-docker.yml
@@ -8,7 +8,7 @@ on:
         require: true
 
 jobs:
-  node-build-push-docker:
+  node-build-push-docker-onfinality:
 
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +53,56 @@ jobs:
           platforms: arm64,amd64
           file: ./packages/node/Dockerfile
           tags: onfinality/subql-node:v${{ steps.get-node-version.outputs.NODE_VERSION }},onfinality/subql-node:latest
+          build-args: RELEASE_VERSION=${{ steps.get-node-version.outputs.NODE_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  node-build-push-docker-subquery:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
+          token: ${{ secrets.REPO_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: subquerynetwork
+          password: ${{ secrets.SQ_DOCKERHUB_TOKEN }}
+
+      ## node
+      - name: Get updated node version
+        id: get-node-version
+        run: |
+          sh .github/workflows/scripts/nodeVersion.sh
+
+      - name: Build and push
+        if: github.event.inputs.isLatest == 'false'
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: arm64,amd64
+          file: ./packages/node/Dockerfile
+          tags: subquerynetwork/subql-node-substrate:v${{ steps.get-node-version.outputs.NODE_VERSION }},
+          build-args: RELEASE_VERSION=${{ steps.get-node-version.outputs.NODE_VERSION }}
+
+      - name: Build and push
+        if: github.event.inputs.isLatest == 'true'
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: arm64,amd64
+          file: ./packages/node/Dockerfile
+          tags: subquerynetwork/subql-node-substrate:v${{ steps.get-node-version.outputs.NODE_VERSION }},subquerynetwork/subql-node-substrate:latest
           build-args: RELEASE_VERSION=${{ steps.get-node-version.outputs.NODE_VERSION }}
 
       - name: Image digest


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Closes #1875 

-  currently there is no way we can get auth from two org in the same time, and publish image with different org tag simultaneously 
- this way publish will run in parallel 
- easy for us to remove onfinality publish in future 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
