### PR TITLE
add file reference validator to subql/common

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added fileReference validator (#1984)
+
 ### Changed
 - move block filters to common (#1969)
 

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -237,3 +237,20 @@ export function notifyUpdates(pjson: Package, logger: Pino.Logger): void {
     logger.info(`Current ${pjson.name} version is ${pjson.version}`);
   }
 }
+
+@ValidatorConstraint({name: 'isFileReference', async: false})
+export class FileReferenceImp<T> implements ValidatorConstraintInterface {
+  validate(value: Map<string, T>): boolean {
+    if (!value) {
+      return false;
+    }
+    return !!Object.values(value).find((fileReference: T) => this.isValidFileReference(fileReference));
+  }
+  defaultMessage(args: ValidationArguments): string {
+    return `${JSON.stringify(args.value)} is not a valid assets format`;
+  }
+
+  private isValidFileReference(fileReference: T): boolean {
+    return typeof fileReference === 'object' && 'file' in fileReference && typeof fileReference.file === 'string';
+  }
+}


### PR DESCRIPTION
# Description
This was introduced with cosmwasm codegen support, as the existing validator on `assets` in the manifest doesn't do its justice. However, `FileReference` is also applicable for Ethereum manifests. But I am unsure whether it is right for it to be a generic, as the type `FileRefence` is apart of `subql/types` but `subql/common` does not include packages from types. 

i think adding `subql/types` would only increase the weight of the node_modules.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
