### PR TITLE
Include outOfOrderTasks in queue size, throttle fetch queue based on process queue capacity

### DIFF
--- a/packages/node-core/src/utils/autoQueue.spec.ts
+++ b/packages/node-core/src/utils/autoQueue.spec.ts
@@ -118,4 +118,28 @@ describe('AutoQueue', () => {
     const end2 = new Date();
     expect(end2.getTime() - start2.getTime()).toBeLessThanOrEqual(300);
   });
+
+  it('includes running tasks in the size and free space', /*async*/ () => {
+    const autoQueue = new AutoQueue<void>(10, 2);
+
+    let resolveFn: () => void = () => {
+      /* Nothing */
+    };
+    const pendingPromise = new Promise<void>((resolve) => {
+      resolveFn = resolve;
+    });
+
+    const task = async () => {
+      await pendingPromise;
+    };
+
+    void autoQueue.put(task);
+
+    expect(autoQueue.size).toEqual(1);
+    expect(autoQueue.freeSpace).toEqual(9);
+    expect(autoQueue.size + (autoQueue.freeSpace ?? 0)).toEqual(autoQueue.capacity);
+
+    // Assertions done, complete the task
+    resolveFn();
+  });
 });

--- a/packages/node-core/src/utils/autoQueue.ts
+++ b/packages/node-core/src/utils/autoQueue.ts
@@ -121,7 +121,7 @@ export class AutoQueue<T> implements IQueue {
   }
 
   get size(): number {
-    return this.queue.size + this.runningTasks.length;
+    return this.queue.size + this.runningTasks.length + Object.keys(this.outOfOrderTasks).length;
   }
 
   get capacity(): number | undefined {
@@ -129,7 +129,8 @@ export class AutoQueue<T> implements IQueue {
   }
 
   get freeSpace(): number | undefined {
-    return this.queue.freeSpace;
+    if (!this.capacity) return undefined;
+    return this.capacity - this.size;
   }
 
   /*


### PR DESCRIPTION
# Description
Include `outOfOrderTasks` in queue size as its needed if you want to throttle the output.

Also adds some logging to check the status of the queues


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
