### PR TITLE
distribute worker load based on number of blocks loaded

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `@willsoto/nestjs-prometheus` version to `5.4.0` (#2012)
 - scaleBatchSize referring to itself instead of config (#2018)
 - set default startBlock of datasources to 1 (#2019)
-- distribute worker load based on number of blocks loaded (#2029)
+- use round-robin worker load balancing with memory constraint consideration (#2029)
 
 ### Changed
 - Move more code from node to node-core. Including configure module, workers (#1797)

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `@willsoto/nestjs-prometheus` version to `5.4.0` (#2012)
 - scaleBatchSize referring to itself instead of config (#2018)
 - set default startBlock of datasources to 1 (#2019)
+- distribute worker load based on number of blocks loaded (#2029)
 
 ### Changed
 - Move more code from node to node-core. Including configure module, workers (#1797)

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -5,22 +5,18 @@ import assert from 'assert';
 
 import {EventEmitter2} from '@nestjs/event-emitter';
 import {hexToU8a, u8aEq} from '@subql/utils';
-import {
-  DynamicDsService,
-  IProjectService,
-  ISubqueryProject,
-  PoiBlock,
-  PoiService,
-  StoreCacheService,
-  SmartBatchService,
-  StoreService,
-} from '..';
 import {NodeConfig} from '../../configure';
 import {IProjectUpgradeService} from '../../configure/ProjectUpgrade.service';
 import {IndexerEvent, PoiEvent} from '../../events';
 import {getLogger} from '../../logger';
 import {IQueue} from '../../utils';
+import {DynamicDsService} from '../dynamic-ds.service';
+import {PoiBlock, PoiService} from '../poi';
+import {SmartBatchService} from '../smartBatch.service';
+import {StoreService} from '../store.service';
+import {StoreCacheService} from '../storeCache';
 import {CachePoiModel} from '../storeCache/cachePoi';
+import {IProjectService, ISubqueryProject} from '../types';
 
 const logger = getLogger('BaseBlockDispatcherService');
 

--- a/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.spec.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.spec.ts
@@ -1,0 +1,78 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {EventEmitter2} from '@nestjs/event-emitter';
+import {IProjectUpgradeService, NodeConfig} from '@subql/node-core/configure';
+import {DynamicDsService} from '../dynamic-ds.service';
+import {PoiService} from '../poi';
+import {SmartBatchService} from '../smartBatch.service';
+import {StoreService} from '../store.service';
+import {StoreCacheService} from '../storeCache';
+import {IProjectService, ISubqueryProject} from '../types';
+import {WorkerBlockDispatcher} from './worker-block-dispatcher';
+
+class TestWorkerBlockDispatcher extends WorkerBlockDispatcher<any, any> {
+  async fetchBlock(worker: any, height: number): Promise<void> {
+    return Promise.resolve();
+  }
+}
+describe('WorkerBlockDispatcher', () => {
+  let dispatcher: WorkerBlockDispatcher<any, any>;
+
+  // Mock workers
+  const mockWorkers = [
+    {getMemoryLeft: jest.fn().mockResolvedValue(100), waitForWorkerBatchSize: jest.fn().mockResolvedValue(undefined)},
+    {getMemoryLeft: jest.fn().mockResolvedValue(200), waitForWorkerBatchSize: jest.fn().mockResolvedValue(undefined)},
+    {getMemoryLeft: jest.fn().mockResolvedValue(300), waitForWorkerBatchSize: jest.fn().mockResolvedValue(undefined)},
+  ];
+
+  beforeEach(() => {
+    dispatcher = new TestWorkerBlockDispatcher(
+      {workers: 3} as unknown as NodeConfig,
+      null as unknown as EventEmitter2,
+      null as unknown as IProjectService<any>,
+      null as unknown as IProjectUpgradeService,
+      {minimumHeapRequired: 150} as unknown as SmartBatchService,
+      null as unknown as StoreService,
+      null as unknown as StoreCacheService,
+      null as unknown as PoiService,
+      null as unknown as ISubqueryProject,
+      null as unknown as DynamicDsService<any>,
+      null as unknown as () => Promise<any>
+    );
+    (dispatcher as any).workers = mockWorkers;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('getNextWorkerIndex should return the index of the next worker that has memory above the minimum limit', async () => {
+    const index = await (dispatcher as any).getNextWorkerIndex();
+    expect(index).toBe(1);
+  });
+
+  test('getNextWorkerIndex should skip workers that have memory below the minimum limit', async () => {
+    // Make the first worker return memory below the limit
+    mockWorkers[1].getMemoryLeft.mockResolvedValue(100);
+
+    const index = await (dispatcher as any).getNextWorkerIndex();
+    expect(index).toBe(2);
+  });
+
+  test('getNextWorkerIndex should wait for memory to be freed if all workers have memory below the minimum limit', async () => {
+    // Make all workers return memory below the limit
+    mockWorkers[0].getMemoryLeft.mockResolvedValue(100);
+    mockWorkers[1].getMemoryLeft.mockResolvedValue(100);
+    mockWorkers[2].getMemoryLeft.mockResolvedValue(100);
+
+    // Make the first worker free up memory after waiting
+    mockWorkers[0].waitForWorkerBatchSize.mockImplementationOnce(() => {
+      mockWorkers[0].getMemoryLeft.mockResolvedValue(200);
+      return Promise.resolve();
+    });
+
+    const index = await (dispatcher as any).getNextWorkerIndex();
+    expect(index).toBe(0);
+  });
+});

--- a/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.ts
@@ -191,8 +191,6 @@ export abstract class WorkerBlockDispatcher<DS, W extends Worker>
     });
   }
 
-  //assuming all workers have same constraints, distribute load by
-  //round-robin based on number of blocks already loaded to ensure even distribution
   private async getNextWorkerIndex(): Promise<number> {
     this.currentWorkerIndex = (this.currentWorkerIndex + 1) % this.workers.length;
     const memLeft = await this.workers[this.currentWorkerIndex].getMemoryLeft();

--- a/packages/node-core/src/indexer/worker/worker.ts
+++ b/packages/node-core/src/indexer/worker/worker.ts
@@ -45,6 +45,11 @@ export function getWorkerService<S extends BaseWorkerService<any, any>>(): S {
   return workerService as S;
 }
 // eslint-disable-next-line @typescript-eslint/require-await
+async function getBlocksLoaded(): Promise<number> {
+  return workerService.numFetchedBlocks + workerService.numFetchingBlocks;
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await
 async function getMemoryLeft(): Promise<number> {
   const totalHeap = getHeapStatistics().heap_size_limit;
   const heapUsed = process.memoryUsage().heapUsed;
@@ -97,6 +102,7 @@ type NumFetchedBlocks = typeof numFetchedBlocks;
 type NumFetchingBlocks = typeof numFetchingBlocks;
 type GetWorkerStatus = typeof getStatus;
 type GetMemoryLeft = typeof getMemoryLeft;
+type GetBlocksLoaded = typeof getBlocksLoaded;
 type WaitForWorkerBatchSize = typeof waitForWorkerBatchSize;
 
 export type IBaseIndexerWorker = {
@@ -106,6 +112,7 @@ export type IBaseIndexerWorker = {
   numFetchingBlocks: NumFetchingBlocks;
   getStatus: GetWorkerStatus;
   getMemoryLeft: GetMemoryLeft;
+  getBlocksLoaded: GetBlocksLoaded;
   waitForWorkerBatchSize: WaitForWorkerBatchSize;
 };
 
@@ -116,6 +123,7 @@ export const baseWorkerFunctions: (keyof IBaseIndexerWorker)[] = [
   'numFetchingBlocks',
   'getStatus',
   'getMemoryLeft',
+  'getBlocksLoaded',
   'waitForWorkerBatchSize',
 ];
 
@@ -144,6 +152,7 @@ export function createWorkerHost<
       numFetchingBlocks,
       getStatus,
       getMemoryLeft,
+      getBlocksLoaded,
       waitForWorkerBatchSize,
     },
     logger


### PR DESCRIPTION
# Description
Current method of distribute fetch loads to workers uses the value of heap memory left in a worker as a metric for distribution. This leads to overloading of first worker before fetching begins, or when it is throttled because of a ratelimited endpoint

![image](https://github.com/subquery/subql/assets/40036742/f6393a86-c99b-49e6-afcc-8e13a1c529f8)

Instead we should use the number of blocks loaded to a worker to distribute further loads. This metric also serves as an approximate comparison for memory used by workers since majority of the heap memory will be occupied by fetched blocks. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
