### PR TITLE
Add getByFields function to store interface

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,12 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for cosmwasm contract abi codegen (#1989)
-
-### Added
 - Update `subql init` to use proxy templates (#1991)
 
 ### Changed
 - Update common packages version from `latest`, to ensure they will be bumped (#1992)
+- Update model codegen to include `getByFields` and produce prettier code (#1993)
 
 ## [3.6.1] - 2023-08-29
 ### Fixed

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -1,17 +1,15 @@
 // Auto-generated , DO NOT EDIT
-import {Entity, FunctionPropertyNames} from "@subql/types";
+import {Entity, FunctionPropertyNames, FieldsExpression} from "@subql/types";
 import assert from 'assert';
 <%if (props.importJsonInterfaces.length !== 0) { %>
 import {<% props.importJsonInterfaces.forEach(function(interface){ %>
     <%= interface %>,
-<% }); %>} from '../interfaces'
+<% }); %>} from '../interfaces';
 <% } %>
-
 <%if (props.importEnums.length !== 0) { %>
 import {<% props.importEnums.forEach(function(e){ %>
     <%= e %>,
-<% }); %>} from '../enums'
-<% } %>
+<% }); %>} from '../enums';<% } %>
 
 export type <%= props.className %>Props = Omit<<%=props.className %>, NonNullable<FunctionPropertyNames<<%=props.className %>>>| '_name'>;
 
