### PR TITLE
Rename skipBlock to skipTransaction, make NodeConfig expandable

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add spec for project upgrades (#1797)
-- skipBlock node runner option (#1968)
+- `skipTransaction` node runner option (#1968)
 
 ## [2.6.0] - 2023-08-25
 ### Changed

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add spec for project upgrades (#1797)
-- `skipTransaction` node runner option (#1968)
+- `skipTransactions` node runner option (#1968)
 
 ## [2.6.0] - 2023-08-25
 ### Changed

--- a/packages/common/src/project/versioned/v1_0_0/models.ts
+++ b/packages/common/src/project/versioned/v1_0_0/models.ts
@@ -64,7 +64,7 @@ export class RunnerNodeOptionsModel implements NodeOptions {
   unfinalizedBlocks?: boolean;
   @IsOptional()
   @IsBoolean()
-  skipTransaction?: boolean;
+  skipTransactions?: boolean;
 }
 
 export class BlockFilterImpl implements BlockFilter {

--- a/packages/common/src/project/versioned/v1_0_0/models.ts
+++ b/packages/common/src/project/versioned/v1_0_0/models.ts
@@ -64,7 +64,7 @@ export class RunnerNodeOptionsModel implements NodeOptions {
   unfinalizedBlocks?: boolean;
   @IsOptional()
   @IsBoolean()
-  skipBlock?: boolean;
+  skipTransaction?: boolean;
 }
 
 export class BlockFilterImpl implements BlockFilter {

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Project upgrades feature and many other changes to support it (#1797)
-- `skipBlock` option to NodeConfig (#1968)
+- `skipTransaction` option to NodeConfig (#1968)
 - `getByFields` to store (#1993)
 - `getPoiBlocksBefore` method to PoiModel so we can get recent blocks with operations (#2009)
 

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Project upgrades feature and many other changes to support it (#1797)
-- `skipTransaction` option to NodeConfig (#1968)
+- `skipTransactions` option to NodeConfig (#1968)
 - `getByFields` to store (#1993)
 - `getPoiBlocksBefore` method to PoiModel so we can get recent blocks with operations (#2009)
 

--- a/packages/node-core/src/configure/configure.module.ts
+++ b/packages/node-core/src/configure/configure.module.ts
@@ -103,7 +103,7 @@ export async function registerApp<P extends ISubqueryProject>(
     rawManifest = await reader.getProjectSchema();
     rebaseArgsWithManifest(argv, rawManifest);
     // use rebased argv generate config to override current config
-    config = NodeConfig.rebaseWithArgs(config, yargsToIConfig(argv, nameMapping), isTest);
+    config = NodeConfig.rebaseWithArgs(config, yargsToIConfig(argv, nameMapping));
   } else {
     if (!argv.subquery) {
       logger.error('Subquery path is missing in both cli options and config file');

--- a/packages/node-core/src/utils/configure.ts
+++ b/packages/node-core/src/utils/configure.ts
@@ -12,7 +12,7 @@ export interface ArgvOverrideOptions {
   unsafe?: boolean;
   disableHistorical?: boolean;
   unfinalizedBlocks?: boolean;
-  skipBlock?: boolean;
+  skipTransaction?: boolean;
 }
 
 export function defaultSubqueryName(config: Partial<IConfig>): MinConfig {
@@ -30,28 +30,26 @@ export function defaultSubqueryName(config: Partial<IConfig>): MinConfig {
   } as MinConfig;
 }
 
-function applyArgs(
-  argvs: ArgvOverrideOptions,
-  options: RunnerNodeOptionsModel,
-  key: keyof Omit<ArgvOverrideOptions, 'disableHistorical'>
-) {
-  if (argvs[key] === undefined && options[key] !== undefined) {
-    argvs[key] = options[key];
-  }
-}
-
 export function rebaseArgsWithManifest(argvs: ArgvOverrideOptions, rawManifest: unknown): void {
   const options = plainToClass(RunnerNodeOptionsModel, (rawManifest as any)?.runner?.node?.options);
   if (!options) {
     return;
   }
 
-  // we override them if they are not provided in args/flag
-  if (argvs.disableHistorical === undefined && options.historical !== undefined) {
-    // THIS IS OPPOSITE
-    argvs.disableHistorical = !options.historical;
-  }
-  applyArgs(argvs, options, 'unsafe');
-  applyArgs(argvs, options, 'unfinalizedBlocks');
-  applyArgs(argvs, options, 'skipBlock');
+  // Do this with any options as other SDKs might want to implement custom options
+  (Object.entries(options) as [keyof Omit<ArgvOverrideOptions, 'disableHistorical'> | 'historical', any][]).map(
+    ([key, value]) => {
+      // we override them if they are not provided in args/flag
+      if (key === 'historical') {
+        if (value !== undefined) {
+          // THIS IS OPPOSITE
+          argvs.disableHistorical = !value;
+        }
+        return;
+      }
+      if (value !== undefined && argvs[key] === undefined) {
+        argvs[key] = value;
+      }
+    }
+  );
 }

--- a/packages/node-core/src/utils/configure.ts
+++ b/packages/node-core/src/utils/configure.ts
@@ -12,7 +12,7 @@ export interface ArgvOverrideOptions {
   unsafe?: boolean;
   disableHistorical?: boolean;
   unfinalizedBlocks?: boolean;
-  skipTransaction?: boolean;
+  skipTransactions?: boolean;
 }
 
 export function defaultSubqueryName(config: Partial<IConfig>): MinConfig {

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Project upgrades feature which allows upgrading projects at specific heights (#1797)
-- Support for `skipTransaction` and LightBlock (#1968)
+- Support for `skipTransactions` and LightBlock (#1968)
 
 ## [2.12.2] - 2023-08-17
 ### Fixed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Project upgrades feature which allows upgrading projects at specific heights (#1797)
-- Support for skipBlock and LightBlock (#1968)
+- Support for `skipTransaction` and LightBlock (#1968)
 
 ## [2.12.2] - 2023-08-17
 ### Fixed

--- a/packages/node/src/configure/NodeConfig.ts
+++ b/packages/node/src/configure/NodeConfig.ts
@@ -4,7 +4,7 @@
 import { IConfig, NodeConfig } from '@subql/node-core';
 
 export interface ISubstrateConfig extends IConfig {
-  skipTransaction: boolean;
+  skipTransactions: boolean;
 }
 
 export class SubstrateNodeConfig extends NodeConfig<ISubstrateConfig> {
@@ -24,7 +24,7 @@ export class SubstrateNodeConfig extends NodeConfig<ISubstrateConfig> {
     super((config as any)._config, (config as any)._isTest);
   }
 
-  get skipTransaction(): boolean {
-    return !!this._config.skipTransaction;
+  get skipTransactions(): boolean {
+    return !!this._config.skipTransactions;
   }
 }

--- a/packages/node/src/configure/NodeConfig.ts
+++ b/packages/node/src/configure/NodeConfig.ts
@@ -1,0 +1,30 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import { IConfig, NodeConfig } from '@subql/node-core';
+
+export interface ISubstrateConfig extends IConfig {
+  skipTransaction: boolean;
+}
+
+export class SubstrateNodeConfig extends NodeConfig<ISubstrateConfig> {
+  /**
+   * This is a wrapper around the core NodeConfig to get additional properties that are provided through args or node runner options
+   * NOTE: This isn't injected anywhere so you need to wrap the injected node config
+   *
+   * @example
+   * constructor(
+   *   nodeConfig: NodeConfig,
+   * ) {
+   *   this.nodeConfig = new SubstrateNodeConfig(nodeConfig);
+   * }
+   * */
+  constructor(config: NodeConfig) {
+    // Rebuild with internal config
+    super((config as any)._config, (config as any)._isTest);
+  }
+
+  get skipTransaction(): boolean {
+    return !!this._config.skipTransaction;
+  }
+}

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -125,30 +125,30 @@ export class ApiService
 
   updateBlockFetching(): void {
     const onlyEventHandlers = isOnlyEventHandlers(this.project);
-    const skipTransaction =
-      this.nodeConfig.skipTransaction && onlyEventHandlers;
+    const skipTransactions =
+      this.nodeConfig.skipTransactions && onlyEventHandlers;
 
-    if (this.nodeConfig.skipTransaction) {
+    if (this.nodeConfig.skipTransactions) {
       if (onlyEventHandlers) {
         logger.info(
-          'skipTransaction is enabled, only events and block headers will be fetched.',
+          'skipTransactions is enabled, only events and block headers will be fetched.',
         );
       } else {
         logger.info(
-          `skipTransaction is disabled, the project contains handlers that aren't event handlers.`,
+          `skipTransactions is disabled, the project contains handlers that aren't event handlers.`,
         );
       }
     } else {
       if (onlyEventHandlers) {
         logger.warn(
-          'skipTransaction is disabled, the project contains only event handlers, it could be enabled to improve indexing performance.',
+          'skipTransactions is disabled, the project contains only event handlers, it could be enabled to improve indexing performance.',
         );
       } else {
-        logger.info(`skipTransaction is disabled.`);
+        logger.info(`skipTransactions is disabled.`);
       }
     }
 
-    const fetchFunc = skipTransaction
+    const fetchFunc = skipTransactions
       ? SubstrateUtil.fetchBlocksBatchesLight
       : SubstrateUtil.fetchBlocksBatches;
 

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -16,6 +16,7 @@ import {
   ConnectionPoolService,
   ApiService as BaseApiService,
 } from '@subql/node-core';
+import { SubstrateNodeConfig } from '../configure/NodeConfig';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { isOnlyEventHandlers } from '../utils/project';
 import * as SubstrateUtil from '../utils/substrate';
@@ -50,13 +51,16 @@ export class ApiService
   private currentBlockHash: string;
   private currentBlockNumber: number;
 
+  private nodeConfig: SubstrateNodeConfig;
+
   constructor(
     @Inject('ISubqueryProject') private project: SubqueryProject,
     connectionPoolService: ConnectionPoolService<ApiPromiseConnection>,
     eventEmitter: EventEmitter2,
-    private nodeConfig: NodeConfig,
+    nodeConfig: NodeConfig,
   ) {
     super(connectionPoolService, eventEmitter);
+    this.nodeConfig = new SubstrateNodeConfig(nodeConfig);
 
     this.updateBlockFetching();
   }
@@ -121,29 +125,30 @@ export class ApiService
 
   updateBlockFetching(): void {
     const onlyEventHandlers = isOnlyEventHandlers(this.project);
-    const skipBlock = this.nodeConfig.skipBlock && onlyEventHandlers;
+    const skipTransaction =
+      this.nodeConfig.skipTransaction && onlyEventHandlers;
 
-    if (this.nodeConfig.skipBlock) {
+    if (this.nodeConfig.skipTransaction) {
       if (onlyEventHandlers) {
         logger.info(
-          'skipBlock is enabled, only events and block headers will be fetched.',
+          'skipTransaction is enabled, only events and block headers will be fetched.',
         );
       } else {
         logger.info(
-          `skipBlock is disabled, the project contains handlers that aren't event handlers.`,
+          `skipTransaction is disabled, the project contains handlers that aren't event handlers.`,
         );
       }
     } else {
       if (onlyEventHandlers) {
         logger.warn(
-          'skipBlock is disabled, the project contains only event handlers, it could be enabled to improve indexing performance.',
+          'skipTransaction is disabled, the project contains only event handlers, it could be enabled to improve indexing performance.',
         );
       } else {
-        logger.info(`skipBlock is disabled.`);
+        logger.info(`skipTransaction is disabled.`);
       }
     }
 
-    const fetchFunc = skipBlock
+    const fetchFunc = skipTransaction
       ? SubstrateUtil.fetchBlocksBatchesLight
       : SubstrateUtil.fetchBlocksBatches;
 

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -29,7 +29,7 @@ export type FetchFunc =
   | typeof SubstrateUtil.fetchBlocksBatches
   | typeof SubstrateUtil.fetchBlocksBatchesLight;
 
-// We use a function to get the fetch function because it can change depending on the skipBlocks feature
+// We use a function to get the fetch function because it can change depending on the skipTransactions feature
 export type GetFetchFunc = () => FetchFunc;
 
 export class ApiPromiseConnection

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -192,7 +192,7 @@ export const yargsOptions = yargs(hideBin(process.argv))
             type: 'boolean',
             default: false,
           },
-          skipTransaction: {
+          skipTransactions: {
             demandOption: false,
             describe:
               'If the project contains only event handlers and only accesses the events or block header then you can enable this option to reduce RPC requests and have a slight performance increase. This will be automatically disabled if handlers other than EventHandlers are detected.',

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -192,7 +192,7 @@ export const yargsOptions = yargs(hideBin(process.argv))
             type: 'boolean',
             default: false,
           },
-          skipBlock: {
+          skipTransaction: {
             demandOption: false,
             describe:
               'If the project contains only event handlers and only accesses the events or block header then you can enable this option to reduce RPC requests and have a slight performance increase. This will be automatically disabled if handlers other than EventHandlers are detected.',

--- a/packages/types-core/src/project/versioned/v1_0_0/types.ts
+++ b/packages/types-core/src/project/versioned/v1_0_0/types.ts
@@ -88,7 +88,7 @@ export interface NodeOptions {
 
   /**
    * Indicates whether unsafe mode are allowed for the indexer (optional).
-   * 
+   *
    * Unsafe mode controls various features that compromise the determinsm of a SubQuery project.
    * Unsafe allows any imports which greatly increases functionality with the tradeoff of decreased security
    * @type {boolean}
@@ -98,7 +98,7 @@ export interface NodeOptions {
 
   /**
    * Indicates whether unfinalized blocks are supported by the indexer (optional).
-   * 
+   *
    * This allows you to index blocks before they become finalized.
    * It can be very useful if you want the most up-to-date data possible.
    * It will detect any forks and remove any blocks that don't become finalized.
@@ -108,10 +108,11 @@ export interface NodeOptions {
   unfinalizedBlocks?: boolean;
 
   /**
-   * Indicates whether block skipping is enabled for the indexer (optional).
+   * Indicates whether transaction skipping is enabled for the indexer. (optional).
+   * If this is enabled and the project only contains event handlers then it wont fetch transactions reducing memory footprint and RPC requests. This can lead to faster indexing.
    * @type {boolean}
    */
-  skipBlock?: boolean;
+  skipTransaction?: boolean;
 }
 
 /**

--- a/packages/types-core/src/project/versioned/v1_0_0/types.ts
+++ b/packages/types-core/src/project/versioned/v1_0_0/types.ts
@@ -112,7 +112,7 @@ export interface NodeOptions {
    * If this is enabled and the project only contains event handlers then it wont fetch transactions reducing memory footprint and RPC requests. This can lead to faster indexing.
    * @type {boolean}
    */
-  skipTransaction?: boolean;
+  skipTransactions?: boolean;
 }
 
 /**


### PR DESCRIPTION
# Description
Renames the `skipBlock` feature to `skipTransactions` to better represent the feature. 

It also makes some minor changes to NodeConfig to do the following:
* Allow extending so the different SDKs can have their own options
* Support any type of node runner options so we can have SDK specific options.

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
