### PR TITLE
Add isSigned filter to call handler, improve dictionary filters

### DIFF
--- a/packages/common-substrate/CHANGELOG.md
+++ b/packages/common-substrate/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `isSigned` filter to call handler (#1940)
 
 ## [2.3.0] - 2023-08-10
 ### Changed

--- a/packages/common-substrate/src/project/models.ts
+++ b/packages/common-substrate/src/project/models.ts
@@ -78,6 +78,9 @@ export class CallFilter extends EventFilter implements SubstrateCallFilter {
   @IsOptional()
   @IsBoolean()
   success?: boolean;
+  @IsOptional()
+  @IsBoolean()
+  isSigned?: boolean;
 }
 
 export class BlockHandler implements SubstrateBlockHandler {

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `isSigned` filter (#1940)
+
+### Fixed
+- Dictionary query only working if `module` AND `method` filters are provided for call or event handlers (#1940)
 
 ## [2.11.1] - 2023-08-11
 ### Fixed
@@ -36,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed missing mmrQueryService in indexer module (#1885)
-- Sync 
+- Sync
   - for `@subql/apollo-links` update (#1886)
   - fix retry logic for workers in connection pool (#1829)
 

--- a/packages/node/src/utils/substrate.test.ts
+++ b/packages/node/src/utils/substrate.test.ts
@@ -3,7 +3,11 @@
 
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import Cron from 'cron-converter';
-import { fetchBlocksArray } from './substrate';
+import {
+  fetchBlocksArray,
+  fetchBlocksBatches,
+  filterExtrinsic,
+} from './substrate';
 
 const ENDPOINT_POLKADOT = 'wss://polkadot.api.onfinality.io/public-ws';
 const ENDPOINT_KARURA = 'wss://karura-rpc-0.aca-api.network';
@@ -34,11 +38,32 @@ describe('substrate utils', () => {
   it('validate block hash after fetch', async () => {
     // This endpoint has issue when fetch block 3467086
     const provider = new WsProvider(ENDPOINT_KARURA);
-    api = await ApiPromise.create({ provider });
+    const api = await ApiPromise.create({ provider });
     await expect(
       fetchBlocksArray(api, [3467085, 3467086]),
     ).rejects.toThrowError(
       'fetched block header hash 0xdcdd89927d8a348e00257e1ecc8617f45edb5118efff3ea2f9961b2ad9b7690a is not match with blockHash 0xd13a656c8c4cd7a6f7d03db8209eee9c597edffba1b7ee2dc40844089e10b21a at block 3467086',
     );
+
+    // This test creates another api instance, so we need to disconnect manually
+    await api.disconnect();
+  });
+
+  it('filters a signed extrinsic', async () => {
+    const [block] = await fetchBlocksBatches(api, [16832854]);
+
+    expect(
+      filterExtrinsic(block.extrinsics[0], { isSigned: true }),
+    ).toBeFalsy(); // Timestamp set
+    expect(
+      filterExtrinsic(block.extrinsics[2], { isSigned: true }),
+    ).toBeTruthy();
+
+    expect(
+      filterExtrinsic(block.extrinsics[0], { isSigned: false }),
+    ).toBeTruthy();
+    expect(
+      filterExtrinsic(block.extrinsics[2], { isSigned: false }),
+    ).toBeFalsy();
   });
 });

--- a/packages/node/src/utils/substrate.ts
+++ b/packages/node/src/utils/substrate.ts
@@ -182,7 +182,8 @@ export function filterExtrinsic(
       extrinsic.method.section === filter.module) &&
     (filter.method === undefined ||
       extrinsic.method.method === filter.method) &&
-    (filter.success === undefined || success === filter.success)
+    (filter.success === undefined || success === filter.success) &&
+    (filter.isSigned === undefined || extrinsic.isSigned === filter.isSigned)
   );
 }
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `isSigned` filter to call handler (#1940)
+
+### Changed
+- Allow boolean types in DictionaryQueryCondition (#1940)
 
 ## [2.1.4] - 2023-08-11
 ### Fixed

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -62,6 +62,7 @@ export interface SubstrateEventFilter extends SubstrateBaseHandlerFilter {
 
 export interface SubstrateCallFilter extends SubstrateEventFilter {
   success?: boolean;
+  isSigned?: boolean;
 }
 
 export type SubstrateBlockHandler = SubstrateCustomHandler<SubstrateHandlerKind.Block, SubstrateBlockFilter>;
@@ -176,7 +177,7 @@ export interface SubstrateDatasourceProcessor<
 
 export interface DictionaryQueryCondition {
   field: string;
-  value: string | string[];
+  value: string | string[] | boolean;
   matcher?: string; // defaults to "equalTo", use "contains" for JSON
 }
 


### PR DESCRIPTION
# Description
- Adds `isSigned` filter to call handlers
- Updates dictionary filters to include `isSigned` and `success` filters on extrinsics
- Removes requirement for `module` AND `method` to use dictionary query for call and event filters. Now just one is required

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/389
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
