### PR TITLE
block height filter

### DIFF
--- a/packages/common/src/project/versioned/v1_0_0/models.ts
+++ b/packages/common/src/project/versioned/v1_0_0/models.ts
@@ -63,6 +63,9 @@ export class BlockFilterImpl implements BlockFilter {
   @IsOptional()
   @IsString()
   timestamp?: string;
+  @IsOptional()
+  @IsInt()
+  height?: number;
 }
 
 export class ParentProjectModel implements ParentProject {

--- a/packages/common/src/project/versioned/v1_0_0/types.ts
+++ b/packages/common/src/project/versioned/v1_0_0/types.ts
@@ -59,4 +59,5 @@ export interface ProjectManifestV1_0_0<
 export interface BlockFilter {
   modulo?: number;
   timestamp?: string;
+  height?: number;
 }

--- a/packages/node-core/src/indexer/fetch.service.spec.ts
+++ b/packages/node-core/src/indexer/fetch.service.spec.ts
@@ -24,6 +24,7 @@ class TestFetchService extends BaseFetchService<BaseDataSource, IBlockDispatcher
   finalizedHeight = 1000;
   bestHeight = 20;
   modulos: number[] = [];
+  filteredHeight: number[] = [];
 
   protected buildDictionaryQueryEntries(
     dataSources: BaseDataSource<any, BaseHandler<any>, BaseMapping<any, BaseHandler<any>>>[]
@@ -42,6 +43,9 @@ class TestFetchService extends BaseFetchService<BaseDataSource, IBlockDispatcher
   }
   protected getModulos(): number[] {
     return this.modulos;
+  }
+  protected getFilteredHeights(): number[] {
+    return this.filteredHeight;
   }
   protected async initBlockDispatcher(): Promise<void> {
     return Promise.resolve();

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -184,13 +184,7 @@ export abstract class BaseFetchService<
 
   getFilteredHeightBlocks(startBlockHeight: number, endBlockHeight: number): number[] {
     const filteredBlocks = this.getFilteredHeights();
-    const heights: number[] = [];
-    for (let i = startBlockHeight; i < endBlockHeight; i++) {
-      if (filteredBlocks.find((m) => m === i)) {
-        heights.push(i);
-      }
-    }
-    return heights;
+    return filteredBlocks.filter(height => height >= startBlockHeight && height < endBlockHeight)
   }
 
   getModuloBlocks(startHeight: number, endHeight: number): number[] {

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -135,6 +135,25 @@ export function getModulos<DS extends BaseDataSource, CDS extends DS & BaseCusto
   return modulos;
 }
 
+export function getFilteredHeights<DS extends BaseDataSource, CDS extends DS & BaseCustomDataSource>(
+  dataSources: DS[],
+  isCustomDs: IsCustomDs<DS, CDS>,
+  blockHandlerKind: string
+): number[] {
+  const heights: number[] = [];
+  for (const ds of dataSources) {
+    if (isCustomDs(ds)) {
+      continue;
+    }
+    for (const handler of ds.mapping.handlers) {
+      if (handler.kind === blockHandlerKind && handler.filter && handler.filter.height) {
+        heights.push(handler.filter.height);
+      }
+    }
+  }
+  return heights;
+}
+
 export async function updateDataSourcesV1_0_0<DS extends BaseDataSource, CDS extends DS & BaseCustomDataSource>(
   _dataSources: (DS | CDS)[],
   reader: Reader,

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -17,7 +17,12 @@ import {
   SubstrateHandlerKind,
   SubstrateRuntimeHandlerFilter,
 } from '@subql/common-substrate';
-import { NodeConfig, BaseFetchService, getModulos } from '@subql/node-core';
+import {
+  NodeConfig,
+  BaseFetchService,
+  getModulos,
+  getFilteredHeights,
+} from '@subql/node-core';
 import {
   DictionaryQueryCondition,
   DictionaryQueryEntry,
@@ -149,7 +154,7 @@ export class FetchService extends BaseFetchService<
         switch (baseHandlerKind) {
           case SubstrateHandlerKind.Block:
             for (const filter of filterList as SubstrateBlockFilter[]) {
-              if (filter.modulo === undefined) {
+              if (filter.modulo === undefined || filter.height === undefined) {
                 return [];
               }
             }
@@ -215,6 +220,14 @@ export class FetchService extends BaseFetchService<
       .toNumber();
 
     return Math.min(BLOCK_TIME_VARIANCE, chainInterval);
+  }
+
+  protected getFilteredHeights(): number[] {
+    return getFilteredHeights(
+      this.projectService.getAllDataSources(),
+      isCustomDs,
+      SubstrateHandlerKind.Block,
+    );
   }
 
   protected getModulos(): number[] {

--- a/packages/node/src/utils/substrate.ts
+++ b/packages/node/src/utils/substrate.ts
@@ -125,6 +125,7 @@ export function filterBlock(
   filter?: SubstrateBlockFilter,
 ): SubstrateBlock | undefined {
   if (!filter) return block;
+  if (!filterBlockHeight(block, filter)) return;
   if (!filterBlockModulo(block, filter)) return;
   if (filter.timestamp) {
     if (!filterBlockTimestamp(block, filter as SubqlProjectBlockFilter)) {
@@ -136,6 +137,15 @@ export function filterBlock(
     checkSpecRange(filter.specVersion, block.specVersion)
     ? block
     : undefined;
+}
+
+export function filterBlockHeight(
+  block: SubstrateBlock,
+  filter: SubstrateBlockFilter,
+): boolean {
+  const { height } = filter;
+  if (!height) return true;
+  return block.block.header.number.toNumber() === height;
 }
 
 export function filterBlockModulo(

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -53,6 +53,7 @@ interface SubstrateBaseHandlerFilter {
 export interface SubstrateBlockFilter extends SubstrateBaseHandlerFilter {
   modulo?: number;
   timestamp?: string;
+  height?: number;
 }
 
 export interface SubstrateEventFilter extends SubstrateBaseHandlerFilter {


### PR DESCRIPTION
# Description

Add a height filter for block handler, allow trigger mapping at specific height. 

Also can use a genesis handler, eg 

```yaml
        - handler: handleGenesisBlock
          kind: substrate/BlockHandler
          filter:
            height: 1
#            modulo: 50

```

This much handy than only a genesis handler 

Fixes #1962

TODO:

- [ ] Unit test

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
