### PR TITLE
Fix project upgrades in workers

### DIFF
--- a/packages/node-core/src/configure/ProjectUpgrade.service.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.ts
@@ -2,16 +2,21 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import assert from 'assert';
+import {isMainThread} from 'worker_threads';
 import {findLast, last} from 'lodash';
 import {CacheMetadataModel, ISubqueryProject} from '../indexer';
 import {getLogger} from '../logger';
-import {getStartHeight} from '../utils';
+import {getStartHeight, mainThreadOnly} from '../utils';
 import {BlockHeightMap} from '../utils/blockHeightMap';
 
 type OnProjectUpgradeCallback<P> = (height: number, project: P) => void | Promise<void>;
 
 export interface IProjectUpgradeService<P extends ISubqueryProject = ISubqueryProject> {
-  init: (metadata: CacheMetadataModel, onProjectUpgrade: OnProjectUpgradeCallback<P>) => Promise<number | undefined>;
+  init: (metadata: CacheMetadataModel, onProjectUpgrade?: OnProjectUpgradeCallback<P>) => Promise<number | undefined>;
+  /**
+   * This should only be called from within a worker thread as they dont have access to the store
+   * */
+  initWorker(currentHeight: number, onProjectUpgrade?: OnProjectUpgradeCallback<P>): void;
   updateIndexedDeployments: (id: string, blockHeight: number) => Promise<void>;
   readonly currentHeight: number;
   setCurrentHeight: (newHeight: number) => Promise<void>;
@@ -80,6 +85,8 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
 
   #metadata?: CacheMetadataModel;
 
+  #initialized = false;
+
   private onProjectUpgrade?: OnProjectUpgradeCallback<P>;
 
   private constructor(private _projects: BlockHeightMap<P>, currentHeight: number) {
@@ -103,9 +110,11 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
     metadata: CacheMetadataModel,
     onProjectUpgrade?: OnProjectUpgradeCallback<P>
   ): Promise<number | undefined> {
-    if (this.#metadata) {
+    if (this.#initialized) {
       logger.warn(`ProjectUpgradeService has already been initialized, this is a no-op`);
+      return;
     }
+    this.#initialized = true;
     this.#metadata = metadata;
     this.onProjectUpgrade = onProjectUpgrade;
 
@@ -119,6 +128,13 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
     }
 
     return lastProjectChange;
+  }
+
+  initWorker(currentHeight: number, onProjectUpgrade?: OnProjectUpgradeCallback<P>): void {
+    assert(!this.onProjectUpgrade, `onProjectUpgrade callback has already been set`);
+    this.#currentHeight = currentHeight;
+    this.#currentProject = this.getProject(this.#currentHeight);
+    this.onProjectUpgrade = onProjectUpgrade;
   }
 
   get projects(): Map<number, P> {
@@ -144,12 +160,14 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
     this.#currentProject = newProject;
 
     if (hasChanged) {
-      try {
-        // Use the project start height here for when resuming indexing at an arbitrary height
-        await this.updateIndexedDeployments(newProject.id, startHeight);
-      } catch (e: any) {
-        logger.error(e, 'Failed to update deployment metadata');
-        process.exit(1);
+      if (isMainThread) {
+        try {
+          // Use the project start height here for when resuming indexing at an arbitrary height
+          await this.updateIndexedDeployments(newProject.id, startHeight);
+        } catch (e: any) {
+          logger.error(e, 'Failed to update deployment metadata');
+          process.exit(1);
+        }
       }
 
       try {
@@ -275,6 +293,7 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
     return JSON.parse(deploymentsRaw);
   }
 
+  @mainThreadOnly()
   async updateIndexedDeployments(id: string, blockHeight: number): Promise<void> {
     assert(this.#metadata, 'Project Upgrades service has not been initialized, unable to update metadata');
     const deployments = await this.getDeploymentsMetadata();

--- a/packages/node-core/src/configure/ProjectUpgrade.service.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.ts
@@ -265,7 +265,7 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
 
       // Nothing has been indexed
       if (!indexedEntries.length) {
-        return projectEntries[0][0];
+        return undefined;
       }
 
       // TODO do we need to compare heights?

--- a/packages/node-core/src/indexer/indexer.manager.ts
+++ b/packages/node-core/src/indexer/indexer.manager.ts
@@ -42,7 +42,6 @@ export abstract class BaseIndexerManager<
   HandlerInputMap extends HandlerInputTypeMap<FilterMap>
 > implements IIndexerManager<B, DS>
 {
-  abstract start(): Promise<void>;
   abstract indexBlock(block: B, datasources: DS[], ...args: any[]): Promise<ProcessBlockResponse>;
   abstract getBlockHeight(block: B): number;
   abstract getBlockHash(block: B): string;

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -78,7 +78,7 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
     return getExistingProjectSchema(this.nodeConfig, this.sequelize);
   }
 
-  async init(): Promise<void> {
+  async init(startHeight?: number): Promise<void> {
     for await (const [, project] of this.projectUpgradeService.projects) {
       await project.applyCronTimestamps(this.getBlockTimestamp.bind(this));
     }
@@ -116,11 +116,11 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
       // Flush any pending operations to set up DB
       await this.storeService.storeCache.flushCache(true, true);
     } else {
-      this._schema = await this.getExistingProjectSchema();
+      assert(startHeight, 'ProjectService must be initalized with a start height in workers');
+      this.projectUpgradeService.initWorker(startHeight, this.handleProjectChange.bind(this));
 
-      assert(this._schema, 'Schema should be created in main thread');
-      await this.storeService.initCoreTables(this._schema);
-      await this.initUpgradeService();
+      // Called to allow handling the first project
+      await this.onProjectChange(this.project);
     }
 
     // Used to load assets into DS-processor, has to be done in any thread
@@ -300,16 +300,7 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
   private async initUpgradeService(): Promise<number | undefined> {
     const metadata = this.storeService.storeCache.metadata;
 
-    const upgradePoint = await this.projectUpgradeService.init(metadata, async () => {
-      // Apply any migrations to the schema
-      await this.initDbSchema();
-
-      // Reload the dynamic ds with new project
-      // TODO are we going to run into problems with this being non blocking
-      await this.dynamicDsService.getDynamicDatasources(true);
-
-      await this.onProjectChange(this.project);
-    });
+    const upgradePoint = await this.projectUpgradeService.init(metadata, this.handleProjectChange.bind(this));
 
     // Called to allow handling the first project
     await this.onProjectChange(this.project);
@@ -338,6 +329,18 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
       }
     }
     return undefined;
+  }
+
+  private async handleProjectChange(): Promise<void> {
+    // Apply any migrations to the schema
+    if (isMainThread) {
+      await this.initDbSchema();
+    }
+
+    // Reload the dynamic ds with new project
+    await this.dynamicDsService.getDynamicDatasources(true);
+
+    await this.onProjectChange(this.project);
   }
 
   async reindex(targetBlockHeight: number): Promise<void> {

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -115,6 +115,12 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
 
       // Flush any pending operations to set up DB
       await this.storeService.storeCache.flushCache(true, true);
+    } else {
+      this._schema = await this.getExistingProjectSchema();
+
+      assert(this._schema, 'Schema should be created in main thread');
+      await this.storeService.initCoreTables(this._schema);
+      await this.initUpgradeService();
     }
 
     // Used to load assets into DS-processor, has to be done in any thread

--- a/packages/node-core/src/indexer/types.ts
+++ b/packages/node-core/src/indexer/types.ts
@@ -37,12 +37,12 @@ export type OperationEntity = {
 };
 
 export interface IIndexerManager<B, DS> {
-  start(): Promise<void>;
   indexBlock(block: B, datasources: DS[], ...args: any[]): Promise<ProcessBlockResponse>;
 }
 
 export interface IProjectService<DS> {
   blockOffset: number | undefined;
+  startHeight: number;
   reindex(lastCorrectHeight: number): Promise<void>;
   getAllDataSources(): DS[];
   getDataSources(blockHeight?: number): Promise<DS[]>;

--- a/packages/node-core/src/indexer/worker/worker.connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/worker/worker.connectionPoolState.manager.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import {isMainThread} from 'node:worker_threads';
 import {Injectable} from '@nestjs/common';
 import {ApiErrorType} from '../../api.connection.error';
 import {IApiConnectionSpecific} from '../../api.service';
@@ -61,7 +62,11 @@ export function connectionPoolStateHostFunctions<T extends IApiConnectionSpecifi
 export class WorkerConnectionPoolStateManager<T extends IApiConnectionSpecific>
   implements IConnectionPoolStateManager<T>
 {
-  constructor(private host: HostConnectionPoolState<any>) {}
+  constructor(private host: HostConnectionPoolState<any>) {
+    if (isMainThread) {
+      throw new Error('Expected to be worker thread');
+    }
+  }
 
   async getNextConnectedEndpoint(): Promise<string | undefined> {
     return this.host.hostGetNextConnectedEndpoint();

--- a/packages/node-core/src/indexer/worker/worker.dynamic-ds.service.ts
+++ b/packages/node-core/src/indexer/worker/worker.dynamic-ds.service.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import {isMainThread} from 'node:worker_threads';
 import {Injectable} from '@nestjs/common';
 import {DatasourceParams, IDynamicDsService} from '../dynamic-ds.service';
 
@@ -16,7 +17,11 @@ export const hostDynamicDsKeys: (keyof HostDynamicDS<any>)[] = [
 
 @Injectable()
 export class WorkerDynamicDsService<DS> implements IDynamicDsService<DS> {
-  constructor(private host: HostDynamicDS<DS>) {}
+  constructor(private host: HostDynamicDS<DS>) {
+    if (isMainThread) {
+      throw new Error('Expected to be worker thread');
+    }
+  }
 
   get dynamicDatasources(): DS[] {
     throw new Error('Worker does not support this property. Use getDynamicDatasources instead');

--- a/packages/node-core/src/indexer/worker/worker.ts
+++ b/packages/node-core/src/indexer/worker/worker.ts
@@ -129,7 +129,7 @@ export const baseWorkerFunctions: (keyof IBaseIndexerWorker)[] = [
 
 export function createWorkerHost<
   T extends AsyncMethods,
-  H extends AsyncMethods & {initWorker: () => Promise<void>},
+  H extends AsyncMethods & {initWorker: (height?: number) => Promise<void>},
   ApiConnection /* ApiPromiseConnection*/,
   DS extends BaseDataSource = BaseDataSource
 >(extraWorkerFns: (keyof T)[], extraHostFns: H): WorkerHost<DefaultWorkerFunctions<ApiConnection, DS> & T> {

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import { isMainThread } from 'worker_threads';
 import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApiPromise } from '@polkadot/api';

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import { isMainThread } from 'worker_threads';
 import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApiPromise } from '@polkadot/api';
@@ -10,7 +9,6 @@ import { RuntimeVersion, Header } from '@polkadot/types/interfaces';
 import { AnyFunction, DefinitionRpcExt } from '@polkadot/types/types';
 import {
   IndexerEvent,
-  NetworkMetadataPayload,
   getLogger,
   NodeConfig,
   profilerWrap,

--- a/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
@@ -43,6 +43,7 @@ async function createIndexerWorker(
   unfinalizedBlocksService: IUnfinalizedBlocksService<BlockContent>,
   connectionPoolState: ConnectionPoolStateManager<ApiPromiseConnection>,
   root: string,
+  startHeight: number,
 ): Promise<IndexerWorker> {
   const indexerWorker = Worker.create<
     IInitIndexerWorker,
@@ -67,7 +68,7 @@ async function createIndexerWorker(
     root,
   );
 
-  await indexerWorker.initWorker();
+  await indexerWorker.initWorker(startHeight);
 
   return indexerWorker;
 }
@@ -113,6 +114,7 @@ export class WorkerBlockDispatcherService
           unfinalizedBlocksSevice,
           connectionPoolState,
           project.root,
+          projectService.startHeight,
         ),
     );
   }

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -137,6 +137,7 @@ export function mockProjectUpgradeService(
   let currentHeight = startBlock;
   return {
     init: jest.fn(),
+    initWorker: jest.fn(),
     updateIndexedDeployments: jest.fn(),
     currentHeight: currentHeight,
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -212,7 +213,6 @@ function createIndexerManager(
     dsProcessorService,
     dynamicDsService,
     unfinalizedBlocksService,
-    projectService,
   );
 }
 
@@ -227,30 +227,28 @@ describe('IndexerManager', () => {
   });
 
   it.skip('should be able to start the manager (v0.0.1)', async () => {
-    indexerManager = createIndexerManager(
-      testSubqueryProject_1(),
-      new ConnectionPoolService<ApiPromiseConnection>(
-        nodeConfig,
-        new ConnectionPoolStateManager(),
-      ),
-      nodeConfig,
-    );
-    await expect(indexerManager.start()).resolves.toBe(undefined);
-
-    expect(Object.keys((indexerManager as any).vms).length).toBe(1);
+    // indexerManager = createIndexerManager(
+    //   testSubqueryProject_1(),
+    //   new ConnectionPoolService<ApiPromiseConnection>(
+    //     nodeConfig,
+    //     new ConnectionPoolStateManager(),
+    //   ),
+    //   nodeConfig,
+    // );
+    // await expect(indexerManager.start()).resolves.toBe(undefined);
+    // expect(Object.keys((indexerManager as any).vms).length).toBe(1);
   });
 
   it.skip('should be able to start the manager (v0.2.0)', async () => {
-    indexerManager = createIndexerManager(
-      testSubqueryProject_2(),
-      new ConnectionPoolService<ApiPromiseConnection>(
-        nodeConfig,
-        new ConnectionPoolStateManager(),
-      ),
-      nodeConfig,
-    );
-    await expect(indexerManager.start()).resolves.toBe(undefined);
-
-    expect(Object.keys((indexerManager as any).vms).length).toBe(1);
+    // indexerManager = createIndexerManager(
+    //   testSubqueryProject_2(),
+    //   new ConnectionPoolService<ApiPromiseConnection>(
+    //     nodeConfig,
+    //     new ConnectionPoolStateManager(),
+    //   ),
+    //   nodeConfig,
+    // );
+    // await expect(indexerManager.start()).resolves.toBe(undefined);
+    // expect(Object.keys((indexerManager as any).vms).length).toBe(1);
   });
 });

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -38,7 +38,6 @@ import {
   DsProcessorService,
 } from './ds-processor.service';
 import { DynamicDsService } from './dynamic-ds.service';
-import { ProjectService } from './project.service';
 import { SandboxService } from './sandbox.service';
 import { ApiAt, BlockContent, isFullBlock, LightBlockContent } from './types';
 import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
@@ -68,7 +67,6 @@ export class IndexerManager extends BaseIndexerManager<
     dsProcessorService: DsProcessorService,
     dynamicDsService: DynamicDsService,
     unfinalizedBlocksService: UnfinalizedBlocksService,
-    @Inject('IProjectService') private projectService: ProjectService,
   ) {
     super(
       apiService,
@@ -80,11 +78,6 @@ export class IndexerManager extends BaseIndexerManager<
       FilterTypeMap,
       ProcessorTypeMap,
     );
-  }
-
-  async start(): Promise<void> {
-    await this.projectService.init();
-    logger.info('indexer manager started');
   }
 
   @profiler()

--- a/packages/node/src/indexer/project.service.ts
+++ b/packages/node/src/indexer/project.service.ts
@@ -34,11 +34,11 @@ export class ProjectService extends BaseProjectService<
     dsProcessorService: DsProcessorService,
     apiService: ApiService,
     @Inject(isMainThread ? PoiService : 'Null') poiService: PoiService,
-    sequelize: Sequelize,
+    @Inject(isMainThread ? Sequelize : 'Null') sequelize: Sequelize,
     @Inject('ISubqueryProject') project: SubqueryProject,
     @Inject('IProjectUpgradeService')
     protected readonly projectUpgradeService: IProjectUpgradeService<SubqueryProject>,
-    storeService: StoreService,
+    @Inject(isMainThread ? StoreService : 'Null') storeService: StoreService,
     nodeConfig: NodeConfig,
     dynamicDsService: DynamicDsService,
     eventEmitter: EventEmitter2,

--- a/packages/node/src/indexer/project.service.ts
+++ b/packages/node/src/indexer/project.service.ts
@@ -8,7 +8,6 @@ import {
   PoiService,
   BaseProjectService,
   StoreService,
-  mainThreadOnly,
   NodeConfig,
   IProjectUpgradeService,
 } from '@subql/node-core';
@@ -35,11 +34,11 @@ export class ProjectService extends BaseProjectService<
     dsProcessorService: DsProcessorService,
     apiService: ApiService,
     @Inject(isMainThread ? PoiService : 'Null') poiService: PoiService,
-    @Inject(isMainThread ? Sequelize : 'Null') sequelize: Sequelize,
+    sequelize: Sequelize,
     @Inject('ISubqueryProject') project: SubqueryProject,
     @Inject('IProjectUpgradeService')
     protected readonly projectUpgradeService: IProjectUpgradeService<SubqueryProject>,
-    @Inject(isMainThread ? StoreService : 'Null') storeService: StoreService,
+    storeService: StoreService,
     nodeConfig: NodeConfig,
     dynamicDsService: DynamicDsService,
     eventEmitter: EventEmitter2,
@@ -65,7 +64,6 @@ export class ProjectService extends BaseProjectService<
     return getTimestamp(block);
   }
 
-  @mainThreadOnly()
   protected onProjectChange(project: SubqueryProject): void | Promise<void> {
     this.apiService.updateBlockFetching();
   }

--- a/packages/node/src/indexer/worker/worker-fetch.module.ts
+++ b/packages/node/src/indexer/worker/worker-fetch.module.ts
@@ -9,8 +9,6 @@ import {
   WorkerConnectionPoolStateManager,
   ConnectionPoolStateManager,
   NodeConfig,
-  StoreService,
-  StoreCacheService,
 } from '@subql/node-core';
 import { SubqueryProject } from '../../configure/SubqueryProject';
 import { ApiService } from '../api.service';
@@ -32,8 +30,6 @@ import { WorkerUnfinalizedBlocksService } from './worker.unfinalizedBlocks.servi
 @Module({
   providers: [
     IndexerManager,
-    StoreService,
-    StoreCacheService,
     {
       provide: ConnectionPoolStateManager,
       useFactory: () =>
@@ -82,6 +78,6 @@ import { WorkerUnfinalizedBlocksService } from './worker.unfinalizedBlocks.servi
     WorkerService,
     WorkerRuntimeService,
   ],
-  exports: [StoreService],
+  exports: [],
 })
 export class WorkerFetchModule {}

--- a/packages/node/src/indexer/worker/worker.module.ts
+++ b/packages/node/src/indexer/worker/worker.module.ts
@@ -4,13 +4,11 @@
 import { Module } from '@nestjs/common';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
-import { DbModule } from '@subql/node-core';
 import { ConfigureModule } from '../../configure/configure.module';
 import { WorkerFetchModule } from './worker-fetch.module';
 
 @Module({
   imports: [
-    DbModule.forRoot(),
     EventEmitterModule.forRoot(),
     ConfigureModule.register(),
     ScheduleModule.forRoot(),

--- a/packages/node/src/indexer/worker/worker.module.ts
+++ b/packages/node/src/indexer/worker/worker.module.ts
@@ -4,11 +4,13 @@
 import { Module } from '@nestjs/common';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
+import { DbModule } from '@subql/node-core';
 import { ConfigureModule } from '../../configure/configure.module';
 import { WorkerFetchModule } from './worker-fetch.module';
 
 @Module({
   imports: [
+    DbModule.forRoot(),
     EventEmitterModule.forRoot(),
     ConfigureModule.register(),
     ScheduleModule.forRoot(),

--- a/packages/node/src/indexer/worker/worker.ts
+++ b/packages/node/src/indexer/worker/worker.ts
@@ -27,13 +27,13 @@ import {
   IBaseIndexerWorker,
 } from '@subql/node-core';
 import { SpecVersion } from '../dictionary.service';
-import { IndexerManager } from '../indexer.manager';
+import { ProjectService } from '../project.service';
 import { WorkerModule } from './worker.module';
 import { WorkerService } from './worker.service';
 
 const logger = getLogger(`worker #${threadId}`);
 
-async function initWorker(): Promise<void> {
+async function initWorker(startHeight: number): Promise<void> {
   try {
     const app = await NestFactory.create(WorkerModule, {
       logger: new NestLogger(argv.debug), // TIP: If the worker is crashing comment out this line for better logging
@@ -41,9 +41,9 @@ async function initWorker(): Promise<void> {
 
     await app.init();
 
-    const indexerManager = app.get(IndexerManager);
+    const projectService: ProjectService = app.get('IProjectService');
     // Initialise async services, we do this here rather than in factories so we can capture one off events
-    await indexerManager.start();
+    await projectService.init(startHeight);
 
     const workerService = app.get(WorkerService);
 

--- a/packages/node/src/indexer/worker/worker.unfinalizedBlocks.service.ts
+++ b/packages/node/src/indexer/worker/worker.unfinalizedBlocks.service.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import { isMainThread } from 'node:worker_threads';
 import { Injectable } from '@nestjs/common';
 import {
   Header,
@@ -14,7 +15,11 @@ import { substrateHeaderToHeader } from '../unfinalizedBlocks.service';
 export class WorkerUnfinalizedBlocksService
   implements IUnfinalizedBlocksService<BlockContent>
 {
-  constructor(private host: HostUnfinalizedBlocks) {}
+  constructor(private host: HostUnfinalizedBlocks) {
+    if (isMainThread) {
+      throw new Error('Expected to be worker thread');
+    }
+  }
 
   async processUnfinalizedBlocks(block: BlockContent): Promise<number | null> {
     return this.host.unfinalizedBlocksProcess(


### PR DESCRIPTION
# Description
Updates project upgrade service to work within workers when the store is not available

Also adds a minor change to move main thread checks from worker fetch module to constructors

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
