### PR TITLE
Fix cli publish using manifest rather than deployment

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -392,13 +392,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] - 2021-04-19
 ### Added
--  annotation is now supported in 
-  - Can be added on any field of any entity except primary or foreign keys
-  - `@subql/node` will recognise it and create table with additional indexes to speed querying
-  - Allow query by indexed field via `global.store` (#271)
--  annotation is now supported in 
-  - We'll automatically generate coresponding JSON interfaces when querying this data (#275)
-  - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
+- `@index` annotation is now supported in `graphql.schema` (#255):
+    - Can be added on any field of any entity except primary or foreign keys
+    - `@subql/node` will recognise it and create table with additional indexes to speed querying
+    - Allow query by indexed field via `global.store` (#271)
+- `@jsonField` annotation is now supported in `graphql.schema` which allows you to store structured data JSON data in a single database field
+    - We'll automatically generate coresponding JSON interfaces when querying this data (#275)
+    - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
 
 ## [0.8.0] - 2021-03-11
 ### Added

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Publish command creating invalid deployment (#1977)
 
 ## [3.6.0] - 2023-08-25
 ### Added
@@ -390,13 +392,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] - 2021-04-19
 ### Added
-- `@index` annotation is now supported in `graphql.schema` (#255):
-    - Can be added on any field of any entity except primary or foreign keys
-    - `@subql/node` will recognise it and create table with additional indexes to speed querying
-    - Allow query by indexed field via `global.store` (#271)
-- `@jsonField` annotation is now supported in `graphql.schema` which allows you to store structured data JSON data in a single database field
-    - We'll automatically generate coresponding JSON interfaces when querying this data (#275)
-    - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
+-  annotation is now supported in 
+  - Can be added on any field of any entity except primary or foreign keys
+  - `@subql/node` will recognise it and create table with additional indexes to speed querying
+  - Allow query by indexed field via `global.store` (#271)
+-  annotation is now supported in 
+  - We'll automatically generate coresponding JSON interfaces when querying this data (#275)
+  - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
 
 ## [0.8.0] - 2021-03-11
 ### Added
@@ -435,7 +437,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - support subcommand codegen
 - support subcommand init
 
-[Unreleased]: https://github.com/subquery/subql/compare/cli/3.5.1...HEAD
+[Unreleased]: https://github.com/subquery/subql/compare/cli/3.6.0...HEAD
+[3.6.0]: https://github.com/subquery/subql/compare/cli/3.5.1...cli/3.6.0
 [3.5.1]: https://github.com/subquery/subql/compare/cli/3.5.0...cli/3.5.1
 [3.5.0]: https://github.com/subquery/subql/compare/cli/3.4.0...cli/3.5.0
 [3.4.0]: https://github.com/subquery/subql/compare/cli/3.3.3...cli/3.4.0

--- a/packages/cli/src/controller/publish-controller.ts
+++ b/packages/cli/src/controller/publish-controller.ts
@@ -78,7 +78,7 @@ export async function uploadToIpfs(
       throw new Error('Unable to parse project manifest');
     }
 
-    const deployment = await replaceFileReferences(reader.root, (manifest as any).deployment, authToken, ipfs);
+    const deployment = await replaceFileReferences(reader.root, manifest.deployment, authToken, ipfs);
 
     // Use JSON.* to convert Map to Object
     const deploymentStr = yaml.dump(JSON.parse(JSON.stringify(deployment)), {sortKeys: true, condenseFlow: true});

--- a/packages/cli/src/controller/publish-controller.ts
+++ b/packages/cli/src/controller/publish-controller.ts
@@ -13,6 +13,7 @@ import {parseStellarProjectManifest} from '@subql/common-stellar';
 import {parseSubstrateProjectManifest} from '@subql/common-substrate';
 import {FileReference} from '@subql/types';
 import {IPFSHTTPClient, create} from 'ipfs-http-client';
+import yaml from 'js-yaml';
 
 const PIN_SERVICE = 'onfinality';
 
@@ -77,10 +78,14 @@ export async function uploadToIpfs(
       throw new Error('Unable to parse project manifest');
     }
 
-    const deployment = await replaceFileReferences(reader.root, manifest, authToken, ipfs);
+    const deployment = await replaceFileReferences(reader.root, (manifest as any).deployment, authToken, ipfs);
+
+    // Use JSON.* to convert Map to Object
+    const deploymentStr = yaml.dump(JSON.parse(JSON.stringify(deployment)), {sortKeys: true, condenseFlow: true});
+
     contents.push({
       path: path.join(directory ?? '', path.basename(project)),
-      content: deployment.toDeployment(),
+      content: deploymentStr,
     });
   }
 


### PR DESCRIPTION
# Description
https://github.com/subquery/subql/pull/1967 introduced a bug where we upload the manifest and referenced files but no longer uploaded the deployment. This fixes the upload by only uploading the deployment instead of the manifest references then converting the deployment to yaml

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
