### PR TITLE
update endpoint health listener

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - handle APIs in connection pool whose initialization failed (#1970)
 - Fix generated operation hash with single entity, buffer did not get hashed issue.
 - Infinite recursion in setValueModel with arrays (#1993)
+- Fix health checks for Networks that produce batched blocks (#2005)
 
 ### Changed
 - Move more code from node to node-core. Including configure module, workers (#1797)

--- a/packages/node-core/src/meta/health.service.ts
+++ b/packages/node-core/src/meta/health.service.ts
@@ -44,6 +44,8 @@ export class HealthService {
     }
   }
 
+  // Not all networks have a consistent interval for Finalized Blocks
+  // Hence, the endpoint's health will be dictated by the best block (as it is a consistent interval)
   @OnEvent(IndexerEvent.BlockBest)
   handleTargetBlock(blockPayload: TargetBlockPayload): void {
     if (this.recordBlockHeight !== blockPayload.height) {

--- a/packages/node-core/src/meta/health.service.ts
+++ b/packages/node-core/src/meta/health.service.ts
@@ -44,7 +44,7 @@ export class HealthService {
     }
   }
 
-  @OnEvent(IndexerEvent.BlockTarget)
+  @OnEvent(IndexerEvent.BlockBest)
   handleTargetBlock(blockPayload: TargetBlockPayload): void {
     if (this.recordBlockHeight !== blockPayload.height) {
       this.recordBlockHeight = blockPayload.height;


### PR DESCRIPTION
# Description
Due to networks like Arbitrum and Optimism where the latest finalized block is batched and outputs every couple of mins. 
The endpoint health should not be listening to the latestFinalized block, rather it should be listening to the latest unFinalizedBlock


Fixes #1965

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
