### PR TITLE
Fix dependency missing when trying to run testing framework

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Testing framework not starting because of missing dependency (#1955)
 
 ## [2.12.1] - 2023-08-17
 ### Fixed

--- a/packages/node/src/subcommands/testing.module.ts
+++ b/packages/node/src/subcommands/testing.module.ts
@@ -6,6 +6,7 @@ import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule, SchedulerRegistry } from '@nestjs/schedule';
 import {
   ConnectionPoolService,
+  ConnectionPoolStateManager,
   DbModule,
   NodeConfig,
   PoiService,
@@ -35,6 +36,7 @@ import { MetaModule } from '../meta/meta.module';
     DynamicDsService,
     ProjectService,
     UnfinalizedBlocksService,
+    ConnectionPoolStateManager,
     ConnectionPoolService,
     {
       provide: 'IProjectService',


### PR DESCRIPTION
# Description
Fix testing framework not running because of missing ConnectionPoolStateManager dependency

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
