### PR TITLE
Rely on base types more and move JSDoc to them

### DIFF
--- a/packages/common-substrate/src/project/models.ts
+++ b/packages/common-substrate/src/project/models.ts
@@ -15,9 +15,7 @@ import {
   SubstrateHandlerKind,
   SubstrateRuntimeDatasource,
   SubstrateRuntimeHandler,
-  SubstrateRuntimeHandlerFilter,
   SubstrateCustomDatasource,
-  CustomDataSourceAsset as SubstrateCustomDataSourceAsset,
 } from '@subql/types';
 import {BaseMapping, FileReference, Processor} from '@subql/types-core';
 import {plainToClass, Transform, Type} from 'class-transformer';
@@ -119,7 +117,7 @@ export class CustomHandler implements SubstrateCustomHandler {
   filter?: Record<string, unknown>;
 }
 
-export class RuntimeMapping implements BaseMapping<SubstrateRuntimeHandlerFilter, SubstrateRuntimeHandler> {
+export class RuntimeMapping implements BaseMapping<SubstrateRuntimeHandler> {
   @Transform((params) => {
     const handlers: SubstrateRuntimeHandler[] = params.value;
     return handlers.map((handler) => {
@@ -142,7 +140,7 @@ export class RuntimeMapping implements BaseMapping<SubstrateRuntimeHandlerFilter
   file: string;
 }
 
-export class CustomMapping implements BaseMapping<Record<string, unknown>, SubstrateCustomHandler> {
+export class CustomMapping implements BaseMapping<SubstrateCustomHandler> {
   @IsArray()
   @Type(() => CustomHandler)
   @ValidateNested()
@@ -180,7 +178,7 @@ export class CustomDataSourceBase<K extends string, M extends CustomMapping, O =
   startBlock?: number;
   @Type(() => FileReferenceImpl)
   @ValidateNested({each: true})
-  assets: Map<string, SubstrateCustomDataSourceAsset>;
+  assets: Map<string, FileReference>;
   @Type(() => ProcessorImpl)
   @IsObject()
   @ValidateNested()

--- a/packages/common-substrate/src/project/versioned/v1_0_0/model.ts
+++ b/packages/common-substrate/src/project/versioned/v1_0_0/model.ts
@@ -36,10 +36,7 @@ export class SubstrateRuntimeDataSourceImpl extends RuntimeDataSourceBase implem
   }
 }
 
-export class SubstrateCustomDataSourceImpl<
-    K extends string = string,
-    M extends BaseMapping<any, any> = BaseMapping<Record<string, unknown>, any>
-  >
+export class SubstrateCustomDataSourceImpl<K extends string = string, M extends BaseMapping<any> = BaseMapping<any>>
   extends CustomDataSourceBase<K, M>
   implements SubstrateCustomDatasource<K, M>
 {

--- a/packages/node-core/src/indexer/fetch.service.spec.ts
+++ b/packages/node-core/src/indexer/fetch.service.spec.ts
@@ -24,7 +24,7 @@ class TestFetchService extends BaseFetchService<BaseDataSource, IBlockDispatcher
   modulos: number[] = [];
 
   protected buildDictionaryQueryEntries(
-    dataSources: BaseDataSource<any, BaseHandler<any>, BaseMapping<any, BaseHandler<any>>>[]
+    dataSources: BaseDataSource<BaseHandler<any>, BaseMapping<BaseHandler<any>>>[]
   ): DictionaryQueryEntry[] {
     return [];
   }

--- a/packages/types-core/src/project/versioned/base.ts
+++ b/packages/types-core/src/project/versioned/base.ts
@@ -1,35 +1,64 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {FileReference} from '../types';
+import {FileReference, Processor} from '../types';
 
-export interface BaseDataSource<
-  F = any,
-  H extends BaseHandler<F> = BaseHandler<F>,
-  T extends BaseMapping<F, H> = BaseMapping<F, H>
-> {
+export interface BaseDataSource<H extends BaseHandler = BaseHandler, M extends BaseMapping<H> = BaseMapping<H>> {
+  /**
+   * The kind of the datasource.
+   * @type {string}
+   */
   kind: string;
+  /**
+   * The starting block number for the datasource. If not specified, 1 will be used (optional).
+   * @type {number}
+   * @default 1
+   */
   startBlock?: number;
-  mapping: T;
+  /**
+   * The mapping associated with the datasource.
+   * This contains the handlers.
+   * @type {M}
+   */
+  mapping: M;
 }
 
-export interface BaseCustomDataSource<
-  F = any,
-  H extends BaseHandler<F> = BaseHandler<F>,
-  T extends BaseMapping<F, H> = BaseMapping<F, H>
-> extends BaseDataSource<F, H, T> {
-  processor: FileReference;
+export interface BaseCustomDataSource<H extends BaseHandler = BaseHandler, T extends BaseMapping<H> = BaseMapping<H>>
+  extends BaseDataSource<H, T> {
+  /**
+   * The processor used for the custom datasource.
+   * @type {Processor<O>}
+   */
+  processor: Processor;
+  /**
+   * A map of custom datasource assets. These typically include ABIs or other files used to decode data.
+   * @type {Map<string, FileReference>}
+   * @example
+   * assets: new Map([['erc20', './abis/erc20.json']])
+   */
   assets: Map<string, FileReference>;
 }
 
-export interface BaseMapping<F, T extends BaseHandler<F>> {
-  file: string;
+export interface BaseMapping<T extends BaseHandler> extends FileReference {
+  /**
+   * An array of handlers associated with the mapping.
+   * @type {T[]}
+   */
   handlers: T[];
 }
 
-export interface BaseHandler<T> {
+export interface BaseHandler<T = any, K extends string = string> {
+  kind: K;
+  /**
+   * The name of your handler function. This must be defined and exported from your code.
+   * @type {string}
+   * @example
+   * handler: 'handleBlock'
+   */
   handler: string;
-  kind: string;
+  /**
+   * The filter for the handler. The handler kind will determine the possible filters (optional).
+   */
   filter?: T;
 }
 

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -12,6 +12,10 @@ import {
   Processor,
   ProjectManifestV1_0_0,
   BlockFilter,
+  BaseDataSource,
+  BaseHandler,
+  BaseMapping,
+  BaseCustomDataSource,
 } from '@subql/types-core';
 import {LightSubstrateEvent, SubstrateBlock, SubstrateEvent, SubstrateExtrinsic} from './interfaces';
 
@@ -152,7 +156,8 @@ export type SubstrateEventHandler = SubstrateCustomHandler<SubstrateHandlerKind.
  * @template K - The kind of the handler (default: string).
  * @template F - The filter type for the handler (default: Record<string, unknown>).
  */
-export interface SubstrateCustomHandler<K extends string = string, F = Record<string, unknown>> {
+export interface SubstrateCustomHandler<K extends string = string, F = Record<string, unknown>>
+  extends BaseHandler<F, K> {
   /**
    * The kind of handler. For `substrate/Runtime` datasources this is either `Block`, `Call` or `Event` kinds.
    * The value of this will determine the filter options as well as the data provided to your handler function
@@ -164,15 +169,6 @@ export interface SubstrateCustomHandler<K extends string = string, F = Record<st
    */
   kind: K;
   /**
-   * The name of your handler function. This must be defined and exported from your code.
-   * @type {string}
-   * @example
-   * handler: 'handleBlock'
-   */
-  handler: string;
-  /**
-   * The filter for the handler. The handler kind will determine the possible filters (optional).
-   *
    * @type {F}
    * @example
    * filter: {
@@ -207,9 +203,8 @@ export type SubstrateRuntimeHandlerFilter = SubstrateBlockFilter | SubstrateCall
  * @interface
  * @extends {FileReference}
  */
-export interface SubstrateMapping<T extends SubstrateHandler = SubstrateHandler> extends FileReference {
+export interface SubstrateMapping<T extends SubstrateHandler = SubstrateHandler> extends BaseMapping<T> {
   /**
-   * An array of handlers associated with the mapping.
    * @type {T[]}
    * @example
    * handlers: [{
@@ -230,27 +225,7 @@ export interface SubstrateMapping<T extends SubstrateHandler = SubstrateHandler>
  * @interface
  * @template M - The mapping type for the datasource.
  */
-interface ISubstrateDatasource<M extends SubstrateMapping> {
-  /**
-   * The kind of the datasource.
-   * @type {string}
-   */
-  kind: string;
-
-  /**
-   * The starting block number for the datasource. If not specified, 1 will be used (optional).
-   * @type {number}
-   * @default 1
-   */
-  startBlock?: number;
-
-  /**
-   * The mapping associated with the datasource.
-   * This contains the handlers.
-   * @type {M}
-   */
-  mapping: M;
-}
+type ISubstrateDatasource<M extends SubstrateMapping> = BaseDataSource<SubstrateHandler, M>;
 
 /**
  * Represents a runtime datasource for Substrate.
@@ -285,7 +260,7 @@ export interface SubstrateCustomDatasource<
   K extends string = string,
   M extends SubstrateMapping = SubstrateMapping<SubstrateCustomHandler>,
   O = any
-> extends ISubstrateDatasource<M> {
+> extends BaseCustomDataSource<SubstrateHandler, M> {
   /**
    * The kind of the custom datasource. This should follow the pattern `substrate/*`.
    * @type {K}
@@ -295,14 +270,6 @@ export interface SubstrateCustomDatasource<
   kind: K;
 
   /**
-   * A map of custom datasource assets. These typically include ABIs or other files used to decode data.
-   * @type {Map<string, CustomDataSourceAsset>}
-   */
-  assets: Map<string, CustomDataSourceAsset>;
-
-  /**
-   * The processor used for the custom datasource.
-   * @type {Processor<O>}
    * @example
    * processor: {
    *    file: './node_modules/@subql/frontier-evm-processor/dist/bundle.js',
@@ -431,5 +398,3 @@ export type SubstrateProject<DS extends SubstrateDatasource = SubstrateRuntimeDa
   SubstrateRuntimeDatasource | DS,
   BaseTemplateDataSource<SubstrateRuntimeDatasource> | BaseTemplateDataSource<DS>
 >;
-
-export type CustomDataSourceAsset = FileReference;


### PR DESCRIPTION
# Description
In order to deduplicate JSDoc across different sdks this uses the base types in types core more from types and moves generic JSDoc from types to types core

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
