### PR TITLE
AutoQueue Parallelism

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move more code from node to node-core. Including configure module, workers (#1797)
 - Update api service generics to support multiple block types (#1968)
 - UnfinalizedBlocksService: make private methods protected to allow custom fork detection (#2009)
+- Update fetching blocks to use moving window rather than batches (#2000)
 
 ### Added
 - Project upgrades feature and many other changes to support it (#1797)

--- a/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
@@ -109,8 +109,6 @@ export abstract class BlockDispatcher<B, DS>
 
   private async fetchBlocksFromQueue(): Promise<void> {
     if (this.fetching || this.isShutdown) return;
-    // Process queue is full, no point in fetching more blocks
-    // if (this.processQueue.freeSpace < this.nodeConfig.batchSize) return;
 
     this.fetching = true;
 
@@ -121,6 +119,7 @@ export abstract class BlockDispatcher<B, DS>
         // Used to compare before and after as a way to check if queue was flushed
         const bufferedHeight = this._latestBufferedHeight;
 
+        // Wait for capacity to fetch blocks
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if (!blockNum || !this.fetchQueue.freeSpace!) {
           await delay(1);

--- a/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
@@ -99,6 +99,7 @@ export abstract class BlockDispatcher<B, DS>
 
   flushQueue(height: number): void {
     super.flushQueue(height);
+    this.fetchQueue.flush();
     this.processQueue.flush();
   }
 

--- a/packages/node-core/src/utils/autoQueue.spec.ts
+++ b/packages/node-core/src/utils/autoQueue.spec.ts
@@ -1,0 +1,29 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {AutoQueue} from './autoQueue';
+
+describe('AutoQueue', () => {
+  it('resovles promises in the order they are pushed', async () => {
+    const autoQueue = new AutoQueue<number>(10, 5);
+
+    const results: number[] = [];
+
+    const tasks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((v) => async () => {
+      const randomTime = Math.floor(Math.random() * 1000);
+      await new Promise((resolve) => setTimeout(resolve, randomTime));
+
+      return v;
+    });
+
+    await Promise.all(
+      tasks.map(async (t) => {
+        const r = await autoQueue.put(t);
+
+        results.push(r);
+      })
+    );
+
+    expect(results).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+});

--- a/packages/node-core/src/utils/autoQueue.spec.ts
+++ b/packages/node-core/src/utils/autoQueue.spec.ts
@@ -6,7 +6,6 @@ import {AutoQueue} from './autoQueue';
 describe('AutoQueue', () => {
   it('resovles promises in the order they are pushed', async () => {
     const autoQueue = new AutoQueue<number>(10, 5);
-
     const results: number[] = [];
 
     const tasks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((v) => async () => {
@@ -25,5 +24,34 @@ describe('AutoQueue', () => {
     );
 
     expect(results).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('doesnt resolve tasks if flush is called', async () => {
+    const autoQueue = new AutoQueue<number>(10, 2);
+    const results: number[] = [];
+
+    const tasks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((v) => async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      return v;
+    });
+
+    tasks.map((t) => {
+      void autoQueue.put(t).then((r) => {
+        results.push(r);
+      });
+    });
+
+    // Wait for some tasks to complete
+    await new Promise((resolve) => setTimeout(resolve, 110));
+
+    autoQueue.flush();
+
+    expect(autoQueue.size).toBe(0);
+
+    // Wait for any other tasks to be completed
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    expect(results).toEqual([1, 2]);
   });
 });

--- a/packages/node-core/src/utils/autoQueue.ts
+++ b/packages/node-core/src/utils/autoQueue.ts
@@ -76,25 +76,40 @@ export class Queue<T> implements IQueue {
 type Task<T> = () => Promise<T> | T;
 
 type Action<T> = {
+  index: number;
   task: Task<T>;
   resolve: (value: T) => void;
   reject: (reason: any) => void;
 };
 
+/*
+ * AutoQueue processes asnyc funcitons in order with a level of concurrency
+ * When concurrency is used it will be running many functions concurrently,
+ * but the promisies for this will still resolve in order they were inserted in the queue
+ */
 export class AutoQueue<T> implements IQueue {
   private pendingPromise = false;
   private queue: Queue<Action<T>>;
   private _abort = false;
-  private processingTasks = 0;
+  // private processingTasks = 0;
 
   private eventEmitter = new EventEmitter2();
+
+  private runningTasks: Promise<void | T>[] = [];
+
+  // Completed tasks that have completed before earlier tasks
+  private outOfOrderTasks: Record<number, {action: Action<T>; result?: T; error?: unknown}> = {};
+  // Next index assigned to a task when pushing to the queue
+  private nextIndex = 0;
+  // Next task to resolve, used to order the outOfOrderTasks
+  private nextTask = 0;
 
   constructor(capacity?: number, private concurrency = 1) {
     this.queue = new Queue<Action<T>>(capacity);
   }
 
   get size(): number {
-    return this.queue.size + this.processingTasks;
+    return this.queue.size + this.runningTasks.length;
   }
 
   get capacity(): number | undefined {
@@ -124,7 +139,7 @@ export class AutoQueue<T> implements IQueue {
 
     return tasks.map((task, index) => {
       return new Promise((resolve, reject) => {
-        this.queue.put({task, resolve, reject});
+        this.queue.put({task, resolve, reject, index: this.nextIndex++});
         if (tasks.length - 1 === index) {
           void this.take();
         }
@@ -132,36 +147,58 @@ export class AutoQueue<T> implements IQueue {
     });
   }
 
+  private processOutOfOrderTasks() {
+    const next = this.outOfOrderTasks[this.nextTask];
+
+    if (!next) return;
+
+    const {action: nextAction, error, result: nextResult} = next;
+    if (nextResult) {
+      nextAction.resolve(nextResult);
+    } else if (error) {
+      nextAction.reject(error);
+    }
+    delete this.outOfOrderTasks[this.nextTask];
+    this.nextTask++;
+    // Check if next task ready
+    this.processOutOfOrderTasks();
+  }
+
   private async take(): Promise<void> {
     if (this.pendingPromise) return;
     if (this._abort) {
-      // Reset so it can be restarted
-      // this._abort = false;
       return;
     }
 
     while (!this._abort) {
-      const actions = this.queue.takeMany(this.concurrency);
+      const action = this.queue.take();
 
-      if (!actions.length) break;
-      this.processingTasks += actions.length;
-
-      this.eventEmitter.emit('size', this.queue.size);
+      // No more actions to start, take will be called again when new items are pushed
+      if (!action) break;
 
       this.pendingPromise = true;
 
-      await Promise.all(
-        actions.map(async (action) => {
-          try {
-            const payload = await action.task();
-            this.processingTasks -= 1;
-            action.resolve(payload);
-          } catch (e) {
-            action.reject(e);
-          }
+      const p = Promise.resolve(action.task())
+        .then((result) => {
+          this.outOfOrderTasks[action.index] = {action, result};
         })
-      );
+        .catch((error) => {
+          this.outOfOrderTasks[action.index] = {action, error};
+        })
+        .finally(() => {
+          this.processOutOfOrderTasks();
+          const index = this.runningTasks.indexOf(p);
+          this.runningTasks.splice(index, 1);
+        });
+
+      this.runningTasks.push(p);
+
+      if (this.runningTasks.length >= this.concurrency) {
+        // Load up more when any task completes
+        await Promise.any(this.runningTasks);
+      }
     }
+
     this.pendingPromise = false;
   }
 

--- a/packages/node-core/src/utils/autoQueue.ts
+++ b/packages/node-core/src/utils/autoQueue.ts
@@ -116,7 +116,7 @@ export class AutoQueue<T> implements IQueue {
    * @param {number} [concurrency=1] - The number of parallel tasks that can be processed at any one time.
    * @param {number} [taskTimeoutSec=60] - A timeout for tasks to complete in. Units are seconds.
    * */
-  constructor(capacity?: number, private concurrency = 1, private taskTimeoutSec = 60) {
+  constructor(capacity?: number, public concurrency = 1, private taskTimeoutSec = 60) {
     this.queue = new Queue<Action<T>>(capacity);
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "noImplicitAny": false,
     "noImplicitThis": true,
     "moduleResolution": "node",
@@ -11,7 +11,7 @@
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "lib": ["ES2017", "ES2020"],
+    "lib": ["ES2017", "ES2020", "ES2021"],
     "emitDecoratorMetadata": true,
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
# Description

## AutoQueue
For a while now we've had the AutoQueue which you can add async functions to it. These functions will then get popped and called one at a time. Or with parallelism it would call N at a time and they could resolve in any order depending on how quick the function is. The changes to AutoQueue now allow running with parallelism and they will resolve in the order that they are pushed.

### Example:
A queue with parallelism 2

**Before**:
Items `1`,`2`,`3`,`4` get enqueued. `1`,`2` are called together but may complete in order `2`,`1`. Then `3`,`4` are run and could also complete in any order

**After**:
Items `1`,`2`,`3`,`4` get enqueued. `1`, `2` are called together. `2` completed first and will wait until `1` is completed and resolved before resolving. While `2` has completed and is waiting for `1` we can also call `3` or any following tasks.

## Taking Advantage
We can use the new features for block fetching. So rather than fetching blocks in a batch we can have a continuous window of the same batch size, when one block is fetched we start fetching another and the order of blocks is retained. This means a change in data flow and the introduction of a new queue. 

**Before**:
`Queue(BlockNumber) ---> Fetch batch-size blocks ---> AutoQueue(ProcessBlock)`

**After**:
`Queue(BlockNumber) ---> AutoQueue(FetchBlock) ---> AutoQueue(ProcessBlock)`

## Performance
Same machine and arguments (batch-size=100, non-ratelimited rpc endpoint) with polkadot starter:

**Before**:
```
2023-09-07T05:17:59.817Z <benchmark> INFO INDEXING: 26.10 blocks/s. Target height: 17,182,275. Current height: 24,425. Estimated time remaining: 7 days 14 hours 37 mins
2023-09-07T05:18:14.818Z <benchmark> INFO INDEXING: 21.25 blocks/s. Target height: 17,182,278. Current height: 24,725. Estimated time remaining: 9 days 08 hours 17 mins
2023-09-07T05:18:30.240Z <benchmark> INFO INDEXING: 20.74 blocks/s. Target height: 17,182,279. Current height: 25,125. Estimated time remaining: 9 days 13 hours 45 mins
```

**After**:
```
2023-09-07T05:19:40.687Z <benchmark> INFO INDEXING: 35.63 blocks/s. Target height: 17,182,292. Current height: 26,358. Estimated time remaining: 5 days 13 hours 44 mins
2023-09-07T05:19:55.708Z <benchmark> INFO INDEXING: 31.03 blocks/s. Target height: 17,182,294. Current height: 26,824. Estimated time remaining: 6 days 09 hours 35 mins
2023-09-07T05:20:10.707Z <benchmark> INFO INDEXING: 38.78 blocks/s. Target height: 17,182,297. Current height: 27,366. Estimated time remaining: 5 days 02 hours 53 mins
2023-09-07T05:20:25.707Z <benchmark> INFO INDEXING: 33.27 blocks/s. Target height: 17,182,300. Current height: 27,897. Estimated time remaining: 5 days 23 hours 12 mins
```

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## TODO

- [x] Smart batch size is not enabled. Need to decide if its really working (i've not see real world usage and still see OOM errors)
- [x] Check that if the queue is reset because of a DynamicDs being created or Reindex that the queue behaves correctly
- [x] Handle a task getting stuck or failing and blocking the queue resulting in a forever growing out-of-order results set
- [x] Test when chain fully synced.

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
