### PR TITLE
CLI Publish improvements

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Publish command uploading files to IPFS multiple times (#1967)
 
 ## [3.5.1] - 2023-08-16
 ### Fixed

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -6,21 +6,14 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {promisify} from 'util';
-import {NETWORK_FAMILY, ReaderFactory} from '@subql/common';
+import {ReaderFactory} from '@subql/common';
 import {parseSubstrateProjectManifest, ProjectManifestV1_0_0Impl} from '@subql/common-substrate';
 import {create} from 'ipfs-http-client';
 import rimraf from 'rimraf';
 import Build from '../commands/build';
 import Codegen from '../commands/codegen';
 import Publish from '../commands/publish';
-import {
-  isProjectSpecV0_0_1,
-  isProjectSpecV1_0_0,
-  ProjectSpecBase,
-  ProjectSpecV0_0_1,
-  ProjectSpecV0_2_0,
-  ProjectSpecV1_0_0,
-} from '../types';
+import {ProjectSpecBase, ProjectSpecV0_0_1, ProjectSpecV0_2_0, ProjectSpecV1_0_0} from '../types';
 import {cloneProjectTemplate, fetchTemplates, prepare} from './init-controller';
 import {uploadFile, uploadToIpfs} from './publish-controller';
 
@@ -109,7 +102,7 @@ describe('Cli publish', () => {
     const ipfs = create({url: ipfsEndpoint});
 
     //test string
-    const cid = (await uploadFile([{path: '', content: 'Test for upload string to ipfs'}], testAuth)).get('');
+    const cid = await uploadFile({path: '', content: 'Test for upload string to ipfs'}, testAuth);
     console.log(`upload file cid: ${cid}`);
   });
 

--- a/packages/cli/src/controller/publish-controller.ts
+++ b/packages/cli/src/controller/publish-controller.ts
@@ -3,7 +3,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import {Readable} from 'stream';
 import {ReaderFactory, IPFS_CLUSTER_ENDPOINT, Reader} from '@subql/common';
 import {parseAlgorandProjectManifest} from '@subql/common-algorand';
 import {parseCosmosProjectManifest} from '@subql/common-cosmos';
@@ -11,10 +10,8 @@ import {parseEthereumProjectManifest} from '@subql/common-ethereum';
 import {parseEthereumProjectManifest as parseFlareProjectManifest} from '@subql/common-flare';
 import {parseNearProjectManifest} from '@subql/common-near';
 import {parseStellarProjectManifest} from '@subql/common-stellar';
-import {parseSubstrateProjectManifest, manifestIsV0_0_1} from '@subql/common-substrate';
+import {parseSubstrateProjectManifest} from '@subql/common-substrate';
 import {FileReference} from '@subql/types';
-import axios from 'axios';
-import FormData from 'form-data';
 import {IPFSHTTPClient, create} from 'ipfs-http-client';
 
 export async function createIPFSFile(root: string, manifest: string, cid: string): Promise<void> {
@@ -52,43 +49,30 @@ export async function uploadToIpfs(
 
   for (const project in projectToReader) {
     const reader = projectToReader[project];
-    let manifest;
     const schema = await reader.getProjectSchema();
 
-    //substrate
-    try {
-      manifest = parseSubstrateProjectManifest(schema).asImpl;
-      if (manifestIsV0_0_1(manifest)) {
-        throw new Error('Unsupported project manifest spec, only 0.2.0 or greater is supported');
-      }
-    } catch (e) {
-      // cosmos
+    const parsingFunctions = [
+      parseSubstrateProjectManifest,
+      parseCosmosProjectManifest,
+      parseAlgorandProjectManifest,
+      parseEthereumProjectManifest,
+      parseFlareProjectManifest,
+      parseNearProjectManifest,
+      parseStellarProjectManifest,
+    ];
+
+    let manifest = null;
+    for (const parseFunction of parsingFunctions) {
       try {
-        manifest = parseCosmosProjectManifest(schema).asImpl;
+        manifest = parseFunction(schema).asImpl;
+        break; // Exit the loop if successful
       } catch (e) {
-        // algorand
-        try {
-          manifest = parseAlgorandProjectManifest(schema).asImpl;
-        } catch (e) {
-          try {
-            manifest = parseEthereumProjectManifest(schema).asImpl;
-          } catch (e) {
-            try {
-              manifest = parseFlareProjectManifest(schema).asImpl;
-            } catch (e) {
-              try {
-                manifest = parseNearProjectManifest(schema).asImpl;
-              } catch (e) {
-                try {
-                  manifest = parseStellarProjectManifest(schema).asImpl;
-                } catch (e) {
-                  throw new Error('Unable to pass project manifest');
-                }
-              }
-            }
-          }
-        }
+        // Continue to the next parsing function
       }
+    }
+
+    if (manifest === null) {
+      throw new Error('Unable to parse project manifest');
     }
 
     const deployment = await replaceFileReferences(reader.root, manifest, authToken, ipfs);
@@ -107,7 +91,7 @@ export async function uploadToIpfs(
   }
 
   // Upload schema
-  return uploadFile(contents, authToken, ipfs);
+  return uploadFiles(contents, authToken, ipfs);
 }
 
 /* Recursively finds all FileReferences in an object and replaces the files with IPFS references */
@@ -126,12 +110,13 @@ async function replaceFileReferences<T>(
       input = mapToObject(input) as T;
     }
     if (isFileReference(input)) {
+      const filePath = path.resolve(projectDir, input.file);
       const content = fs.readFileSync(path.resolve(projectDir, input.file));
-      input.file = await uploadFile([{content: content.toString(), path: ''}], authToken, ipfs).then(
-        (fileToCidMap) => `ipfs://${fileToCidMap.get('')}`
+      input.file = await uploadFile({content: content.toString(), path: filePath}, authToken, ipfs).then(
+        (cid) => `ipfs://${cid}`
       );
     }
-    const keys = Object.keys(input) as unknown as (keyof T)[];
+    const keys = Object.keys(input).filter((key) => key !== '_deployment') as unknown as (keyof T)[];
     await Promise.all(
       keys.map(async (key) => {
         // this is the loop
@@ -143,9 +128,9 @@ async function replaceFileReferences<T>(
   return input;
 }
 
-const fileMap = new Map<string | fs.ReadStream, string>();
+const fileMap = new Map<string | fs.ReadStream, Promise<string>>();
 
-export async function uploadFile(
+export async function uploadFiles(
   contents: {path: string; content: string}[],
   authToken: string,
   ipfs?: IPFSHTTPClient
@@ -164,96 +149,65 @@ export async function uploadFile(
     }
   }
 
-  let ipfsClusterContent;
+  const ipfsCluster = create({
+    url: IPFS_CLUSTER_ENDPOINT,
+    headers: {Authorization: `Bearer ${authToken}`},
+  });
+
   try {
-    ipfsClusterContent = await uploadFileByCluster(contents, authToken);
+    const results = ipfsCluster.addAll(contents, {pin: true, cidVersion: 0});
+
+    for await (const result of results) {
+      fileCidMap.set(result.path, result.cid.toString());
+    }
   } catch (e) {
     throw new Error(`Publish project to default cluster failed, ${e}`);
   }
 
-  ipfsClusterContent.map((clusterContent) => {
-    const clientCid = fileMap.get(clusterContent.content);
-    if (clientCid !== clusterContent.cid) {
-      throw new Error(`Published and received IPFS cid not identical for ${clusterContent.name}\n,
-      IPFS gateway: ${clientCid}, IPFS cluster: ${clusterContent.cid}`);
-    }
-
-    fileCidMap.set(clusterContent.name, clusterContent.cid);
-  });
-
   return fileCidMap;
 }
 
-async function uploadFileByCluster(
-  content: {path: string; content: string}[],
-  authToken: string
-): Promise<{name: string; content: string; cid: string}[]> {
-  // Determine the endpoint based on the number of content items
-  const endpoint = content.length > 1 ? `${IPFS_CLUSTER_ENDPOINT}?wrap-with-directory=true` : IPFS_CLUSTER_ENDPOINT;
-
-  // Identify new files not present in the fileMap
-  const newFiles = content.filter((ct) => !fileMap.has(ct.content));
-
-  // If all content is available in fileMap, return the results using existing CIDs
-  if (newFiles.length === 0) {
-    return content.map((ct) => ({name: ct.path, content: ct.content, cid: fileMap.get(ct.content) as string}));
+export async function uploadFile(
+  contents: {path: string; content: string},
+  authToken: string,
+  ipfs?: IPFSHTTPClient
+): Promise<string> {
+  if (fileMap.has(contents.path)) {
+    return fileMap.get(contents.path);
   }
 
-  // Create FormData and append new files
-  const bodyFormData = new FormData();
-  newFiles.forEach((ct) => bodyFormData.append('file', Readable.from(ct.content), {filepath: ct.path}));
-
-  // Perform the axios request to upload files
-  const result = await axios.post(endpoint, bodyFormData, {
-    headers: {
-      Authorization: `Bearer ${authToken}`,
-      'Content-Type': 'multipart/form-data',
-      ...bodyFormData.getHeaders(),
-    },
-    maxBodyLength: 50 * 1024 * 1024, // 50 MB
-    maxContentLength: 50 * 1024 * 1024,
-  });
-
-  // Parse the axios response
-  let parsedResult;
-  if (typeof result.data === 'string') {
-    parsedResult = result.data.split(/\r?\n/).reduce((accumulator, res) => {
-      if (res !== '') {
-        accumulator.push(JSON.parse(res));
-      }
-      return accumulator;
-    }, []);
-  } else {
-    parsedResult = Array.isArray(result.data) ? result.data : [result.data];
+  let pendingClientCid: Promise<string>;
+  if (ipfs) {
+    pendingClientCid = ipfs
+      .add(contents.content, {pin: true, cidVersion: 0})
+      .then((result) => result.cid.toString())
+      .catch((e) => {
+        throw new Error(`Publish project to default cluster failed, ${e}`);
+      });
   }
 
-  // Process the parsed result to obtain the uploaded files data
-  const uploadedFiles = parsedResult.map((res) => {
-    // Extract the CID from the response
-    const cid = res.cid?.['/'] || res.cid;
-    if (!cid) throw new Error('Failed to get CID from IPFS response');
-
-    // Find the corresponding content item for the uploaded file
-    const ct = content.find((ct) => ct.path === res.name);
-
-    // Create the file data object for the uploaded file
-    const fileData = ct
-      ? {name: ct.path, content: ct.content, cid: cid.toString()}
-      : {name: res.name, content: res.name, cid: cid.toString()};
-
-    // Update the fileMap with the new CID
-    fileMap.set(fileData.content, fileData.cid);
-
-    return fileData;
+  const ipfsCluster = create({
+    url: IPFS_CLUSTER_ENDPOINT,
+    headers: {Authorization: `Bearer ${authToken}`},
   });
 
-  // Include the CIDs from the fileMap for the files that were not uploaded in this request
-  const existingFiles = content
-    .filter((ct) => !newFiles.includes(ct))
-    .map((ct) => ({name: ct.path, content: ct.content, cid: fileMap.get(ct.content) as string}));
+  const pendingCid = ipfsCluster
+    .add(contents.content, {pin: true, cidVersion: 0})
+    .then((result) => result.cid.toString())
+    .catch((e) => {
+      throw new Error(`Publish project to default cluster failed, ${e}`);
+    });
 
-  // Combine the results from uploaded and existing files
-  return [...uploadedFiles, ...existingFiles];
+  fileMap.set(contents.path, pendingCid);
+
+  const [clusterCid, clientCid] = await Promise.all([pendingCid, pendingClientCid]);
+
+  if (clientCid && clientCid !== clusterCid) {
+    throw new Error(`Published and received IPFS cid not identical \n,
+    IPFS gateway: ${clientCid}, IPFS cluster: ${clusterCid}`);
+  }
+
+  return clusterCid;
 }
 
 function mapToObject(map: Map<string | number, unknown>): Record<string | number, unknown> {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update ipfs-http-api (#1967)
 
 ## [2.5.0] - 2023-08-10
 ### Added

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "fs-extra": "^10.1.0",
-    "ipfs-http-client": "^52.0.3",
+    "ipfs-http-client": "56",
     "js-yaml": "^4.1.0",
     "reflect-metadata": "^0.1.13",
     "semver": "^7.5.2",

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -8,7 +8,7 @@ export const DEFAULT_PORT = 3000;
 export const IPFS_READ = 'https://unauthipfs.subquery.network';
 export const IPFS_WRITE = 'https://authipfs.subquery.network';
 export const IPFS_NODE_ENDPOINT = `${IPFS_READ}/ipfs/api/v0`;
-export const IPFS_CLUSTER_ENDPOINT = `${IPFS_WRITE}/cluster/add`;
+export const IPFS_CLUSTER_ENDPOINT = `${IPFS_WRITE}/ipfs/api/v0`;
 export const IPFS_REGEX = /^ipfs:\/\//i;
 
 // MANIFEST

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -8,7 +8,7 @@ export const DEFAULT_PORT = 3000;
 export const IPFS_READ = 'https://unauthipfs.subquery.network';
 export const IPFS_WRITE = 'https://authipfs.subquery.network';
 export const IPFS_NODE_ENDPOINT = `${IPFS_READ}/ipfs/api/v0`;
-export const IPFS_CLUSTER_ENDPOINT = `${IPFS_WRITE}/ipfs/api/v0`;
+export const IPFS_WRITE_ENDPOINT = `${IPFS_WRITE}/ipfs/api/v0`;
 export const IPFS_REGEX = /^ipfs:\/\//i;
 
 // MANIFEST

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:12-alpine
+    image: postgres:15-alpine
     ports:
       - 5432:5432
     environment:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,13 +2565,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ipld/dag-cbor@npm:^6.0.5":
+"@ipld/dag-cbor@npm:^6.0.3, @ipld/dag-cbor@npm:^6.0.5":
   version: 6.0.15
   resolution: "@ipld/dag-cbor@npm:6.0.15"
   dependencies:
     cborg: ^1.5.4
     multiformats: ^9.5.4
   checksum: c4ac8d7d271b9dd093c43495b1f24c3cdb7f10487aac529c2010c53a3320439ac9b17f53f02177e022735a1aae3d921f359c7020f765b72f94799ec3ff8e7207
+  languageName: node
+  linkType: hard
+
+"@ipld/dag-cbor@npm:^7.0.0":
+  version: 7.0.3
+  resolution: "@ipld/dag-cbor@npm:7.0.3"
+  dependencies:
+    cborg: ^1.6.0
+    multiformats: ^9.5.4
+  checksum: c0c59907ab6146a214c1ecb2341cc02904bc952255e15544554990690f7841380a87636d5937aaa23e9004b1c141e90238277d088ed6932b5b0e6d2e6ee1fe02
+  languageName: node
+  linkType: hard
+
+"@ipld/dag-json@npm:^8.0.1":
+  version: 8.0.11
+  resolution: "@ipld/dag-json@npm:8.0.11"
+  dependencies:
+    cborg: ^1.5.4
+    multiformats: ^9.5.4
+  checksum: 5ce25e4ed4004839a0dc18a51b09d0e2bda02a00bc15e8066809ddcedf5927ef8829a7dacaaf71ba0eb1c8699599130389af6d137da1d6f524394f5ddb0763f0
   languageName: node
   linkType: hard
 
@@ -4545,7 +4565,7 @@ __metadata:
     class-transformer: ^0.5.1
     class-validator: ^0.14.0
     fs-extra: ^10.1.0
-    ipfs-http-client: ^52.0.3
+    ipfs-http-client: 56
     js-yaml: ^4.1.0
     reflect-metadata: ^0.1.13
     semver: ^7.5.2
@@ -6451,6 +6471,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"any-signal@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "any-signal@npm:3.0.1"
+  checksum: 073eb14c365b7552f9f16fbf36cd76171e4a0fe156a8faa865fe1d5ac4ed2f5c5ab6e3faad0ac0d4c69511b5892971c5573baa8a1cbf85fe250d0c54ff0734ff
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:^3.0.3, anymatch@npm:~3.1.2":
   version: 3.1.2
   resolution: "anymatch@npm:3.1.2"
@@ -7303,7 +7330,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browser-readablestream-to-it@npm:^1.0.1, browser-readablestream-to-it@npm:^1.0.3":
+"browser-readablestream-to-it@npm:^1.0.0, browser-readablestream-to-it@npm:^1.0.1, browser-readablestream-to-it@npm:^1.0.3":
   version: 1.0.3
   resolution: "browser-readablestream-to-it@npm:1.0.3"
   checksum: 07895bbc54cdeea62c8e9b7e32d374ec5c340ed1d0bc0c6cd6f1e0561ad931b160a3988426c763672ddf38ac1f75e45b9d8ae267b43f387183edafcad625f30a
@@ -7680,6 +7707,15 @@ __metadata:
   bin:
     cborg: cli.js
   checksum: 856d0bb10dae4ae4528b120b078525427a01490ebbfea0ece18f01502caa834f6924a09e3ea3e09b1d015150c3fa1e6e02358a26f84a4abf1d1c36403bd1a7c9
+  languageName: node
+  linkType: hard
+
+"cborg@npm:^1.6.0":
+  version: 1.10.2
+  resolution: "cborg@npm:1.10.2"
+  bin:
+    cborg: cli.js
+  checksum: 7743a8f125046ac27fb371c4ea18af54fbe853f7210f1ffacc6504a79566480c39d52ac4fbc1a5b5155e27b13c3b58955dc29db1bf20c4d651549d55fec2fa7f
   languageName: node
   linkType: hard
 
@@ -8586,6 +8622,16 @@ __metadata:
     es5-ext: ^0.10.50
     type: ^1.0.1
   checksum: 49ca0639c7b822db670de93d4fbce44b4aa072cd848c76292c9978a8cd0fff1028763020ff4b0f147bd77bfe29b4c7f82e0f71ade76b2a06100543cdfd948d19
+  languageName: node
+  linkType: hard
+
+"dag-jose@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "dag-jose@npm:1.0.0"
+  dependencies:
+    "@ipld/dag-cbor": ^6.0.3
+    multiformats: ^9.0.2
+  checksum: 2d95e938f08c383718dd6f07d92063f164bb85be831f624f122687ca3f4d365a76320c3f6f16cfbe013c581198504728abd226567775ef35fb40176e1cb23112
   languageName: node
   linkType: hard
 
@@ -11420,10 +11466,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"interface-datastore@npm:^6.0.2":
+  version: 6.1.1
+  resolution: "interface-datastore@npm:6.1.1"
+  dependencies:
+    interface-store: ^2.0.2
+    nanoid: ^3.0.2
+    uint8arrays: ^3.0.0
+  checksum: a0388adabf029be229bbfce326bbe64fd3353373512e7e6ed4283e06710bfa141db118e3536f8535a65016a0abeec631b888d42790b00637879d6ae56cf728cd
+  languageName: node
+  linkType: hard
+
 "interface-store@npm:^1.0.2":
   version: 1.0.2
   resolution: "interface-store@npm:1.0.2"
   checksum: 62039ad87f6fc7330b1e78b1aa448174f6f6bb05993535ed8afd14abc02b64321c80e9ffd0f2f824f343408ccd0e4e9150ba782b4f781d68882bd2c5dd56aab6
+  languageName: node
+  linkType: hard
+
+"interface-store@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "interface-store@npm:2.0.2"
+  checksum: 0e80adb1de9ff57687cfa1b08499702b72cacf33a7e0320ac7781989f3685d73f2a84996358f540250229afa19c7acebf03085087762f718035622ea6a1a5b8a
   languageName: node
   linkType: hard
 
@@ -11466,6 +11530,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ipfs-core-types@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "ipfs-core-types@npm:0.10.3"
+  dependencies:
+    "@ipld/dag-pb": ^2.1.3
+    interface-datastore: ^6.0.2
+    ipfs-unixfs: ^6.0.3
+    multiaddr: ^10.0.0
+    multiformats: ^9.5.1
+  checksum: 2a36b0ac72b98011aed333b57253d87fd5888e9e102fa3dd8f9e2dcf1b5e8c8f5582fbe3957ec24a445cec207943ea4ce4cc839770a794b273fd8b66a7a0de9d
+  languageName: node
+  linkType: hard
+
 "ipfs-core-types@npm:^0.7.3":
   version: 0.7.3
   resolution: "ipfs-core-types@npm:0.7.3"
@@ -11498,6 +11575,60 @@ __metadata:
     timeout-abort-controller: ^1.1.1
     uint8arrays: ^3.0.0
   checksum: 9f3531d80f69011553c245835914de93e099f710feea88fbb000f10e0de44b7ab7e70437c9c135783683e08915f31279ab90829825def31c801b8ed9b5d79433
+  languageName: node
+  linkType: hard
+
+"ipfs-core-utils@npm:^0.14.3":
+  version: 0.14.3
+  resolution: "ipfs-core-utils@npm:0.14.3"
+  dependencies:
+    any-signal: ^3.0.0
+    blob-to-it: ^1.0.1
+    browser-readablestream-to-it: ^1.0.1
+    debug: ^4.1.1
+    err-code: ^3.0.1
+    ipfs-core-types: ^0.10.3
+    ipfs-unixfs: ^6.0.3
+    ipfs-utils: ^9.0.6
+    it-all: ^1.0.4
+    it-map: ^1.0.4
+    it-peekable: ^1.0.2
+    it-to-stream: ^1.0.0
+    merge-options: ^3.0.4
+    multiaddr: ^10.0.0
+    multiaddr-to-uri: ^8.0.0
+    multiformats: ^9.5.1
+    nanoid: ^3.1.23
+    parse-duration: ^1.0.0
+    timeout-abort-controller: ^3.0.0
+    uint8arrays: ^3.0.0
+  checksum: ed1bceef0677e050a06db3cc0fdd659ffaac256d89fedfa01633747675c1519ba01985d5adf5db40d7d82631028c363564a2c53678b9a665c54c75d287065d08
+  languageName: node
+  linkType: hard
+
+"ipfs-http-client@npm:56":
+  version: 56.0.3
+  resolution: "ipfs-http-client@npm:56.0.3"
+  dependencies:
+    "@ipld/dag-cbor": ^7.0.0
+    "@ipld/dag-json": ^8.0.1
+    "@ipld/dag-pb": ^2.1.3
+    any-signal: ^3.0.0
+    dag-jose: ^1.0.0
+    debug: ^4.1.1
+    err-code: ^3.0.1
+    ipfs-core-types: ^0.10.3
+    ipfs-core-utils: ^0.14.3
+    ipfs-utils: ^9.0.6
+    it-first: ^1.0.6
+    it-last: ^1.0.4
+    merge-options: ^3.0.4
+    multiaddr: ^10.0.0
+    multiformats: ^9.5.1
+    parse-duration: ^1.0.0
+    stream-to-it: ^0.2.2
+    uint8arrays: ^3.0.0
+  checksum: d45fe955b368655ff37bbaeaa72eb968399cffb6ac1ae44bd7898d834259fbe8b2394b73626d2338cd753b57b4f99ebaa8e7dfbead887c73f36c0070185cd9d6
   languageName: node
   linkType: hard
 
@@ -11561,6 +11692,30 @@ __metadata:
     react-native-fetch-api: ^2.0.0
     stream-to-it: ^0.2.2
   checksum: 39bee2f77837d8f2bf2e8dad2abfc8568c609440ca3127ec9d9baf706fe8e160c9cd349a9b0e42312c6a2e8cf17f3398e81edc3ec09339de6f340178fd4876aa
+  languageName: node
+  linkType: hard
+
+"ipfs-utils@npm:^9.0.6":
+  version: 9.0.14
+  resolution: "ipfs-utils@npm:9.0.14"
+  dependencies:
+    any-signal: ^3.0.0
+    browser-readablestream-to-it: ^1.0.0
+    buffer: ^6.0.1
+    electron-fetch: ^1.7.2
+    err-code: ^3.0.1
+    is-electron: ^2.2.0
+    iso-url: ^1.1.5
+    it-all: ^1.0.4
+    it-glob: ^1.0.1
+    it-to-stream: ^1.0.0
+    merge-options: ^3.0.4
+    nanoid: ^3.1.20
+    native-fetch: ^3.0.0
+    node-fetch: ^2.6.8
+    react-native-fetch-api: ^3.0.0
+    stream-to-it: ^0.2.2
+  checksum: 08108e03ea7b90e0fa11b76a4e24bd29d7e027c603494b53c1cc37b367fb559eaeea7b0f10b2e83ee419d50cdcb4d8105febdf185cab75c7e55afd4c8ed51aba
   languageName: node
   linkType: hard
 
@@ -12054,6 +12209,16 @@ __metadata:
   version: 1.0.7
   resolution: "it-first@npm:1.0.7"
   checksum: 0c9106d29120f02e68a08118de328437fb44c966385635d672684d4f0321ee22ca470a30f390132bdb454da0d4d3abb82c796dad8e391a827f1a3446711c7685
+  languageName: node
+  linkType: hard
+
+"it-glob@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "it-glob@npm:1.0.2"
+  dependencies:
+    "@types/minimatch": ^3.0.4
+    minimatch: ^3.0.4
+  checksum: 629e7b66510006041df98882acfd73ac785836d51fc3ffa5c83c7099f931b3287a64c5a3772e7c1e46b63f1d511a9222f5b637c50f1c738222b46d104ff2e91c
   languageName: node
   linkType: hard
 
@@ -13903,6 +14068,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"multiformats@npm:^9.0.2, multiformats@npm:^9.5.1":
+  version: 9.9.0
+  resolution: "multiformats@npm:9.9.0"
+  checksum: d3e8c1be400c09a014f557ea02251a2710dbc9fca5aa32cc702ff29f636c5471e17979f30bdcb0a9cbb556f162a8591dc2e1219c24fc21394a56115b820bb84e
+  languageName: node
+  linkType: hard
+
 "multiformats@npm:^9.4.1, multiformats@npm:^9.4.2, multiformats@npm:^9.4.5, multiformats@npm:^9.5.4":
   version: 9.6.5
   resolution: "multiformats@npm:9.6.5"
@@ -13965,6 +14137,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 2fddd6dee994b7676f008d3ffa4ab16035a754f4bb586c61df5a22cf8c8c94017aadd360368f47d653829e0569a92b129979152ff97af23a558331e47e37cd9c
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.1.23":
+  version: 3.3.6
+  resolution: "nanoid@npm:3.3.6"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 7d0eda657002738aa5206107bd0580aead6c95c460ef1bdd0b1a87a9c7ae6277ac2e9b945306aaa5b32c6dcb7feaf462d0f552e7f8b5718abfc6ead5c94a71b3
   languageName: node
   linkType: hard
 
@@ -15689,6 +15870,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-fetch-api@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "react-native-fetch-api@npm:3.0.0"
+  dependencies:
+    p-defer: ^3.0.0
+  checksum: f10f435060551c470711ba0b3663e3d49c7701aae84ea645d66992d756b13e923fb5762b324d3583d85c1c0def4138b9cc3f686bab1c1bc10d3ad82dc7175c99
+  languageName: node
+  linkType: hard
+
 "read-cmd-shim@npm:^3.0.0":
   version: 3.0.0
   resolution: "read-cmd-shim@npm:3.0.0"
@@ -16054,6 +16244,13 @@ __metadata:
   version: 2.0.0
   resolution: "retimer@npm:2.0.0"
   checksum: a59c837e1b364c4ef85c19250a94c09a49c55076ec3c5c51fafa335ee89d2ac2b91b7623548c8edb1345d7515b054986e904f8429e6caefa0595c2c70be8923d
+  languageName: node
+  linkType: hard
+
+"retimer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "retimer@npm:3.0.0"
+  checksum: f88309196e9d4f2d4be0c76eafc27a9f102c74b40b391ce730785b052c345d7bd59c3e4411a4c422f89f19a42b97b28034639e2f06c63133a06ec8958e9e7516
   languageName: node
   linkType: hard
 
@@ -17376,6 +17573,15 @@ __metadata:
     abort-controller: ^3.0.0
     retimer: ^2.0.0
   checksum: 070c220be4cac532f8cfbffccba3497baf3abe97d4bfc62344dba832b55a2eef1f0e60f33d862a1662e14852c9ef8ae952d1d93f5626d39b6592f29d7d00bd45
+  languageName: node
+  linkType: hard
+
+"timeout-abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "timeout-abort-controller@npm:3.0.0"
+  dependencies:
+    retimer: ^3.0.0
+  checksum: c74387e6472a1e151d89b4af8c2a18ac72d566f3cd6ec9b203e3cda969fb5c54acba0a8d20cda8e9772efda52e27bea59c3423bab785b65f0287c9419184607e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
- Switch from cluster api to normal api (need to check that pinning works)
- Fix uploading files twice by uploading manifest and deployment version
- Fix fileMap type not caching promisies causing repeated file references to be uploading multiple times
- Update to latest ipfs-http-api that doesn't use ESM
- Replaces https://github.com/subquery/subql/pull/1443

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