@@ -19,17 +17,14 @@ export class <%= props.className %> implements Entity {
 
     constructor(
         <% props.fields.forEach(function(field) { if (field.required) { %>
-            <%= field.name %>: <%= field.type %><%= field.isArray ? "[]" : "" %>,<% } %>
-        <% }) %>
+        <%= field.name %>: <%= field.type %><%= field.isArray ? "[]" : "" %>,<% } %><% }) %>
     ) {
-        <% props.fields.filter(function(field) {return field.required === true;}).forEach(function(requiredField) { %>
-            this.<%= requiredField.name %> = <%= requiredField.name %>;
+        <% props.fields.filter(function(field) {return field.required === true;}).forEach(function(requiredField) { %>this.<%= requiredField.name %> = <%= requiredField.name %>;
         <% }) %>
     }
 
-<% props.fields.forEach(function(field){ %>
-    public <%= field.name %><%= field.required ? "" : "?" %>: <%= field.type %><%= field.isArray ? "[]" : "" %>;
-<% }); %>
+    <% props.fields.forEach(function(field){ %>public <%= field.name %><%= field.required ? "" : "?" %>: <%= field.type %><%= field.isArray ? "[]" : "" %>;
+    <% }); %>
 
     get _name(): string {
         return '<%=props.entityName %>';
@@ -40,6 +35,7 @@ export class <%= props.className %> implements Entity {
         assert(id !== null, "Cannot save <%=props.className %> entity without an ID");
         await store.set('<%=props.entityName %>', id.toString(), this);
     }
+
     static async remove(id:string): Promise<void>{
         assert(id !== null, "Cannot remove <%=props.className %> entity without an ID");
         await store.remove('<%=props.entityName %>', id.toString());
@@ -48,34 +44,34 @@ export class <%= props.className %> implements Entity {
     static async get(id:string): Promise<<%=props.className %> | undefined>{
         assert((id !== null && id !== undefined), "Cannot get <%=props.className %> entity without an ID");
         const record = await store.get('<%=props.entityName %>', id.toString());
-        if (record){
+        if (record) {
             return this.create(record as <%= props.className %>Props);
-        }else{
+        } else {
             return;
         }
     }
-
 <% props.indexedFields.forEach(function(field){ %>
     static async getBy<%=helper.upperFirst(field.name) %>(<%=field.name %>: <%=field.type %>): Promise<<%=props.className %><%=field.unique ? '' : '[]' %> | undefined>{
       <% if (field.unique) {%>
       const record = await store.getOneByField('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>);
-      if (record){
+      if (record) {
           return this.create(record as <%= props.className %>Props);
-      }else{
+      } else {
           return;
       }
-      <% } else { %>
-      const records = await store.getByField('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>);
-      return records.map(record => this.create(record as <%= props.className %>Props));
-      <% }%>
+      <% } else { %>const records = await store.getByField('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>);
+      return records.map(record => this.create(record as <%= props.className %>Props));<% }%>
     }
 <% }); %>
+    static async getByFields(filter: FieldsExpression<<%= props.className %>Props>[], options?: { offset?: number, limit?: number}): Promise<<%=props.className %>[]> {
+        const records = await store.getByFields('<%=props.entityName %>', filter, options);
+        return records.map(record => this.create(record as <%= props.className %>Props));
+    }
 
     static create(record: <%= props.className %>Props): <%=props.className %> {
         assert(typeof record.id === 'string', "id must be provided");
         let entity = new this(
-        <% props.fields.filter(function(field) {return field.required === true;}).forEach(function(requiredField) { %>
-            record.<%= requiredField.name %>,
+        <% props.fields.filter(function(field) {return field.required === true;}).forEach(function(requiredField) { %>    record.<%= requiredField.name %>,
         <% }) %>);
         Object.assign(entity,record);
         return entity;

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update apollo-links to 1.0.2, fix dictionary resolver failed to get token issue
 - Use test runs as unit for tests instead of entity checks (#1957)
 - Fix generated operation hash with single entity, buffer did not get hashed issue.
-- Infinite recursion in setValueModel (#1993)
+- Infinite recursion in setValueModel with arrays (#1993)
 
 ### Changed
 - Move more code from node to node-core. Including configure module, workers (#1797)

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update apollo-links to 1.0.2, fix dictionary resolver failed to get token issue
 - Use test runs as unit for tests instead of entity checks (#1957)
 - Fix generated operation hash with single entity, buffer did not get hashed issue.
+- Infinite recursion in setValueModel (#1993)
 
 ### Changed
 - Move more code from node to node-core. Including configure module, workers (#1797)
@@ -16,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Project upgrades feature and many other changes to support it (#1797)
-- skipBlock option to NodeConfig (#1968)
+- `skipBlock` option to NodeConfig (#1968)
+- `getByFields` to store (#1993)
 
 ## [4.2.3] - 2023-08-17
 ### Fixed

--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -4,7 +4,7 @@
 import assert from 'assert';
 import {Inject, Injectable} from '@nestjs/common';
 import {getDbType, SUPPORT_DB} from '@subql/common';
-import {Entity, Store} from '@subql/types';
+import {Entity, FieldsExpression, Store} from '@subql/types';
 import {
   GraphQLModelsRelationsEnums,
   GraphQLModelsType,
@@ -754,6 +754,15 @@ group by
     }
   }
 
+  isIndexed(entity: string, field: string): boolean {
+    return (
+      this.modelIndexedFields.findIndex(
+        (indexField) =>
+          upperFirst(camelCase(indexField.entityName)) === entity && camelCase(indexField.fieldName) === field
+      ) > -1
+    );
+  }
+
   getStore(): Store {
     return {
       get: async <T extends Entity>(entity: string, id: string): Promise<T | undefined> => {
@@ -773,11 +782,7 @@ group by
         } = {}
       ): Promise<T[]> => {
         try {
-          const indexed =
-            this.modelIndexedFields.findIndex(
-              (indexField) =>
-                upperFirst(camelCase(indexField.entityName)) === entity && camelCase(indexField.fieldName) === field
-            ) > -1;
+          const indexed = this.isIndexed(entity, String(field));
           assert(indexed, `to query by field ${String(field)}, an index must be created on model ${entity}`);
           if (options?.limit && this.config.queryLimit < options?.limit) {
             logger.warn(
@@ -793,6 +798,39 @@ group by
             .getByField(field, value, {limit: finalLimit, offset: options.offset});
         } catch (e) {
           throw new Error(`Failed to getByField Entity ${entity} with field ${String(field)}: ${e}`);
+        }
+      },
+      getByFields: async <T extends Entity>(
+        entity: string,
+        filter: FieldsExpression<T>[],
+        options?: {
+          offset?: number;
+          limit?: number;
+        }
+      ): Promise<T[]> => {
+        try {
+          // Check that the fields are indexed
+          filter.forEach((f) => {
+            assert(
+              this.isIndexed(entity, String(f[0])),
+              `to query by field ${String(f[0])}, an index must be created on model ${entity}`
+            );
+          });
+
+          if (options?.limit && this.config.queryLimit < options?.limit) {
+            logger.warn(
+              `store getByField for entity ${entity} with ${options.limit} records exceeds config limit ${this.config.queryLimit}. Will use ${this.config.queryLimit} as the limit.`
+            );
+          }
+
+          const finalOptions = {
+            offset: options?.offset ?? 0,
+            limit: Math.min(options?.limit ?? this.config.queryLimit, this.config.queryLimit),
+          };
+
+          return this.storeCache.getModel<T>(entity).getByFields(filter, finalOptions);
+        } catch (e) {
+          throw new Error(`Failed to getByFields Entity ${entity}: ${e}`);
         }
       },
       getOneByField: async <T extends Entity>(

--- a/packages/node-core/src/indexer/storeCache/cacheModel.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.spec.ts
@@ -242,7 +242,7 @@ describe('cacheModel', () => {
         await testModel.getByFields(
           [
             ['field1', '=', 1],
-            ['field1', 'in', 2],
+            ['field1', 'in', [2]],
           ],
           {offset: 0, limit: 1}
         );

--- a/packages/node-core/src/indexer/storeCache/cacheModel.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.spec.ts
@@ -12,12 +12,28 @@ jest.mock('@subql/x-sequelize', () => {
   let pendingData: typeof data = {};
   let afterCommitHooks: Array<() => void> = [];
 
+  const Op = {
+    in: jest.fn(),
+    notIn: jest.fn(),
+    eq: jest.fn(),
+    ne: jest.fn(),
+  };
+
+  const transaction = () => ({
+    commit: jest.fn(async () => {
+      await delay(1);
+      data = {...data, ...pendingData};
+      pendingData = {};
+      afterCommitHooks.map((fn) => fn());
+      afterCommitHooks = [];
+    }), // Delay of 1s is used to test whether we wait for cache to flush
+    rollback: jest.fn(),
+    afterCommit: jest.fn((fn) => afterCommitHooks.push(fn)),
+  });
+
   const mSequelize = {
     authenticate: jest.fn(),
-    Op: {
-      in: jest.fn(),
-      notIn: jest.fn(),
-    },
+    Op,
     define: () => ({
       findOne: jest.fn(),
       create: (input: any) => input,
@@ -32,16 +48,19 @@ jest.mock('@subql/x-sequelize', () => {
         fn: jest.fn().mockImplementation(() => {
           return {fn: 'int8range', args: [41204769, null]};
         }),
+        transaction,
       },
       upsert: jest.fn(),
       associations: [{}, {}],
       count: 5,
-      findAll: [
+      findAll: jest.fn(() => [
         {
-          id: 'apple-05-sequelize',
-          field1: 'set apple at block 5 with sequelize',
+          toJSON: () => ({
+            id: 'apple-05-sequelize',
+            field1: 'set apple at block 5 with sequelize',
+          }),
         },
-      ],
+      ]),
       findOne: jest.fn(({transaction, where: {id}}) => ({
         toJSON: () => (transaction ? pendingData[id] ?? data[id] : data[id]),
       })),
@@ -51,17 +70,7 @@ jest.mock('@subql/x-sequelize', () => {
       destroy: jest.fn(),
     }),
     sync: jest.fn(),
-    transaction: () => ({
-      commit: jest.fn(async () => {
-        await delay(1);
-        data = {...data, ...pendingData};
-        pendingData = {};
-        afterCommitHooks.map((fn) => fn());
-        afterCommitHooks = [];
-      }), // Delay of 1s is used to test whether we wait for cache to flush
-      rollback: jest.fn(),
-      afterCommit: jest.fn((fn) => afterCommitHooks.push(fn)),
-    }),
+    transaction,
     // createSchema: jest.fn(),
   };
   const actualSequelize = jest.requireActual('@subql/x-sequelize');
@@ -70,6 +79,7 @@ jest.mock('@subql/x-sequelize', () => {
     DataTypes: actualSequelize.DataTypes,
     QueryTypes: actualSequelize.QueryTypes,
     Deferrable: actualSequelize.Deferrable,
+    Op,
   };
 });
 
@@ -89,8 +99,17 @@ describe('cacheModel', () => {
     beforeEach(() => {
       let i = 0;
       sequelize = new Sequelize();
-      testModel = new CachedModel(sequelize.model('entity1'), false, {} as NodeConfig);
-      testModel.init(() => i++);
+      testModel = new CachedModel(
+        sequelize.model('entity1'),
+        false,
+        {} as NodeConfig,
+        () => i++,
+        async () => {
+          const tx = await sequelize.transaction();
+          await testModel.flush(tx);
+          await tx.commit();
+        }
+      );
     });
 
     it('can avoid race conditions', async () => {
@@ -160,8 +179,17 @@ describe('cacheModel', () => {
     beforeEach(() => {
       let i = 0;
       sequelize = new Sequelize();
-      testModel = new CachedModel(sequelize.model('entity1'), true, {} as NodeConfig);
-      testModel.init(() => i++);
+      testModel = new CachedModel(
+        sequelize.model('entity1'),
+        true,
+        {} as NodeConfig,
+        () => i++,
+        async () => {
+          const tx = await sequelize.transaction();
+          await testModel.flush(tx);
+          await tx.commit();
+        }
+      );
     });
 
     // it should keep same behavior as hook we used
@@ -188,5 +216,49 @@ describe('cacheModel', () => {
       expect(spyDbGet).not.toBeCalled();
       expect(JSON.stringify(entity)).not.toContain('__block_range');
     }, 500000);
+
+    describe('getByFields', () => {
+      it('calls getByField if there is one filter', async () => {
+        const spy = jest.spyOn(testModel, 'getByField');
+
+        await testModel.getByFields([['field1', '=', 1]], {offset: 0, limit: 1});
+
+        expect(spy).toBeCalledWith('field1', 1, {offset: 0, limit: 1});
+      });
+
+      it('flushes the cache first', async () => {
+        const spy = jest.spyOn(testModel, 'flush');
+
+        // Set data so there is something to be flushed
+        testModel.set(
+          'entity1_id_0x02',
+          {
+            id: 'entity1_id_0x02',
+            field1: 2,
+          },
+          2
+        );
+
+        await testModel.getByFields(
+          [
+            ['field1', '=', 1],
+            ['field1', 'in', 2],
+          ],
+          {offset: 0, limit: 1}
+        );
+
+        expect(spy).toBeCalled();
+      });
+
+      it('throws for unsupported operators', async () => {
+        await expect(
+          testModel.getByFields(
+            // Any needed to get past type check
+            [['field1', 'badOperator' as any, 1]],
+            {offset: 0, limit: 1}
+          )
+        ).rejects.toThrow(`Operator ('badOperator') for field field1 is not valid. Options are =, !=, in, !in`);
+      });
+    });
   });
 });

--- a/packages/node-core/src/indexer/storeCache/setValueModel.ts
+++ b/packages/node-core/src/indexer/storeCache/setValueModel.ts
@@ -107,7 +107,7 @@ export class SetValueModel<T> {
       return true;
     }
     if (Array.isArray(value)) {
-      return value.findIndex((v) => this.isMatchData(field, value)) > -1;
+      return value.findIndex((v) => this.isMatchData(field, v)) > -1;
     } else {
       return isEqual(this.getLatest()?.data?.[field], value);
     }

--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -79,8 +79,14 @@ export class StoreCacheService extends BaseCacheService {
     if (!this.cachedModels[entity]) {
       const model = this.sequelize.model(entity);
       assert(model, `model ${entity} not exists`);
-      const cacheModel = new CachedModel(model, this._historical, this.config, this._useCockroachDb);
-      cacheModel.init(this.getNextStoreOperationIndex.bind(this));
+      const cacheModel = new CachedModel(
+        model,
+        this._historical,
+        this.config,
+        this.getNextStoreOperationIndex.bind(this),
+        () => this.flushCache(true),
+        this._useCockroachDb
+      );
       this.cachedModels[entity] = cacheModel;
     }
     return this.cachedModels[entity] as unknown as ICachedModel<T>;

--- a/packages/node-core/src/indexer/storeCache/types.ts
+++ b/packages/node-core/src/indexer/storeCache/types.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import {FieldsExpression} from '@subql/types';
 import {Transaction} from '@subql/x-sequelize';
 import LRUCache from 'lru-cache';
 import {SetValueModel} from './setValueModel';
@@ -15,6 +16,7 @@ export interface ICachedModel<T> {
     value: T[keyof T] | T[keyof T][],
     options: {limit: number; offset: number}
   ) => Promise<T[]>;
+  getByFields: (filter: FieldsExpression<T>[], options: {limit: number; offset: number}) => Promise<T[]>;
   getOneByField: (field: keyof T, value: T[keyof T]) => Promise<T | undefined>;
   set: (id: string, data: T, blockHeight: number) => void;
   bulkCreate: (data: T[], blockHeight: number) => void;

--- a/packages/node-core/src/indexer/worker/worker.store.service.ts
+++ b/packages/node-core/src/indexer/worker/worker.store.service.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {Store} from '@subql/types';
+import {FieldsExpression, Store} from '@subql/types';
 import {classToPlain} from 'class-transformer';
 
 export type HostStore = {
@@ -11,6 +11,11 @@ export type HostStore = {
     entity: string,
     field: string,
     value: any,
+    options?: {offset?: number; limit?: number}
+  ) => Promise<any[]>;
+  storeGetByFields: (
+    entity: string,
+    filter: FieldsExpression<any>[],
     options?: {offset?: number; limit?: number}
   ) => Promise<any[]>;
   storeGetOneByField: (entity: string, field: string, value: any) => Promise<any | null>;
@@ -24,6 +29,7 @@ export type HostStore = {
 export const hostStoreKeys: (keyof HostStore)[] = [
   'storeGet',
   'storeGetByField',
+  'storeGetByFields',
   'storeGetOneByField',
   'storeSet',
   'storeBulkCreate',
@@ -38,6 +44,7 @@ export const hostStoreToStore = (host: HostStore): Store => {
   return {
     get: host.storeGet,
     getByField: host.storeGetByField,
+    getByFields: host.storeGetByFields,
     getOneByField: host.storeGetOneByField,
     set: (entity, id, data) => host.storeSet(entity, id, classToPlain(data)),
     bulkCreate: (entity, data) => host.storeBulkCreate(entity, classToPlain(data) as any[]),
@@ -51,6 +58,7 @@ export function storeHostFunctions(store: Store): HostStore {
   return {
     storeGet: store.get.bind(store),
     storeGetByField: store.getByField.bind(store),
+    storeGetByFields: store.getByFields.bind(store),
     storeGetOneByField: store.getOneByField.bind(store),
     storeSet: store.set.bind(store),
     storeBulkCreate: store.bulkCreate.bind(store),

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - New LightBlock type (#1968)
+- `getByFields` function to store interface (#1993)
 
 ## [2.2.0] - 2023-08-16
 ### Added

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -16,9 +16,18 @@ export type FunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? K : never;
 }[keyof T];
 
+export type FieldOperators = '=' | '!=' | 'in' | '!in';
+
+export type FieldsExpression<T> = [field: keyof T, operator: FieldOperators, value: T[keyof T] | Array<T[keyof T]>];
+
 export interface Store {
   get(entity: string, id: string): Promise<Entity | undefined>;
   getByField(entity: string, field: string, value: any, options?: {offset?: number; limit?: number}): Promise<Entity[]>;
+  getByFields<T extends Entity>(
+    entity: string,
+    filter: FieldsExpression<T>[],
+    options?: {offset?: number; limit?: number}
+  ): Promise<T[]>;
   getOneByField(entity: string, field: string, value: any): Promise<Entity | undefined>;
   set(entity: string, id: string, data: Entity): Promise<void>;
   bulkCreate(entity: string, data: Entity[]): Promise<void>;

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -16,9 +16,13 @@ export type FunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? K : never;
 }[keyof T];
 
-export type FieldOperators = '=' | '!=' | 'in' | '!in';
+type SingleOperators = '=' | '!=';
+type ArrayOperators = 'in' | '!in';
+export type FieldOperators = SingleOperators | ArrayOperators;
 
-export type FieldsExpression<T> = [field: keyof T, operator: FieldOperators, value: T[keyof T] | Array<T[keyof T]>];
+export type FieldsExpression<T> =
+  | [field: keyof T, operator: SingleOperators, value: T[keyof T]]
+  | [field: keyof T, operator: ArrayOperators, value: Array<T[keyof T]>];
 
 export interface Store {
   get(entity: string, id: string): Promise<Entity | undefined>;


### PR DESCRIPTION
# Description
Adds the ability to query entities from mapping handlers by multiple fields. When this is used, it will flush the cache if there is any pending data for the entity. This provides a single source of truth so we don't need to combine cache data with db data. This could lead to some slower performance if used.

Example usage:
```ts
const res = await store.getByFields('Extrinsic', [
    ['module', '=', extrinsic.extrinsic.method.section],
    ['call', '=', extrinsic.extrinsic.method.method]
], { limit: 5 });

const res = await Extrinsic.getByFields([
    ['module', '=', extrinsic.extrinsic.method.section],
    ['call', '=', extrinsic.extrinsic.method.method]
]);

const res = await Extrinsic.getByFields([
    ['module', 'in', ['timestamp', 'parachains']],
    ['call', 'in', ['set', 'setHeads']],
  ], { limit: 5 });
```

Fixes https://github.com/subquery/subql/issues/1756

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update https://github.com/subquery/documentation/pull/409

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/409
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
