### PR TITLE
Fix dictionary query using wrong field for method/call

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Incorrect dictionary query for methods/calls filter (#1950)
 
 ## [2.12.0] - 2023-08-16
 ### Added

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -65,7 +65,7 @@ function callFilterToQueryEntry(
     conditions: Object.keys(filter).map(
       (key) =>
         ({
-          field: key,
+          field: key === 'method' ? 'call' : key,
           value: filter[key],
         } as DictionaryQueryCondition),
     ),


### PR DESCRIPTION
# Description
Fixes building the dictionary query filter for extrinsic calls that was introduced here https://github.com/subquery/subql/pull/1940/files#diff-fcb06f77cc4b787f2ed3c116347e39144575cd2ce8fb07af6b6ea11ef0ac2a05L67

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
