### PR TITLE
change scope of rewind() to protect

### DIFF
--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -128,7 +128,7 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS> implements IBloc
    * rewind() is called from this.postProcessBlock(),
    * it handles runtime status like compare it with current indexing number, if last corrected is already indexed
    * then dispatch to projectService.reindex()
-   * if rollback is greater than current index flush queue only
+   * not likely happen but if rewind to future block, flush queue only
    * @param lastCorrectHeight
    */
   @mainThreadOnly()

--- a/packages/node-core/src/indexer/dynamic-ds.service.ts
+++ b/packages/node-core/src/indexer/dynamic-ds.service.ts
@@ -48,6 +48,10 @@ export abstract class DynamicDsService<DS> implements IDynamicDsService<DS> {
     return this._metadata;
   }
 
+  /**
+   * remove dynamic ds that is created after this height
+   * @param targetHeight this height is exclusive
+   */
   async resetDynamicDatasource(targetHeight: number): Promise<void> {
     const dynamicDs = await this.getDynamicDatasourceParams();
     if (dynamicDs.length !== 0) {

--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -703,6 +703,13 @@ group by
     return rows.map((result) => camelCaseObjectKey(result)) as IndexField[];
   }
 
+  /**
+   * rollback db that is newer than ${targetBlockHeight} (exclusive)
+   * set metadata
+   * since transaction is handled outside, metadata cache flushing and tx is done there.
+   * @param targetBlockHeight
+   * @param transaction
+   */
   async rewind(targetBlockHeight: number, transaction: Transaction): Promise<void> {
     if (!this.historical) {
       throw new Error('Unable to reindex, historical state not enabled');

--- a/packages/node-core/src/utils/reindex.ts
+++ b/packages/node-core/src/utils/reindex.ts
@@ -9,7 +9,7 @@ import {ForceCleanService} from '../subcommands';
 const logger = getLogger('Reindex');
 
 /**
- * Reindex the project to ${targetBlockHeight}
+ * Reindex the project to ${targetBlockHeight} (continue indexing after this height)
  * reset project if ${targetBlockHeight} <= startHeight
  * - storeCache is handled first, flush cached content before the actual rewind starts
  * - rewind is usually triggered by signal from unfinalizedBlockService, so some state cleanup is required there. FIXME
@@ -18,7 +18,7 @@ const logger = getLogger('Reindex');
  * - in the end, update metadata to targetHeight
  * @param startHeight
  * @param blockOffset
- * @param targetBlockHeight
+ * @param targetBlockHeight !IMPORTANT! this height is exclusive in the reindex operation
  * @param lastProcessedHeight
  * @param storeService
  * @param unfinalizedBlockService

--- a/packages/node-core/src/utils/reindex.ts
+++ b/packages/node-core/src/utils/reindex.ts
@@ -46,7 +46,7 @@ export async function reindex(
   }
 
   // if startHeight is greater than the targetHeight, just force clean
-  if (targetBlockHeight <= startHeight) {
+  if (targetBlockHeight < startHeight) {
     logger.info(
       `targetHeight: ${targetBlockHeight} is less than startHeight: ${startHeight}. Hence executing force-clean`
     );

--- a/packages/node-core/src/utils/reindex.ts
+++ b/packages/node-core/src/utils/reindex.ts
@@ -8,6 +8,25 @@ import {ForceCleanService} from '../subcommands';
 
 const logger = getLogger('Reindex');
 
+/**
+ * Reindex the project to ${targetBlockHeight}
+ * reset project if ${targetBlockHeight} <= startHeight
+ * - storeCache is handled first, flush cached content before the actual rewind starts
+ * - rewind is usually triggered by signal from unfinalizedBlockService, so some state cleanup is required there. FIXME
+ * - dynamicDsService will need to look after, clean all ds that added after the targetHeight
+ * - poi need to cope with rewind as well. FIXME
+ * - in the end, update metadata to targetHeight
+ * @param startHeight
+ * @param blockOffset
+ * @param targetBlockHeight
+ * @param lastProcessedHeight
+ * @param storeService
+ * @param unfinalizedBlockService
+ * @param dynamicDsService
+ * @param sequelize
+ * @param forceCleanService
+ * @param latestSyncedPoiHeight
+ */
 export async function reindex(
   startHeight: number,
   targetBlockHeight: number,
@@ -27,7 +46,7 @@ export async function reindex(
   }
 
   // if startHeight is greater than the targetHeight, just force clean
-  if (targetBlockHeight < startHeight) {
+  if (targetBlockHeight <= startHeight) {
     logger.info(
       `targetHeight: ${targetBlockHeight} is less than startHeight: ${startHeight}. Hence executing force-clean`
     );


### PR DESCRIPTION
since rewind() should be called directly from BlockDispatcher, it's logically to remove it from the interface.

* add more comments

# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
