### PR TITLE
skip dictionary when indexing latest

### DIFF
--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -235,11 +235,15 @@ export abstract class BaseFetchService<
         continue;
       }
 
-      if (this.useDictionary && startBlockHeight >= this.dictionaryService.startHeight) {
+      if (
+        this.useDictionary &&
+        startBlockHeight >= this.dictionaryService.startHeight &&
+        startBlockHeight < this.latestFinalizedHeight
+      ) {
         /* queryEndBlock needs to be limited by the latest height.
          * Dictionaries could be in the future depending on if they index unfinalized blocks or the node is using an RPC endpoint that is behind.
          */
-        const queryEndBlock = Math.min(startBlockHeight + DICTIONARY_MAX_QUERY_SIZE, latestHeight);
+        const queryEndBlock = Math.min(startBlockHeight + DICTIONARY_MAX_QUERY_SIZE, this.latestFinalizedHeight);
         try {
           const dictionary = await this.dictionaryService.scopedDictionaryEntries(
             startBlockHeight,


### PR DESCRIPTION
# Description
Skip dictionary when we are indexing unfinalised blocks or latest block (when unfinalised=false)

Fixes #1963

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
