### PR TITLE
Add skipBlock option to improve performance with event handlers

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - move block filters to common (#1969)
+
 ### Added
 - Add spec for project upgrades (#1797)
+- skipBlock node runner option (#1968)
 
 ## [2.6.0] - 2023-08-25
 ### Changed
@@ -305,7 +307,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - init commit
 
-[Unreleased]: https://github.com/subquery/subql/compare/common/2.5.0...HEAD
+[Unreleased]: https://github.com/subquery/subql/compare/common/2.6.0...HEAD
+[2.6.0]: https://github.com/subquery/subql/compare/common/2.5.0...common/2.6.0
 [2.5.0]: https://github.com/subquery/subql/compare/common/2.4.0...common/2.5.0
 [2.4.0]: https://github.com/subquery/subql/compare/common/2.3.0...common/2.4.0
 [2.3.0]: https://github.com/subquery/subql/compare/common/2.2.2...common/2.3.0

--- a/packages/common/src/project/versioned/v1_0_0/models.ts
+++ b/packages/common/src/project/versioned/v1_0_0/models.ts
@@ -51,6 +51,9 @@ export class RunnerNodeOptionsModel implements NodeOptions {
   @IsOptional()
   @IsBoolean()
   unfinalizedBlocks?: boolean;
+  @IsOptional()
+  @IsBoolean()
+  skipBlock?: boolean;
 }
 
 export class BlockFilterImpl implements BlockFilter {

--- a/packages/common/src/project/versioned/v1_0_0/types.ts
+++ b/packages/common/src/project/versioned/v1_0_0/types.ts
@@ -24,6 +24,7 @@ export interface NodeOptions {
   historical?: boolean;
   unsafe?: boolean;
   unfinalizedBlocks?: boolean;
+  skipBlock?: boolean;
 }
 
 export interface ParentProject {

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Move more code from node to node-core. Including configure module, workers (#1797)
+- Update api service generics to support multiple block types (#1968)
 
 ### Added
 - Project upgrades feature and many other changes to support it (#1797)
+- skipBlock option to NodeConfig (#1968)
 
 ## [4.2.3] - 2023-08-17
 ### Fixed

--- a/packages/node-core/src/api.service.ts
+++ b/packages/node-core/src/api.service.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {ApiConnectionError, ApiErrorType} from './api.connection.error';
-import {NodeConfig} from './configure';
 import {NetworkMetadataPayload} from './events';
 import {ConnectionPoolService} from './indexer';
 import {getLogger} from './logger';
@@ -11,25 +10,25 @@ const logger = getLogger('api');
 
 const MAX_RECONNECT_ATTEMPTS = 5;
 
-export interface IApi<A = any, SA = any, B = any> {
-  fetchBlocks(heights: number[], ...args: any): Promise<B[]>;
+export interface IApi<A = any, SA = any, B extends Array<any> = any[]> {
+  fetchBlocks(heights: number[], ...args: any): Promise<B>;
   safeApi(height: number): SA;
   unsafeApi: A;
   networkMeta: NetworkMetadataPayload;
 }
 
-export interface IApiConnectionSpecific<A = any, SA = any, B = any> extends IApi<A, SA, B> {
+export interface IApiConnectionSpecific<A = any, SA = any, B extends Array<any> = any[]> extends IApi<A, SA, B> {
   handleError(error: Error): ApiConnectionError;
   apiConnect(): Promise<void>;
   apiDisconnect(): Promise<void>;
 }
 
-export abstract class ApiService<A = any, SA = any, B = any> implements IApi<A, SA, B> {
+export abstract class ApiService<A = any, SA = any, B extends Array<any> = any[]> implements IApi<A, SA, B> {
   constructor(protected connectionPoolService: ConnectionPoolService<IApiConnectionSpecific<A, SA, B>>) {}
 
   abstract networkMeta: NetworkMetadataPayload;
 
-  async fetchBlocks(heights: number[], numAttempts = MAX_RECONNECT_ATTEMPTS): Promise<B[]> {
+  async fetchBlocks(heights: number[], numAttempts = MAX_RECONNECT_ATTEMPTS): Promise<B> {
     let reconnectAttempts = 0;
     while (reconnectAttempts < numAttempts) {
       try {

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -59,6 +59,7 @@ export interface IConfig {
   readonly storeFlushInterval: number;
   readonly isTest?: boolean;
   readonly root?: string;
+  readonly skipBlock?: boolean;
 }
 
 export type MinConfig = Partial<Omit<IConfig, 'subquery'>> & Pick<IConfig, 'subquery'>;
@@ -86,6 +87,7 @@ const DEFAULT_CONFIG = {
   storeGetCacheSize: 500,
   storeCacheAsync: true,
   storeFlushInterval: 5,
+  skipBlock: false,
 };
 
 export class NodeConfig implements IConfig {
@@ -271,6 +273,10 @@ export class NodeConfig implements IConfig {
 
   get scaleBatchSize(): boolean {
     return !!this.scaleBatchSize;
+  }
+
+  get skipBlock(): boolean {
+    return !!this._config.skipBlock;
   }
 
   get postgresCACert(): string | undefined {

--- a/packages/node-core/src/configure/configure.module.ts
+++ b/packages/node-core/src/configure/configure.module.ts
@@ -105,7 +105,7 @@ export async function registerApp<P extends ISubqueryProject>(
     config = NodeConfig.rebaseWithArgs(config, yargsToIConfig(argv, nameMapping), isTest);
   } else {
     if (!argv.subquery) {
-      logger.error('Subquery path is missing neither in cli options nor in config file');
+      logger.error('Subquery path is missing in both cli options and config file');
       showHelp();
       process.exit(1);
     }

--- a/packages/node-core/src/indexer/dictionary.service.test.ts
+++ b/packages/node-core/src/indexer/dictionary.service.test.ts
@@ -110,6 +110,7 @@ const nodeConfig = new NodeConfig({
   subqueryName: 'asdf',
   networkEndpoint: ['wss://polkadot.api.onfinality.io/public-ws'],
   dictionaryTimeout: 10,
+  // dictionaryResolver: 'https://kepler-auth.subquery.network'
 });
 
 jest.setTimeout(10000);

--- a/packages/node-core/src/indexer/indexer.manager.ts
+++ b/packages/node-core/src/indexer/indexer.manager.ts
@@ -34,7 +34,7 @@ export abstract class BaseIndexerManager<
   SA, // Api Type
   A, // SafeApi Type
   B, // Block Type
-  API extends IApi<A, SA, B>,
+  API extends IApi<A, SA, B[]>,
   DS extends BaseDataSource,
   CDS extends DS & BaseCustomDataSource, // Custom datasource
   FilterMap extends FilterTypeMap,

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -36,6 +36,7 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
 
   protected abstract packageVersion: string;
   protected abstract getBlockTimestamp(height: number): Promise<Date>;
+  protected abstract onProjectChange(project: ISubqueryProject<IProjectNetworkConfig, DS>): void | Promise<void>;
 
   constructor(
     private readonly dsProcessorService: BaseDsProcessorService,
@@ -331,7 +332,12 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
       // Reload the dynamic ds with new project
       // TODO are we going to run into problems with this being non blocking
       await this.dynamicDsService.getDynamicDatasources(true);
+
+      await this.onProjectChange(this.project);
     });
+
+    // Called to allow handling the first project
+    await this.onProjectChange(this.project);
 
     if (isMainThread) {
       const lastProcessedHeight = await this.getLastProcessedHeight();

--- a/packages/node-core/src/indexer/test.runner.ts
+++ b/packages/node-core/src/indexer/test.runner.ts
@@ -28,7 +28,7 @@ export class TestRunner<A, SA, B, DS> {
   private passedTests = 0;
   private failedTests = 0;
   constructor(
-    @Inject('IApi') protected readonly apiService: IApi<A, SA, B>,
+    @Inject('IApi') protected readonly apiService: IApi<A, SA, B[]>,
     protected readonly storeService: StoreService,
     protected readonly sequelize: Sequelize,
     protected readonly nodeConfig: NodeConfig,
@@ -42,7 +42,7 @@ export class TestRunner<A, SA, B, DS> {
       block: B,
       handler: string,
       indexerManager: IIndexerManager<B, DS>,
-      apiService?: IApi<A, SA, B>
+      apiService?: IApi<A, SA, B[]>
     ) => Promise<void>
   ): Promise<{
     passedTests: number;

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -59,7 +59,7 @@ export abstract class TestingService<A, SA, B, DS extends BaseDataSource> {
     block: B,
     handler: string,
     indexerManager: IIndexerManager<B, DS>,
-    apiService?: IApi<A, SA, B>
+    apiService?: IApi<A, SA, B[]>
   ): Promise<void> {
     await indexerManager.indexBlock(block, this.getDsWithHandler(handler));
   }

--- a/packages/node-core/src/utils/configure.ts
+++ b/packages/node-core/src/utils/configure.ts
@@ -12,6 +12,7 @@ export interface ArgvOverrideOptions {
   unsafe?: boolean;
   disableHistorical?: boolean;
   unfinalizedBlocks?: boolean;
+  skipBlock?: boolean;
 }
 
 export function defaultSubqueryName(config: Partial<IConfig>): MinConfig {
@@ -29,20 +30,28 @@ export function defaultSubqueryName(config: Partial<IConfig>): MinConfig {
   } as MinConfig;
 }
 
+function applyArgs(
+  argvs: ArgvOverrideOptions,
+  options: RunnerNodeOptionsModel,
+  key: keyof Omit<ArgvOverrideOptions, 'disableHistorical'>
+) {
+  if (argvs[key] === undefined && options[key] !== undefined) {
+    argvs[key] = options[key];
+  }
+}
+
 export function rebaseArgsWithManifest(argvs: ArgvOverrideOptions, rawManifest: unknown): void {
   const options = plainToClass(RunnerNodeOptionsModel, (rawManifest as any)?.runner?.node?.options);
   if (!options) {
     return;
   }
+
   // we override them if they are not provided in args/flag
-  if (argvs.unsafe === undefined && options.unsafe !== undefined) {
-    argvs.unsafe = options.unsafe;
-  }
   if (argvs.disableHistorical === undefined && options.historical !== undefined) {
     // THIS IS OPPOSITE
     argvs.disableHistorical = !options.historical;
   }
-  if (argvs.unfinalizedBlocks === undefined && options.unfinalizedBlocks !== undefined) {
-    argvs.unfinalizedBlocks = options.unfinalizedBlocks;
-  }
+  applyArgs(argvs, options, 'unsafe');
+  applyArgs(argvs, options, 'unfinalizedBlocks');
+  applyArgs(argvs, options, 'skipBlock');
 }

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Project upgrades feature which allows upgrading projects at specific heights (#1797)
+- Support for skipBlock and LightBlock (#1968)
+
+### Fixed
+- Project node runner options being overwritten by yargs defaults (#1967)
 
 ## [2.12.2] - 2023-08-17
 ### Fixed

--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -102,7 +102,7 @@ describe('ApiService', () => {
     const mockBlock = wrapBlock(block, []) as unknown as SubstrateBlock;
     const runtimeVersion = { specVersion: 1 } as unknown as RuntimeVersion;
     const patchedApi = await apiService.getPatchedApi(
-      mockBlock,
+      mockBlock.block.header,
       runtimeVersion,
     );
     const [patchedValidators, currentValidators] = await Promise.all([
@@ -121,7 +121,7 @@ describe('ApiService', () => {
     const mockBlock = wrapBlock(block, []) as unknown as SubstrateBlock;
     const runtimeVersion = { specVersion: 13 } as unknown as RuntimeVersion;
     const patchedApi = await apiService.getPatchedApi(
-      mockBlock,
+      mockBlock.block.header,
       runtimeVersion,
     );
     const apiResults = await api.query.staking.erasStakers.at(
@@ -151,7 +151,7 @@ describe('ApiService', () => {
     const apiResults = await api.rpc.state.getRuntimeVersion(earlyBlockhash);
     // step 2, api get patched result with block height
     const patchedApi = await apiService.getPatchedApi(
-      mockBlock,
+      mockBlock.block.header,
       runtimeVersion,
     );
     const patchedResult = await patchedApi.rpc.state.getRuntimeVersion(
@@ -179,7 +179,7 @@ describe('ApiService', () => {
     const futureBlockhash = await api.rpc.chain.getBlockHash(6721195);
     // step 2, api get patched result with block height
     const patchedApi = await apiService.getPatchedApi(
-      mockBlock,
+      mockBlock.block.header,
       runtimeVersion,
     );
     await expect(
@@ -206,7 +206,7 @@ describe('ApiService', () => {
     const mockBlock = wrapBlock(block, []) as unknown as SubstrateBlock;
     const runtimeVersion = { specVersion: 28 } as unknown as RuntimeVersion;
     const patchedApi = await apiService.getPatchedApi(
-      mockBlock,
+      mockBlock.block.header,
       runtimeVersion,
     );
     expect(
@@ -379,7 +379,7 @@ describe('ApiService', () => {
     const runtimeVersion = { specVersion: 1 } as unknown as RuntimeVersion;
 
     const patchedApi = await apiService.getPatchedApi(
-      mockBlock,
+      mockBlock.block.header,
       runtimeVersion,
     );
     await expect(patchedApi.query.system.events()).resolves.toHaveLength(2);
@@ -399,7 +399,7 @@ describe('ApiService', () => {
     const runtimeVersion = { specVersion: 1103 } as unknown as RuntimeVersion;
 
     const patchedApi = await apiService.getPatchedApi(
-      mockBlock,
+      mockBlock.block.header,
       runtimeVersion,
     );
     /* If Block number not provided should be ignored and `blockNumber` above used */

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -5,7 +5,7 @@ import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApiPromise } from '@polkadot/api';
 import { RpcMethodResult } from '@polkadot/api/types';
-import { RuntimeVersion } from '@polkadot/types/interfaces';
+import { RuntimeVersion, Header } from '@polkadot/types/interfaces';
 import { AnyFunction, DefinitionRpcExt } from '@polkadot/types/types';
 import {
   IndexerEvent,
@@ -16,11 +16,11 @@ import {
   ConnectionPoolService,
   ApiService as BaseApiService,
 } from '@subql/node-core';
-import { SubstrateBlock } from '@subql/types';
 import { SubqueryProject } from '../configure/SubqueryProject';
+import { isOnlyEventHandlers } from '../utils/project';
 import * as SubstrateUtil from '../utils/substrate';
-import { ApiPromiseConnection } from './apiPromise.connection';
-import { ApiAt, BlockContent } from './types';
+import { ApiPromiseConnection, FetchFunc } from './apiPromise.connection';
+import { ApiAt, BlockContent, LightBlockContent } from './types';
 
 const NOT_SUPPORT = (name: string) => () => {
   throw new Error(`${name}() is not supported`);
@@ -34,10 +34,14 @@ const logger = getLogger('api');
 
 @Injectable()
 export class ApiService
-  extends BaseApiService<ApiPromise, ApiAt, BlockContent>
+  extends BaseApiService<
+    ApiPromise,
+    ApiAt,
+    BlockContent[] | LightBlockContent[]
+  >
   implements OnApplicationShutdown
 {
-  private fetchBlocksBatches = SubstrateUtil.fetchBlocksBatches;
+  private fetchBlocksBatches: FetchFunc;
   private currentBlockHash: string;
   private currentBlockNumber: number;
   networkMeta: NetworkMetadataPayload;
@@ -49,6 +53,8 @@ export class ApiService
     private nodeConfig: NodeConfig,
   ) {
     super(connectionPoolService);
+
+    this.updateBlockFetching();
   }
 
   async onApplicationShutdown(): Promise<void> {
@@ -79,14 +85,6 @@ export class ApiService
     } catch (e) {
       logger.error(e);
       process.exit(1);
-    }
-
-    if (this.nodeConfig?.profiler) {
-      this.fetchBlocksBatches = profilerWrap(
-        SubstrateUtil.fetchBlocksBatches,
-        'SubstrateUtil',
-        'fetchBlocksBatches',
-      );
     }
 
     const endpointToApiIndex: Record<string, ApiPromiseConnection> = {};
@@ -162,16 +160,55 @@ export class ApiService
     return this;
   }
 
+  updateBlockFetching(): void {
+    const onlyEventHandlers = isOnlyEventHandlers(this.project);
+    const skipBlock = this.nodeConfig.skipBlock && onlyEventHandlers;
+
+    if (this.nodeConfig.skipBlock) {
+      if (onlyEventHandlers) {
+        logger.info(
+          'skipBlock is enabled, only events and block headers will be fetched.',
+        );
+      } else {
+        logger.info(
+          `skipBlock is disabled, the project contains handlers that aren't event handlers.`,
+        );
+      }
+    } else {
+      if (onlyEventHandlers) {
+        logger.warn(
+          'skipBlock is disabled, the project contains only event handlers, it could be enabled to improve indexing performance.',
+        );
+      } else {
+        logger.info(`skipBlock is disabled.`);
+      }
+    }
+
+    const fetchFunc = skipBlock
+      ? SubstrateUtil.fetchBlocksBatchesLight
+      : SubstrateUtil.fetchBlocksBatches;
+
+    if (this.nodeConfig?.profiler) {
+      this.fetchBlocksBatches = profilerWrap(
+        fetchFunc,
+        'SubstrateUtil',
+        'fetchBlocksBatches',
+      );
+    } else {
+      this.fetchBlocksBatches = fetchFunc;
+    }
+  }
+
   get api(): ApiPromise {
     return this.unsafeApi;
   }
 
   async getPatchedApi(
-    block: SubstrateBlock,
+    header: Header,
     runtimeVersion: RuntimeVersion,
   ): Promise<ApiAt> {
-    this.currentBlockHash = block.block.hash.toString();
-    this.currentBlockNumber = block.block.header.number.toNumber();
+    this.currentBlockHash = header.hash.toString();
+    this.currentBlockNumber = header.number.toNumber();
 
     const api = this.api;
     const apiAt = (await api.at(
@@ -267,7 +304,7 @@ export class ApiService
     heights: number[],
     overallSpecVer?: number,
     numAttempts = MAX_RECONNECT_ATTEMPTS,
-  ): Promise<BlockContent[]> {
+  ): Promise<LightBlockContent[]> {
     let reconnectAttempts = 0;
     while (reconnectAttempts < numAttempts) {
       try {

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -16,7 +16,7 @@ import {
   IApiConnectionSpecific,
 } from '@subql/node-core';
 import * as SubstrateUtil from '../utils/substrate';
-import { ApiAt, BlockContent } from './types';
+import { ApiAt, BlockContent, LightBlockContent } from './types';
 import { createCachedProvider } from './x-provider/cachedProvider';
 import { HttpProvider } from './x-provider/http';
 
@@ -25,10 +25,17 @@ const { version: packageVersion } = require('../../package.json');
 
 const RETRY_DELAY = 2_500;
 
-type FetchFunc = typeof SubstrateUtil.fetchBlocksBatches;
+export type FetchFunc =
+  | typeof SubstrateUtil.fetchBlocksBatches
+  | typeof SubstrateUtil.fetchBlocksBatchesLight;
 
 export class ApiPromiseConnection
-  implements IApiConnectionSpecific<ApiPromise, ApiAt, BlockContent>
+  implements
+    IApiConnectionSpecific<
+      ApiPromise,
+      ApiAt,
+      BlockContent[] | LightBlockContent[]
+    >
 {
   readonly networkMeta: NetworkMetadataPayload;
 
@@ -88,11 +95,11 @@ export class ApiPromiseConnection
   async fetchBlocks(
     heights: number[],
     overallSpecVer?: number,
-  ): Promise<BlockContent[]> {
+  ): Promise<BlockContent[] | LightBlockContent[]> {
     const blocks = await this.fetchBlocksBatches(
       this.unsafeApi,
       heights,
-      overallSpecVer,
+      // overallSpecVer,
     );
     return blocks;
   }

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -99,7 +99,7 @@ export class ApiPromiseConnection
     const blocks = await this.fetchBlocksBatches(
       this.unsafeApi,
       heights,
-      // overallSpecVer,
+      overallSpecVer,
     );
     return blocks;
   }

--- a/packages/node/src/indexer/project.service.ts
+++ b/packages/node/src/indexer/project.service.ts
@@ -15,6 +15,7 @@ import {
 import { SubstrateDatasource } from '@subql/types';
 import { Sequelize } from '@subql/x-sequelize';
 import { SubqueryProject } from '../configure/SubqueryProject';
+import { isOnlyEventHandlers } from '../utils/project';
 import { getBlockByHeight, getTimestamp } from '../utils/substrate';
 import { ApiService } from './api.service';
 import { DsProcessorService } from './ds-processor.service';
@@ -67,5 +68,9 @@ export class ProjectService extends BaseProjectService<
   protected async getBlockTimestamp(height: number): Promise<Date> {
     const block = await getBlockByHeight(this.apiService.api, height);
     return getTimestamp(block);
+  }
+
+  protected onProjectChange(project: SubqueryProject): void | Promise<void> {
+    this.apiService.updateBlockFetching();
   }
 }

--- a/packages/node/src/indexer/types.ts
+++ b/packages/node/src/indexer/types.ts
@@ -5,6 +5,8 @@ import { ApiPromise } from '@polkadot/api';
 import { ApiDecoration } from '@polkadot/api/types';
 import type { HexString } from '@polkadot/util/types';
 import {
+  BlockHeader,
+  LightSubstrateEvent,
   SubstrateBlock,
   SubstrateEvent,
   SubstrateExtrinsic,
@@ -16,6 +18,17 @@ export interface BlockContent {
   events: SubstrateEvent[];
 }
 
+export interface LightBlockContent {
+  block: BlockHeader; // A subset of SubstrateBlock
+  events: LightSubstrateEvent[];
+}
+
 export type BestBlocks = Record<number, HexString>;
 
 export type ApiAt = ApiDecoration<'promise'> & { rpc: ApiPromise['rpc'] };
+
+export function isFullBlock(
+  block: BlockContent | LightBlockContent,
+): block is BlockContent {
+  return (block as BlockContent).extrinsics !== undefined;
+}

--- a/packages/node/src/indexer/unfinalizedBlocks.service.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.ts
@@ -10,7 +10,7 @@ import {
   StoreCacheService,
 } from '@subql/node-core';
 import { ApiService } from './api.service';
-import { BlockContent } from './types';
+import { BlockContent, LightBlockContent } from './types';
 
 export function substrateHeaderToHeader(header: SubstrateHeader): Header {
   return {
@@ -21,7 +21,9 @@ export function substrateHeaderToHeader(header: SubstrateHeader): Header {
 }
 
 @Injectable()
-export class UnfinalizedBlocksService extends BaseUnfinalizedBlocksService<BlockContent> {
+export class UnfinalizedBlocksService extends BaseUnfinalizedBlocksService<
+  BlockContent | LightBlockContent
+> {
   constructor(
     private readonly apiService: ApiService,
     nodeConfig: NodeConfig,

--- a/packages/node/src/subcommands/testing.module.ts
+++ b/packages/node/src/subcommands/testing.module.ts
@@ -14,9 +14,7 @@ import {
   TestRunner,
 } from '@subql/node-core';
 import { ConfigureModule } from '../configure/configure.module';
-import { SubqueryProject } from '../configure/SubqueryProject';
 import { ApiService } from '../indexer/api.service';
-import { ApiPromiseConnection } from '../indexer/apiPromise.connection';
 import { DsProcessorService } from '../indexer/ds-processor.service';
 import { DynamicDsService } from '../indexer/dynamic-ds.service';
 import { FetchModule } from '../indexer/fetch.module';
@@ -42,30 +40,7 @@ import { MetaModule } from '../meta/meta.module';
       provide: 'IProjectService',
       useClass: ProjectService,
     },
-    {
-      provide: ApiService,
-      useFactory: async (
-        project: SubqueryProject,
-        connectionPoolService: ConnectionPoolService<ApiPromiseConnection>,
-        eventEmitter: EventEmitter2,
-        config: NodeConfig,
-      ) => {
-        const apiService = new ApiService(
-          project,
-          connectionPoolService,
-          eventEmitter,
-          config,
-        );
-        await apiService.init();
-        return apiService;
-      },
-      inject: [
-        'ISubqueryProject',
-        ConnectionPoolService,
-        EventEmitter2,
-        NodeConfig,
-      ],
-    },
+    ApiService,
     SchedulerRegistry,
     TestRunner,
     {

--- a/packages/node/src/subcommands/testing.service.ts
+++ b/packages/node/src/subcommands/testing.service.ts
@@ -16,14 +16,14 @@ import { SubqueryProject } from '../configure/SubqueryProject';
 import { ApiService } from '../indexer/api.service';
 import { IndexerManager } from '../indexer/indexer.manager';
 import { ProjectService } from '../indexer/project.service';
-import { ApiAt, BlockContent } from '../indexer/types';
+import { ApiAt, BlockContent, LightBlockContent } from '../indexer/types';
 import { TestingModule } from './testing.module';
 
 @Injectable()
 export class TestingService extends BaseTestingService<
   ApiPromise,
   ApiAt,
-  BlockContent,
+  BlockContent | LightBlockContent,
   SubqlProjectDs<SubstrateDatasource>
 > {
   constructor(
@@ -61,7 +61,7 @@ export class TestingService extends BaseTestingService<
   }
 
   async indexBlock(
-    block: BlockContent,
+    block: BlockContent | LightBlockContent,
     handler: string,
     indexerManager: IndexerManager,
     apiService: ApiService,

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -162,9 +162,9 @@ export const yargsOptions = yargs(hideBin(process.argv))
           },
           'disable-historical': {
             demandOption: false,
-            default: false,
             describe: 'Disable storing historical state entities',
             type: 'boolean',
+            // NOTE: don't set a default for this. It will break apply args from manifest. The default should be set in NodeConfig
           },
           'log-level': {
             demandOption: false,
@@ -267,6 +267,13 @@ export const yargsOptions = yargs(hideBin(process.argv))
             type: 'boolean',
             default: false,
           },
+          skipBlock: {
+            demandOption: false,
+            describe:
+              'If the project contains only event handlers and only accesses the events or block header then you can enable this option to reduce RPC requests and have a slight performance increase. This will be automatically disabled if handlers other than EventHandlers are detected.',
+            type: 'boolean',
+            // NOTE: don't set a default for this. It will break apply args from manifest. The default should be set in NodeConfig
+          },
           timeout: {
             demandOption: false,
             describe:
@@ -275,14 +282,15 @@ export const yargsOptions = yargs(hideBin(process.argv))
           },
           'unfinalized-blocks': {
             demandOption: false,
-            default: false,
             describe: 'Enable to fetch and index unfinalized blocks',
             type: 'boolean',
+            // NOTE: don't set a default for this. It will break apply args from manifest. The default should be set in NodeConfig
           },
           unsafe: {
             type: 'boolean',
             demandOption: false,
             describe: 'Allows usage of any built-in module within the sandbox',
+            // NOTE: don't set a default for this. It will break apply args from manifest. The default should be set in NodeConfig
           },
           workers: {
             alias: 'w',

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New LightBlock type (#1968)
 
 ## [2.2.0] - 2023-08-16
 ### Added

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -3,7 +3,7 @@
 
 import {AnyTuple, Codec} from '@polkadot/types-codec/types';
 import {GenericExtrinsic} from '@polkadot/types/extrinsic';
-import {EventRecord, SignedBlock} from '@polkadot/types/interfaces';
+import {EventRecord, SignedBlock, Header} from '@polkadot/types/interfaces';
 import {IEvent} from '@polkadot/types/types';
 
 export interface Entity {
@@ -44,9 +44,24 @@ export interface SubstrateExtrinsic<A extends AnyTuple = AnyTuple> {
   success: boolean;
 }
 
-export interface SubstrateEvent<T extends AnyTuple = AnyTuple> extends TypedEventRecord<T> {
+interface BaseSubstrateEvent<T extends AnyTuple = AnyTuple> extends TypedEventRecord<T> {
   // index in the block
   idx: number;
+}
+
+// A subset of SubstrateBlock with just the header
+export interface BlockHeader {
+  block: {
+    header: Header;
+  };
+  events: EventRecord[];
+}
+
+export interface LightSubstrateEvent<T extends AnyTuple = AnyTuple> extends BaseSubstrateEvent<T> {
+  block: BlockHeader;
+}
+
+export interface SubstrateEvent<T extends AnyTuple = AnyTuple> extends BaseSubstrateEvent<T> {
   extrinsic?: SubstrateExtrinsic;
   block: SubstrateBlock;
 }

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -3,7 +3,7 @@
 
 import {ApiPromise} from '@polkadot/api';
 import {AnyTuple, RegistryTypes} from '@polkadot/types/types';
-import {SubstrateBlock, SubstrateEvent, SubstrateExtrinsic} from './interfaces';
+import {LightSubstrateEvent, SubstrateBlock, SubstrateEvent, SubstrateExtrinsic} from './interfaces';
 
 export enum SubstrateDatasourceKind {
   Runtime = 'substrate/Runtime',
@@ -17,7 +17,7 @@ export enum SubstrateHandlerKind {
 
 export type RuntimeHandlerInputMap<T extends AnyTuple = AnyTuple> = {
   [SubstrateHandlerKind.Block]: SubstrateBlock;
-  [SubstrateHandlerKind.Event]: SubstrateEvent<T>;
+  [SubstrateHandlerKind.Event]: SubstrateEvent<T> | LightSubstrateEvent<T>;
   [SubstrateHandlerKind.Call]: SubstrateExtrinsic<T>;
 };
 


### PR DESCRIPTION
# Description
If a project only has event handlers there is not always a need to fetch all the block content. This can lead to ~10% performance increase in indexing speed.

`skipBlock` can be set in node runner options or in cli flags. It will automatically disable this if handlers other than event handlers are found.

I also found a bug where node runner options in project.yaml were broken because of default values in yargs. This will need to be fixed in other SDKs

Completes https://github.com/subquery/subql/issues/1889 for Substrate

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update https://github.com/subquery/documentation/pull/400

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/400
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
