### PR TITLE
Ensure absolute pathing `codegen:generate`

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Ensure absolute pathing for all path related flags (#1947)
 
 ## [3.5.0] - 2023-08-11
 ### Added

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import {Command, Flags} from '@oclif/core';
 import glob from 'glob';
 import {runWebpack} from '../controller/build-controller';
+import {resolveToAbsolutePath} from '../utils';
 
 export default class Build extends Command {
   static description = 'Build this SubQuery project code';
@@ -21,7 +22,7 @@ export default class Build extends Command {
     try {
       const {flags} = await this.parse(Build);
 
-      const directory = flags.location ? path.resolve(flags.location) : process.cwd();
+      const directory = flags.location ? resolveToAbsolutePath(flags.location) : process.cwd();
       const isDev = flags.mode === 'development' || flags.mode === 'dev';
 
       if (!lstatSync(directory).isDirectory()) {

--- a/packages/cli/src/commands/codegen/index.ts
+++ b/packages/cli/src/commands/codegen/index.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import {Command, Flags} from '@oclif/core';
 import {getProjectRootAndManifest, getSchemaPath} from '@subql/common';
 import {codegen} from '../../controller/codegen-controller';
+import {resolveToAbsolutePath} from '../../utils';
 
 export default class Codegen extends Command {
   static description = 'Generate schemas for graph node';
@@ -25,7 +26,7 @@ export default class Codegen extends Command {
 
     const {file, location} = flags;
 
-    const projectPath = path.resolve(file ?? location ?? process.cwd());
+    const projectPath = resolveToAbsolutePath(file ?? location ?? process.cwd());
 
     const {manifests, root} = getProjectRootAndManifest(projectPath);
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -250,12 +250,6 @@ export default class Init extends Command {
         type: 'input',
         name: 'abiFilePath',
         message: 'Path to ABI',
-        validate(input: string): boolean | string | Promise<boolean | string> {
-          if (!path.isAbsolute(path.resolve(input))) {
-            return 'Please enter an absolute file path';
-          }
-          return true;
-        },
       },
     ]);
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -23,6 +23,7 @@ import {
   validateEthereumProjectManifest,
 } from '../controller/init-controller';
 import {ProjectSpecBase} from '../types';
+import {resolveToAbsolutePath} from '../utils';
 import Generate from './codegen/generate';
 inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
 
@@ -88,7 +89,7 @@ export default class Init extends Command {
   async run(): Promise<void> {
     const {args, flags} = await this.parse(Init);
 
-    this.location = flags.location ? path.resolve(flags.location) : process.cwd();
+    this.location = flags.location ? resolveToAbsolutePath(flags.location) : process.cwd();
     this.project = {} as ProjectSpecBase;
     this.project.name = args.projectName
       ? args.projectName

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import {Command, Flags} from '@oclif/core';
 import {loadSubstrateProjectManifest, SubstrateProjectManifestVersioned} from '@subql/common-substrate';
 import {migrate, prepare} from '../controller/migrate-controller';
+import {resolveToAbsolutePath} from '../utils';
 
 export default class Migrate extends Command {
   static description = 'Migrate Subquery project manifest to v1.0.0';
@@ -17,7 +18,7 @@ export default class Migrate extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Migrate);
-    const location = flags.location ? path.resolve(flags.location) : process.cwd();
+    const location = flags.location ? resolveToAbsolutePath(flags.location) : process.cwd();
     let manifest: SubstrateProjectManifestVersioned;
     try {
       manifest = loadSubstrateProjectManifest(location);

--- a/packages/cli/src/commands/multi-chain/add.ts
+++ b/packages/cli/src/commands/multi-chain/add.ts
@@ -4,6 +4,7 @@
 import {Command, Flags} from '@oclif/core';
 import {cli} from 'cli-ux';
 import {addChain} from '../../controller/add-chain-controller';
+import {resolveToAbsolutePath} from '../../utils';
 
 export default class MultiChainAdd extends Command {
   static description = 'Add new chain manifest to multi-chain configuration';
@@ -23,6 +24,6 @@ export default class MultiChainAdd extends Command {
       chainManifestPath = await cli.prompt('Enter the path to the new chain manifest');
     }
 
-    await addChain(multichain, chainManifestPath);
+    await addChain(multichain, resolveToAbsolutePath(chainManifestPath));
   }
 }

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import {Command, Flags} from '@oclif/core';
 import {getMultichainManifestPath, getProjectRootAndManifest} from '@subql/common';
 import {createIPFSFile, uploadToIpfs} from '../controller/publish-controller';
+import {resolveToAbsolutePath} from '../utils';
 import Build from './build';
 
 const ACCESS_TOKEN_PATH = path.resolve(
@@ -24,7 +25,7 @@ export default class Publish extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Publish);
-    const location = flags.location ? path.resolve(flags.location) : process.cwd();
+    const location = flags.location ? resolveToAbsolutePath(flags.location) : process.cwd();
     const project = getProjectRootAndManifest(location);
 
     // Ensure that the project is built

--- a/packages/cli/src/controller/generate-controller.spec.ts
+++ b/packages/cli/src/controller/generate-controller.spec.ts
@@ -339,10 +339,4 @@ describe('CLI codegen:generate', () => {
     const absolutePath = '/root/Downloads/example.file';
     expect(resolveToAbsolutePath(absolutePath)).toBe(absolutePath);
   });
-  it('if relative path regex should resolve it to absolute', () => {
-    let relativePath = './Downloads/example.file';
-    expect(resolveToAbsolutePath(relativePath)).toBe('Downloads/example.file');
-    relativePath = '../Downloads/example.file';
-    expect(resolveToAbsolutePath(relativePath)).toBe(relativePath);
-  });
 });

--- a/packages/cli/src/controller/generate-controller.spec.ts
+++ b/packages/cli/src/controller/generate-controller.spec.ts
@@ -1,12 +1,14 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import os from 'os';
 import path from 'path';
 import {EventFragment, FunctionFragment} from '@ethersproject/abi/src.ts/fragments';
 import {EthereumDatasourceKind, EthereumHandlerKind, EthereumTransactionFilter} from '@subql/common-ethereum';
 import {SubqlRuntimeDatasource as EthereumDs, EthereumLogFilter} from '@subql/types-ethereum';
 import {parseContractPath} from 'typechain';
 import {SelectedMethod, UserInput} from '../commands/codegen/generate';
+import {resolveToAbsolutePath} from '../utils';
 import {
   constructDatasources,
   constructHandlerProps,
@@ -328,5 +330,19 @@ describe('CLI codegen:generate', () => {
     expect(getAbiInterface(mockPath_1, 'artifact.json')).toBeTruthy();
 
     expect(() => getAbiInterface(mockPath_2, 'artifact.json')).toThrow('Provided ABI is not a valid ABI or Artifact');
+  });
+  it('resolve to absolutePath from tilde', () => {
+    const tildePath = '~/Downloads/example.file';
+    expect(resolveToAbsolutePath(tildePath)).toBe(`${os.homedir()}/Downloads/example.file`);
+  });
+  it('if absolutePath regex should not do anything', () => {
+    const absolutePath = '/root/Downloads/example.file';
+    expect(resolveToAbsolutePath(absolutePath)).toBe(absolutePath);
+  });
+  it('if relative path regex should resolve it to absolute', () => {
+    let relativePath = './Downloads/example.file';
+    expect(resolveToAbsolutePath(relativePath)).toBe('Downloads/example.file');
+    relativePath = '../Downloads/example.file';
+    expect(resolveToAbsolutePath(relativePath)).toBe(relativePath);
   });
 });

--- a/packages/cli/src/controller/generate-controller.ts
+++ b/packages/cli/src/controller/generate-controller.ts
@@ -19,7 +19,7 @@ import {upperFirst, difference, pickBy} from 'lodash';
 import {parseContractPath} from 'typechain';
 import {Document, parseDocument, YAMLSeq} from 'yaml';
 import {SelectedMethod, UserInput} from '../commands/codegen/generate';
-import {renderTemplate} from '../utils';
+import {renderTemplate, resolveToAbsolutePath} from '../utils';
 
 interface HandlerPropType {
   name: string;
@@ -53,7 +53,8 @@ export async function prepareAbiDirectory(abiPath: string, rootPath: string): Pr
   }
 
   // Ensure abiPath is an absolute path
-  const ensuredAbiPath = path.isAbsolute(abiPath) ? abiPath : path.resolve(rootPath, abiPath);
+  const ensuredAbiPath = path.isAbsolute(abiPath) ? abiPath : resolveToAbsolutePath(abiPath);
+
   try {
     const abiFileContent = await fs.promises.readFile(ensuredAbiPath, 'utf8');
     await fs.promises.writeFile(path.join(abiDirPath, path.basename(ensuredAbiPath)), abiFileContent);

--- a/packages/cli/src/controller/generate-controller.ts
+++ b/packages/cli/src/controller/generate-controller.ts
@@ -53,7 +53,7 @@ export async function prepareAbiDirectory(abiPath: string, rootPath: string): Pr
   }
 
   // Ensure abiPath is an absolute path
-  const ensuredAbiPath = path.isAbsolute(abiPath) ? abiPath : resolveToAbsolutePath(abiPath);
+  const ensuredAbiPath = resolveToAbsolutePath(abiPath);
 
   try {
     const abiFileContent = await fs.promises.readFile(ensuredAbiPath, 'utf8');

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -97,6 +97,8 @@ export async function prepareDirPath(path: string, recreate: boolean): Promise<v
   }
 }
 
+// oclif's default path resolver only applies when parsed as `--flag path`
+// else it would not resolve, hence we need to resolve it manually.
 export function resolveToAbsolutePath(inputPath: string): string {
   const regex = new RegExp(`^~(?=$|[/\\\\])`);
   return path.normalize(inputPath.replace(regex, os.homedir()));

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import fs, {existsSync, readFileSync} from 'fs';
+import os from 'os';
+import path from 'path';
 import {promisify} from 'util';
 import axios from 'axios';
 import cli, {ux} from 'cli-ux';
@@ -93,4 +95,9 @@ export async function prepareDirPath(path: string, recreate: boolean): Promise<v
   } catch (e) {
     throw new Error(`Failed to prepare ${path}: ${e.message}`);
   }
+}
+
+export function resolveToAbsolutePath(inputPath: string): string {
+  const regex = new RegExp(`^~(?=$|[/\\\\])`);
+  return path.normalize(inputPath.replace(regex, os.homedir()));
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -101,5 +101,5 @@ export async function prepareDirPath(path: string, recreate: boolean): Promise<v
 // else it would not resolve, hence we need to resolve it manually.
 export function resolveToAbsolutePath(inputPath: string): string {
   const regex = new RegExp(`^~(?=$|[/\\\\])`);
-  return path.normalize(inputPath.replace(regex, os.homedir()));
+  return path.resolve(inputPath.replace(regex, os.homedir()));
 }


### PR DESCRIPTION
# Description
Ensure that provided pathing for abi file for command `codegen:generate` is absolute

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
