### PR TITLE
default startBlock to 1

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Infinite recursion in setValueModel with arrays (#1993)
 - Fix health checks for Networks that produce batched blocks (#2005)
 - Update `@willsoto/nestjs-prometheus` version to `5.4.0` (#2012)
+- set default startBlock of datasources to 1 (#2019)
 
 ### Changed
 - Move more code from node to node-core. Including configure module, workers (#1797)

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -144,6 +144,7 @@ export async function updateDataSourcesV1_0_0<DS extends BaseDataSource, CDS ext
   // force convert to updated ds
   return Promise.all(
     _dataSources.map(async (dataSource) => {
+      dataSource.startBlock = dataSource.startBlock ?? 1;
       const entryScript = await loadDataSourceScript(reader, dataSource.mapping.file);
       const file = await updateDataSourcesEntry(reader, dataSource.mapping.file, root, entryScript);
       if (isCustomDs(dataSource)) {


### PR DESCRIPTION
# Description
default startBlock of datasources to 1 when they are undefined.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
