### PR TITLE
delay getPoiBlocksByRange when fully synced

### DIFF
--- a/packages/node-core/src/indexer/mmr.service.ts
+++ b/packages/node-core/src/indexer/mmr.service.ts
@@ -4,7 +4,13 @@
 import fs from 'fs';
 import {Injectable, OnApplicationShutdown} from '@nestjs/common';
 import {EventEmitter2} from '@nestjs/event-emitter';
-import {DEFAULT_WORD_SIZE, DEFAULT_LEAF, MMR_AWAIT_TIME, RESET_MMR_BLOCK_BATCH} from '@subql/common';
+import {
+  DEFAULT_WORD_SIZE,
+  DEFAULT_LEAF,
+  MMR_AWAIT_TIME,
+  RESET_MMR_BLOCK_BATCH,
+  DEFAULT_FETCH_RANGE,
+} from '@subql/common';
 import {u8aToHex, u8aEq} from '@subql/utils';
 import {MMR, FileBasedDb} from '@subql/x-merkle-mountain-range';
 import {Op} from '@subql/x-sequelize';
@@ -133,6 +139,9 @@ export class MmrService extends baseMmrService implements OnApplicationShutdown 
           JSON.stringify(appendedBlocks[appendedBlocks.length - 1])
         );
       }
+    }
+    if (poiBlocks.length < DEFAULT_FETCH_RANGE) {
+      await delay(MMR_AWAIT_TIME);
     }
   }
 


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

Poi is keep make query when project is fully synced, this could be the cause of increase cpu usage for indexer and database.

When getPoiBlocksByRange didn't get more than `DEFAULT_FETCH_RANGE`, which means poi is almost fully synced, we add a delay here to ensure `getPoiBlocksByRange` only get called again after few seconds. 

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
