### PR TITLE
Update unfinalized blocks to allow customised fork detection

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -15,11 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Move more code from node to node-core. Including configure module, workers (#1797)
 - Update api service generics to support multiple block types (#1968)
+- UnfinalizedBlocksService: make private methods protected to allow custom fork detection (#2009)
 
 ### Added
 - Project upgrades feature and many other changes to support it (#1797)
 - `skipBlock` option to NodeConfig (#1968)
 - `getByFields` to store (#1993)
+- `getPoiBlocksBefore` method to PoiModel so we can get recent blocks with operations (#2009)
 
 ## [4.2.3] - 2023-08-17
 ### Fixed

--- a/packages/node-core/src/indexer/poi/poiModel.ts
+++ b/packages/node-core/src/indexer/poi/poiModel.ts
@@ -9,7 +9,15 @@ import {PoiRepo, ProofOfIndex} from '../entities';
 export interface PoiInterface {
   model: PoiRepo;
   bulkUpsert(proofs: ProofOfIndex[]): Promise<void> | void;
+  /**
+   * Gets the first 100 blocks >= the startHeight.
+   * */
   getPoiBlocksByRange(startHeight: number): Promise<ProofOfIndex[]>;
+  /**
+   * Gets the 100 blocks <= to the start height where there is an operation.
+   * This can be used to determine the last blocks that had data to index.
+   * */
+  getPoiBlocksBefore(startHeight: number): Promise<ProofOfIndex[]>;
   getFirst(): Promise<ProofOfIndex | undefined>;
 }
 
@@ -37,6 +45,18 @@ export class PlainPoiModel implements PoiInterface {
       limit: DEFAULT_FETCH_RANGE,
       where: {id: {[Op.gte]: startHeight}},
       order: [['id', 'ASC']],
+    });
+    return result.map((r) => ensureProofOfIndexId(r?.toJSON<ProofOfIndex>()));
+  }
+
+  async getPoiBlocksBefore(startHeight: number): Promise<ProofOfIndex[]> {
+    const result = await this.model.findAll({
+      limit: DEFAULT_FETCH_RANGE,
+      where: {
+        id: {[Op.lte]: startHeight},
+        operationHashRoot: {[Op.ne]: null},
+      },
+      order: [['id', 'DESC']],
     });
     return result.map((r) => ensureProofOfIndexId(r?.toJSON<ProofOfIndex>()));
   }

--- a/packages/node-core/src/indexer/poi/poiModel.ts
+++ b/packages/node-core/src/indexer/poi/poiModel.ts
@@ -49,9 +49,13 @@ export class PlainPoiModel implements PoiInterface {
     return result.map((r) => ensureProofOfIndexId(r?.toJSON<ProofOfIndex>()));
   }
 
-  async getPoiBlocksBefore(startHeight: number): Promise<ProofOfIndex[]> {
+  async getPoiBlocksBefore(
+    startHeight: number,
+    options: {limit: number; offset: number} = {limit: DEFAULT_FETCH_RANGE, offset: 0}
+  ): Promise<ProofOfIndex[]> {
     const result = await this.model.findAll({
-      limit: DEFAULT_FETCH_RANGE,
+      limit: options.limit,
+      offset: options.offset,
       where: {
         id: {[Op.lte]: startHeight},
         operationHashRoot: {[Op.ne]: null},

--- a/packages/node-core/src/indexer/storeCache/cachePoi.ts
+++ b/packages/node-core/src/indexer/storeCache/cachePoi.ts
@@ -38,6 +38,11 @@ export class CachePoiModel implements ICachedModelControl, PoiInterface {
     await this.mutex.waitForUnlock();
     return this.plainPoiModel.getPoiBlocksByRange(startHeight);
   }
+
+  async getPoiBlocksBefore(startHeight: number): Promise<ProofOfIndex[]> {
+    await this.mutex.waitForUnlock();
+    return this.plainPoiModel.getPoiBlocksBefore(startHeight);
+  }
   async getPoiById(id: number): Promise<ProofOfIndex | undefined> {
     await this.mutex.waitForUnlock();
     if (this.setCache[id]) {

--- a/packages/node-core/src/indexer/storeCache/cachePoi.ts
+++ b/packages/node-core/src/indexer/storeCache/cachePoi.ts
@@ -39,9 +39,9 @@ export class CachePoiModel implements ICachedModelControl, PoiInterface {
     return this.plainPoiModel.getPoiBlocksByRange(startHeight);
   }
 
-  async getPoiBlocksBefore(startHeight: number): Promise<ProofOfIndex[]> {
+  async getPoiBlocksBefore(startHeight: number, options?: {offset: number; limit: number}): Promise<ProofOfIndex[]> {
     await this.mutex.waitForUnlock();
-    return this.plainPoiModel.getPoiBlocksBefore(startHeight);
+    return this.plainPoiModel.getPoiBlocksBefore(startHeight, options);
   }
   async getPoiById(id: number): Promise<ProofOfIndex | undefined> {
     await this.mutex.waitForUnlock();

--- a/packages/node-core/src/indexer/unfinalizedBlocks.service.ts
+++ b/packages/node-core/src/indexer/unfinalizedBlocks.service.ts
@@ -33,7 +33,7 @@ export interface IUnfinalizedBlocksService<B> {
 export abstract class BaseUnfinalizedBlocksService<B> implements IUnfinalizedBlocksService<B> {
   private _unfinalizedBlocks?: UnfinalizedBlocks;
   private _finalizedHeader?: Header;
-  private lastCheckedBlockHeight?: number;
+  protected lastCheckedBlockHeight?: number;
 
   protected abstract blockToHeader(block: B): Header;
   protected abstract getFinalizedHead(): Promise<Header>;
@@ -44,7 +44,7 @@ export abstract class BaseUnfinalizedBlocksService<B> implements IUnfinalizedBlo
     this._unfinalizedBlocks = unfinalizedBlocks;
   }
 
-  private get unfinalizedBlocks(): UnfinalizedBlocks {
+  protected get unfinalizedBlocks(): UnfinalizedBlocks {
     assert(this._unfinalizedBlocks !== undefined, new Error('Unfinalized blocks service has not been initialized'));
     return this._unfinalizedBlocks;
   }
@@ -53,12 +53,12 @@ export abstract class BaseUnfinalizedBlocksService<B> implements IUnfinalizedBlo
     this._finalizedHeader = finalizedHeader;
   }
 
-  private get finalizedHeader(): Header {
+  protected get finalizedHeader(): Header {
     assert(this._finalizedHeader !== undefined, new Error('Unfinalized blocks service has not been initialized'));
     return this._finalizedHeader;
   }
 
-  constructor(private readonly nodeConfig: NodeConfig, private readonly storeCache: StoreCacheService) {}
+  constructor(protected readonly nodeConfig: NodeConfig, protected readonly storeCache: StoreCacheService) {}
 
   async init(reindex: (targetHeight: number) => Promise<void>): Promise<number | undefined> {
     logger.info(`Unfinalized blocks is ${this.nodeConfig.unfinalizedBlocks ? 'enabled' : 'disabled'}`);
@@ -163,7 +163,7 @@ export abstract class BaseUnfinalizedBlocksService<B> implements IUnfinalizedBlo
   }
 
   // check unfinalized blocks for a fork, returns the header where a fork happened
-  private async hasForked(): Promise<Header | undefined> {
+  protected async hasForked(): Promise<Header | undefined> {
     const lastVerifiableBlock = this.getClosestRecord(this.finalizedBlockNumber);
 
     // No unfinalized blocks
@@ -206,7 +206,7 @@ export abstract class BaseUnfinalizedBlocksService<B> implements IUnfinalizedBlo
     return;
   }
 
-  private async getLastCorrectFinalizedBlock(forkedHeader: Header): Promise<number | undefined> {
+  protected async getLastCorrectFinalizedBlock(forkedHeader: Header): Promise<number | undefined> {
     const bestVerifiableBlocks = this.unfinalizedBlocks.filter(
       ({blockHeight}) => blockHeight <= this.finalizedBlockNumber
     );


### PR DESCRIPTION
# Description
Make private methods protected so that we can override the fork detection. This will be used with EVM networks that don't have concrete finalization.

It also adds a method to the POI model so we can get recent blocks that had operations.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
