### PR TITLE
Fix dependency injection for testing framework and not initing api service

### DIFF
--- a/packages/node-core/src/api.service.ts
+++ b/packages/node-core/src/api.service.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import assert from 'assert';
 import {EventEmitter2} from '@nestjs/event-emitter';
 import {ProjectNetworkConfig} from '@subql/common';
 import {ApiConnectionError, ApiErrorType} from './api.connection.error';
@@ -17,7 +18,7 @@ export interface IApi<A = any, SA = any, B extends Array<any> = any[]> {
   fetchBlocks(heights: number[], ...args: any): Promise<B>;
   safeApi(height: number): SA;
   unsafeApi: A;
-  networkMeta: NetworkMetadataPayload;
+  readonly networkMeta: NetworkMetadataPayload;
 }
 
 export interface IApiConnectionSpecific<A = any, SA = any, B extends Array<any> = any[]> extends IApi<A, SA, B> {
@@ -32,7 +33,12 @@ export abstract class ApiService<A = any, SA = any, B extends Array<any> = any[]
     protected eventEmitter: EventEmitter2
   ) {}
 
-  abstract networkMeta: NetworkMetadataPayload;
+  private _networkMeta?: NetworkMetadataPayload;
+
+  get networkMeta(): NetworkMetadataPayload {
+    assert(this._networkMeta, 'ApiService has not been init');
+    return this._networkMeta;
+  }
 
   private timeouts: Record<string, NodeJS.Timeout | undefined> = {};
 
@@ -89,8 +95,8 @@ export abstract class ApiService<A = any, SA = any, B extends Array<any> = any[]
           postConnectedHook(connection, endpoint, i);
         }
 
-        if (!this.networkMeta) {
-          this.networkMeta = connection.networkMeta;
+        if (!this._networkMeta) {
+          this._networkMeta = connection.networkMeta;
         }
 
         const chainId = await getChainId(connection);
@@ -133,7 +139,7 @@ export abstract class ApiService<A = any, SA = any, B extends Array<any> = any[]
     index: number,
     endpoint: string,
     postConnectedHook?: (connection: IApiConnectionSpecific, endpoint: string, index: number) => void
-  ) {
+  ): Promise<void> {
     const connection = await createConnection(endpoint);
     const chainId = await getChainId(connection);
 

--- a/packages/node-core/src/configure/ProjectUpgrade.service.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.ts
@@ -104,7 +104,9 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
     metadata: CacheMetadataModel,
     onProjectUpgrade?: OnProjectUpgradeCallback<P>
   ): Promise<number | undefined> {
-    assert(!this.#metadata, `ProjectUpgradeService has already been initialized`);
+    if (this.#metadata) {
+      logger.warn(`ProjectUpgradeService has already been initialized, this is a no-op`);
+    }
     this.#metadata = metadata;
     this.onProjectUpgrade = onProjectUpgrade;
 

--- a/packages/node-core/src/indexer/storeCache/baseCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/baseCache.service.ts
@@ -66,7 +66,10 @@ export abstract class BaseCacheService implements BeforeApplicationShutdown {
   }
 
   async beforeApplicationShutdown(): Promise<void> {
-    this.schedulerRegistry.deleteInterval(this.intervalName);
+    // Check the interval exists, it might not with the testing framework
+    if (this.schedulerRegistry.doesExist('interval', this.intervalName)) {
+      this.schedulerRegistry.deleteInterval(this.intervalName);
+    }
     await timeout(this.flushCache(true), 5);
     this.logger.info(`Force flush cache successful!`);
   }

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -49,7 +49,6 @@ export class ApiService
   private fetchBlocksBatches: GetFetchFunc = () => this.fetchBlocksFunction;
   private currentBlockHash: string;
   private currentBlockNumber: number;
-  networkMeta: NetworkMetadataPayload;
 
   constructor(
     @Inject('ISubqueryProject') private project: SubqueryProject,

--- a/packages/node/src/subcommands/testing.module.ts
+++ b/packages/node/src/subcommands/testing.module.ts
@@ -10,6 +10,7 @@ import {
   DbModule,
   NodeConfig,
   PoiService,
+  StoreCacheService,
   StoreService,
   TestRunner,
 } from '@subql/node-core';
@@ -17,16 +18,15 @@ import { ConfigureModule } from '../configure/configure.module';
 import { ApiService } from '../indexer/api.service';
 import { DsProcessorService } from '../indexer/ds-processor.service';
 import { DynamicDsService } from '../indexer/dynamic-ds.service';
-import { FetchModule } from '../indexer/fetch.module';
 import { IndexerManager } from '../indexer/indexer.manager';
 import { ProjectService } from '../indexer/project.service';
 import { SandboxService } from '../indexer/sandbox.service';
 import { UnfinalizedBlocksService } from '../indexer/unfinalizedBlocks.service';
-import { MetaModule } from '../meta/meta.module';
 
 @Module({
   providers: [
     StoreService,
+    StoreCacheService,
     EventEmitter2,
     PoiService,
     SandboxService,
@@ -51,8 +51,6 @@ import { MetaModule } from '../meta/meta.module';
       useClass: IndexerManager,
     },
   ],
-
-  imports: [MetaModule, FetchModule],
   controllers: [],
   exports: [TestRunner],
 })

--- a/packages/node/src/subcommands/testing.module.ts
+++ b/packages/node/src/subcommands/testing.module.ts
@@ -32,7 +32,6 @@ import { MetaModule } from '../meta/meta.module';
     SandboxService,
     DsProcessorService,
     DynamicDsService,
-    ProjectService,
     UnfinalizedBlocksService,
     ConnectionPoolStateManager,
     ConnectionPoolService,
@@ -45,7 +44,7 @@ import { MetaModule } from '../meta/meta.module';
     TestRunner,
     {
       provide: 'IApi',
-      useClass: ApiService,
+      useExisting: ApiService,
     },
     {
       provide: 'IIndexerManager',

--- a/packages/node/src/subcommands/testing.service.ts
+++ b/packages/node/src/subcommands/testing.service.ts
@@ -34,12 +34,15 @@ export class TestingService extends BaseTestingService<
   }
 
   async getTestRunner(): Promise<
-    TestRunner<
-      ApiPromise,
-      ApiAt,
-      BlockContent,
-      SubqlProjectDs<SubstrateDatasource>
-    >
+    [
+      close: () => Promise<void>,
+      runner: TestRunner<
+        ApiPromise,
+        ApiAt,
+        BlockContent,
+        SubqlProjectDs<SubstrateDatasource>
+      >,
+    ]
   > {
     const testContext = await NestFactory.createApplicationContext(
       TestingModule,
@@ -57,7 +60,7 @@ export class TestingService extends BaseTestingService<
     await apiService.init();
     await projectService.init();
 
-    return testContext.get(TestRunner);
+    return [testContext.close.bind(testContext), testContext.get(TestRunner)];
   }
 
   async indexBlock(

--- a/packages/node/src/subcommands/testing.service.ts
+++ b/packages/node/src/subcommands/testing.service.ts
@@ -50,7 +50,7 @@ export class TestingService extends BaseTestingService<
 
     await testContext.init();
 
-    const projectService: ProjectService = testContext.get(ProjectService);
+    const projectService: ProjectService = testContext.get('IProjectService');
     const apiService = testContext.get(ApiService);
 
     // Initialise async services, we do this here rather than in factories, so we can capture one off events


### PR DESCRIPTION
# Description
Fixes testing framework not running. Removes duplicate ApiService and ProjectService. 

Fixes https://github.com/subquery/subql/issues/2020

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
