### PR TITLE
count each test runs as one test

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use test runs as unit for tests instead of entity checks (#1957)
 
 ## [4.2.3] - 2023-08-17
 ### Fixed

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -130,8 +130,8 @@ export abstract class TestingService<A, SA, B, DS> {
       this.indexBlock.bind(this)
     );
 
-    this.totalPassedTests += passedTests;
-    this.totalFailedTests += failedTests;
+    failedTests > 0 ? this.totalFailedTests++ : this.totalPassedTests++;
+
     if (failedTestSummary) {
       this.failedTestsSummary.push(failedTestSummary);
     }


### PR DESCRIPTION
# Description
Each test runs should be counted as 1 unit of test instead of each entities with in a test

Fixes https://github.com/subquery/subql-cosmos/issues/158

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
