### PR TITLE
Endblock feature

### DIFF
--- a/packages/common-substrate/src/project/models.ts
+++ b/packages/common-substrate/src/project/models.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {RegisteredTypes, RegistryTypes, OverrideModuleType, OverrideBundleType} from '@polkadot/types/types';
-import {BlockFilterImpl, ProcessorImpl} from '@subql/common';
+import {BlockFilterImpl, IsEndBlockGreater, ProcessorImpl} from '@subql/common';
 import {
   SubstrateBlockFilter,
   SubstrateBlockHandler,
@@ -29,6 +29,7 @@ import {
   IsString,
   IsObject,
   ValidateNested,
+  Validate,
 } from 'class-validator';
 
 export class BlockFilter extends BlockFilterImpl implements SubstrateBlockFilter {
@@ -158,6 +159,10 @@ export class RuntimeDataSourceBase implements SubstrateRuntimeDatasource {
   @IsOptional()
   @IsInt()
   startBlock?: number;
+  @Validate(IsEndBlockGreater)
+  @IsOptional()
+  @IsInt()
+  endBlock?: number;
 }
 
 export class FileReferenceImpl implements FileReference {
@@ -176,6 +181,10 @@ export class CustomDataSourceBase<K extends string, M extends CustomMapping, O =
   @IsOptional()
   @IsInt()
   startBlock?: number;
+  @Validate(IsEndBlockGreater)
+  @IsOptional()
+  @IsInt()
+  endBlock?: number;
   @Type(() => FileReferenceImpl)
   @ValidateNested({each: true})
   assets: Map<string, FileReference>;

--- a/packages/common-substrate/src/project/models.ts
+++ b/packages/common-substrate/src/project/models.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {RegisteredTypes, RegistryTypes, OverrideModuleType, OverrideBundleType} from '@polkadot/types/types';
-import {BlockFilterImpl, IsEndBlockGreater, ProcessorImpl} from '@subql/common';
+import {BaseDataSource, BlockFilterImpl, ProcessorImpl} from '@subql/common';
 import {
   SubstrateBlockFilter,
   SubstrateBlockHandler,
@@ -24,12 +24,10 @@ import {
   IsArray,
   IsBoolean,
   IsEnum,
-  IsInt,
   IsOptional,
   IsString,
   IsObject,
   ValidateNested,
-  Validate,
 } from 'class-validator';
 
 export class BlockFilter extends BlockFilterImpl implements SubstrateBlockFilter {
@@ -150,19 +148,12 @@ export class CustomMapping implements BaseMapping<SubstrateCustomHandler> {
   file: string;
 }
 
-export class RuntimeDataSourceBase implements SubstrateRuntimeDatasource {
+export class RuntimeDataSourceBase extends BaseDataSource implements SubstrateRuntimeDatasource {
   @IsEnum(SubstrateDatasourceKind, {groups: [SubstrateDatasourceKind.Runtime]})
   kind: SubstrateDatasourceKind.Runtime;
   @Type(() => RuntimeMapping)
   @ValidateNested()
   mapping: RuntimeMapping;
-  @IsOptional()
-  @IsInt()
-  startBlock?: number;
-  @Validate(IsEndBlockGreater)
-  @IsOptional()
-  @IsInt()
-  endBlock?: number;
 }
 
 export class FileReferenceImpl implements FileReference {
@@ -171,6 +162,7 @@ export class FileReferenceImpl implements FileReference {
 }
 
 export class CustomDataSourceBase<K extends string, M extends CustomMapping, O = any>
+  extends BaseDataSource
   implements SubstrateCustomDatasource<K, M, O>
 {
   @IsString()
@@ -178,13 +170,6 @@ export class CustomDataSourceBase<K extends string, M extends CustomMapping, O =
   @Type(() => CustomMapping)
   @ValidateNested()
   mapping: M;
-  @IsOptional()
-  @IsInt()
-  startBlock?: number;
-  @Validate(IsEndBlockGreater)
-  @IsOptional()
-  @IsInt()
-  endBlock?: number;
   @Type(() => FileReferenceImpl)
   @ValidateNested({each: true})
   assets: Map<string, FileReference>;

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import {FileReference, MultichainProjectManifest, ProjectRootAndManifest} from '@subql/types-core';
+import {BaseDataSource, FileReference, MultichainProjectManifest, ProjectRootAndManifest} from '@subql/types-core';
 import {
   registerDecorator,
   validateSync,
@@ -294,3 +294,17 @@ export class FileReferenceImp<T> implements ValidatorConstraintInterface {
 }
 
 export const tsProjectYamlPath = (tsManifestEntry: string) => tsManifestEntry.replace('.ts', '.yaml');
+
+@ValidatorConstraint({async: false})
+export class IsEndBlockGreater implements ValidatorConstraintInterface {
+  validate(endBlock: number, args: ValidationArguments) {
+    const object = args.object as BaseDataSource;
+    return object.startBlock !== undefined && object.endBlock !== undefined
+      ? object.endBlock >= object.startBlock
+      : true;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return 'End block must be greater than or equal to start block';
+  }
+}

--- a/packages/common/src/project/versioned/base.ts
+++ b/packages/common/src/project/versioned/base.ts
@@ -3,9 +3,19 @@
 
 import {FileReference, ParentProject, Processor} from '@subql/types-core';
 import {plainToInstance, Type} from 'class-transformer';
-import {Allow, Equals, IsObject, IsOptional, IsString, ValidateNested, validateSync} from 'class-validator';
+import {
+  Allow,
+  Equals,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  Validate,
+  ValidateNested,
+  validateSync,
+} from 'class-validator';
 import yaml from 'js-yaml';
-import {toJsonObject} from '../utils';
+import {IsEndBlockGreater, toJsonObject} from '../utils';
 import {ParentProjectModel} from './v1_0_0/models';
 
 export abstract class ProjectManifestBaseImpl<D extends BaseDeploymentV1_0_0> {
@@ -77,4 +87,14 @@ export class BaseDeploymentV1_0_0 {
       condenseFlow: true,
     });
   }
+}
+
+export class BaseDataSource {
+  @IsOptional()
+  @IsInt()
+  startBlock?: number;
+  @Validate(IsEndBlockGreater)
+  @IsOptional()
+  @IsInt()
+  endBlock?: number;
 }

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -208,7 +208,7 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS> implements IBloc
       await this.storeCacheService.flushCache(false, true);
     }
 
-    if (!(await this.projectService.hasDataSourceWithEndBlockGreaterThan(height))) {
+    if (!(await this.projectService.hasDataSourcesAfterHeight(height))) {
       logger.info(`All data sources have been processed up to block number ${height}. Exiting gracefully...`);
       await this.storeCacheService.flushCache(false, true);
       process.exit(0);

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -209,7 +209,7 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS> implements IBloc
       await this.storeCacheService.flushCache(false, true);
     }
 
-    if (!(await this.projectService.hasDataSourcesAfterHeight(height))) {
+    if (!this.projectService.hasDataSourcesAfterHeight(height)) {
       logger.info(`All data sources have been processed up to block number ${height}. Exiting gracefully...`);
       await this.storeCacheService.flushCache(false, true);
       process.exit(0);

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -209,7 +209,7 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS> implements IBloc
     }
 
     if (!(await this.projectService.hasDataSourceWithEndBlockGreaterThan(height))) {
-      logger.info(`No data sources found with endBlock greater than the block number ${height}`);
+      logger.info(`All data sources have been processed up to block number ${height}. Exiting gracefully...`);
       await this.storeCacheService.flushCache(false, true);
       process.exit(0);
     }

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -207,6 +207,12 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS> implements IBloc
       // Flush all data from cache and wait
       await this.storeCacheService.flushCache(false, true);
     }
+
+    if (!(await this.projectService.hasDataSourceWithEndBlockGreaterThan(height))) {
+      logger.info(`No data sources found with endBlock greater than the block number ${height}`);
+      await this.storeCacheService.flushCache(false, true);
+      process.exit(0);
+    }
   }
 
   // First creation of POI

--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -343,18 +343,6 @@ export class DictionaryService {
     buildDictionaryQueryEntries: (dataSources: DS[]) => DictionaryQueryEntry[]
   ): void {
     this.queriesMap = dataSources.map(buildDictionaryQueryEntries);
-    const newQueriesMap = this.queriesMap?.getAll() || new Map();
-
-    dataSources.getAll().forEach((ds, height) => {
-      const endBlock = maxEndBlockHeight(ds);
-      const queryDetails = this.queriesMap?.getDetails(height);
-
-      if (!queryDetails?.endHeight || queryDetails.endHeight > endBlock) {
-        newQueriesMap.set(endBlock + 1, []);
-      }
-    });
-
-    this.queriesMap = new BlockHeightMap(newQueriesMap);
   }
 
   async scopedDictionaryEntries(

--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -15,7 +15,6 @@ import {getLogger} from '../logger';
 import {profiler} from '../profiler';
 import {timeout} from '../utils';
 import {BlockHeightMap} from '../utils/blockHeightMap';
-import {maxEndBlockHeight} from '../utils/endBlock';
 
 export type SpecVersion = {
   id: string;

--- a/packages/node-core/src/indexer/fetch.service.spec.ts
+++ b/packages/node-core/src/indexer/fetch.service.spec.ts
@@ -152,7 +152,9 @@ describe('Fetch Service', () => {
   const enableDictionary = () => {
     // Mock the remainder of dictionary service so it works
     (dictionaryService as any).useDictionary = true;
-    dictionaryService.queriesMap = new BlockHeightMap(new Map([[1, [{entity: 'mock', conditions: []}]]]));
+    dictionaryService.queriesMap = new BlockHeightMap(
+      new Map([[1, {query: [{entity: 'mock', conditions: []}], maxDsEndBlock: 1000}]])
+    );
     dictionaryService.scopedDictionaryEntries = (start, end, batch) => {
       return Promise.resolve({
         batchBlocks: [2, 4, 6, 8, 10],

--- a/packages/node-core/src/indexer/fetch.service.spec.ts
+++ b/packages/node-core/src/indexer/fetch.service.spec.ts
@@ -4,6 +4,7 @@
 import {EventEmitter2} from '@nestjs/event-emitter';
 import {SchedulerRegistry} from '@nestjs/schedule';
 import {BaseDataSource, BaseHandler, BaseMapping, DictionaryQueryEntry, IProjectNetworkConfig} from '@subql/types-core';
+import {range} from 'lodash';
 import {
   BlockDispatcher,
   delay,
@@ -80,7 +81,6 @@ const mockDs: BaseDataSource = {
 
 const projectService = {
   getStartBlockFromDataSources: jest.fn(() => mockDs.startBlock),
-  getDataSourcesMap: jest.fn(() => new BlockHeightMap(new Map([[1, [mockDs, mockDs]]]))), // TODO
   getAllDataSources: jest.fn(() => [mockDs]),
 } as any as IProjectService<any>;
 
@@ -147,6 +147,10 @@ describe('Fetch Service', () => {
       eventEmitter,
       schedulerRegistry
     );
+
+    (fetchService as any).projectService.getDataSourcesMap = jest.fn(
+      () => new BlockHeightMap(new Map([[1, [mockDs, mockDs]]]))
+    );
   });
 
   const enableDictionary = () => {
@@ -174,6 +178,58 @@ describe('Fetch Service', () => {
     await fetchService.init(1);
 
     expect(preHookLoopSpy).toHaveBeenCalled();
+  });
+
+  it('adds bypassBlocks for empty datasources', async () => {
+    (fetchService as any).projectService.getDataSourcesMap = jest.fn().mockReturnValueOnce(
+      new BlockHeightMap(
+        new Map([
+          [
+            1,
+            [
+              {startBlock: 1, endBlock: 300},
+              {startBlock: 1, endBlock: 100},
+            ],
+          ],
+          [
+            10,
+            [
+              {startBlock: 1, endBlock: 300},
+              {startBlock: 1, endBlock: 100},
+              {startBlock: 10, endBlock: 20},
+            ],
+          ],
+          [
+            21,
+            [
+              {startBlock: 1, endBlock: 300},
+              {startBlock: 1, endBlock: 100},
+            ],
+          ],
+          [
+            50,
+            [
+              {startBlock: 1, endBlock: 300},
+              {startBlock: 1, endBlock: 100},
+              {startBlock: 50, endBlock: 200},
+            ],
+          ],
+          [
+            101,
+            [
+              {startBlock: 1, endBlock: 300},
+              {startBlock: 50, endBlock: 200},
+            ],
+          ],
+          [201, [{startBlock: 1, endBlock: 300}]],
+          [301, []],
+          [500, [{startBlock: 500}]],
+        ])
+      )
+    );
+
+    await fetchService.init(1);
+    expect((fetchService as any).bypassBlocks).toEqual(range(301, 500));
   });
 
   it('checks chain heads at an interval', async () => {
@@ -308,8 +364,7 @@ describe('Fetch Service', () => {
   });
 
   it('skips bypassBlocks', async () => {
-    // This doesn't get set in init because networkConfig doesn't define it, so we can set it
-    (fetchService as any).bypassBlocks = [3];
+    (fetchService as any).networkConfig.bypassBlocks = [3];
 
     const enqueueBlocksSpy = jest.spyOn(blockDispatcher, 'enqueueBlocks');
 

--- a/packages/node-core/src/indexer/fetch.service.spec.ts
+++ b/packages/node-core/src/indexer/fetch.service.spec.ts
@@ -152,9 +152,7 @@ describe('Fetch Service', () => {
   const enableDictionary = () => {
     // Mock the remainder of dictionary service so it works
     (dictionaryService as any).useDictionary = true;
-    dictionaryService.queriesMap = new BlockHeightMap(
-      new Map([[1, {query: [{entity: 'mock', conditions: []}], maxDsEndBlock: 1000}]])
-    );
+    dictionaryService.queriesMap = new BlockHeightMap(new Map([[1, [{entity: 'mock', conditions: []}]]]));
     dictionaryService.scopedDictionaryEntries = (start, end, batch) => {
       return Promise.resolve({
         batchBlocks: [2, 4, 6, 8, 10],

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -243,10 +243,15 @@ export abstract class BaseFetchService<
         startBlockHeight >= this.dictionaryService.startHeight &&
         startBlockHeight < this.latestFinalizedHeight
       ) {
-        /* queryEndBlock needs to be limited by the latest height.
+        /* queryEndBlock needs to be limited by the latest height or the maximum value of endBlock in datasources.
          * Dictionaries could be in the future depending on if they index unfinalized blocks or the node is using an RPC endpoint that is behind.
          */
-        const queryEndBlock = Math.min(startBlockHeight + DICTIONARY_MAX_QUERY_SIZE, this.latestFinalizedHeight);
+        const maxEndBlock = await this.projectService.maxEndBlockHeight();
+        const queryEndBlock = Math.min(
+          startBlockHeight + DICTIONARY_MAX_QUERY_SIZE,
+          this.latestFinalizedHeight,
+          maxEndBlock
+        );
         try {
           const dictionary = await this.dictionaryService.scopedDictionaryEntries(
             startBlockHeight,

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -94,7 +94,7 @@ export abstract class BaseFetchService<
       this.dictionaryService.useDictionary &&
       !!this.dictionaryService.queriesMap?.get(
         this.blockDispatcher.latestBufferedHeight || this.projectService.getStartBlockFromDataSources()
-      )?.query.length
+      )?.length
     );
   }
 

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -94,7 +94,7 @@ export abstract class BaseFetchService<
       this.dictionaryService.useDictionary &&
       !!this.dictionaryService.queriesMap?.get(
         this.blockDispatcher.latestBufferedHeight || this.projectService.getStartBlockFromDataSources()
-      )?.length
+      )?.query.length
     );
   }
 
@@ -246,12 +246,7 @@ export abstract class BaseFetchService<
         /* queryEndBlock needs to be limited by the latest height or the maximum value of endBlock in datasources.
          * Dictionaries could be in the future depending on if they index unfinalized blocks or the node is using an RPC endpoint that is behind.
          */
-        const maxEndBlock = await this.projectService.maxEndBlockHeight();
-        const queryEndBlock = Math.min(
-          startBlockHeight + DICTIONARY_MAX_QUERY_SIZE,
-          this.latestFinalizedHeight,
-          maxEndBlock
-        );
+        const queryEndBlock = Math.min(startBlockHeight + DICTIONARY_MAX_QUERY_SIZE, this.latestFinalizedHeight);
         try {
           const dictionary = await this.dictionaryService.scopedDictionaryEntries(
             startBlockHeight,

--- a/packages/node-core/src/indexer/indexer.manager.ts
+++ b/packages/node-core/src/indexer/indexer.manager.ts
@@ -129,7 +129,12 @@ export abstract class BaseIndexerManager<
   private filterDataSources(nextProcessingHeight: number, dataSources: DS[]): DS[] {
     let filteredDs: DS[];
 
-    filteredDs = dataSources.filter((ds) => ds.startBlock !== undefined && ds.startBlock <= nextProcessingHeight);
+    filteredDs = dataSources.filter(
+      (ds) =>
+        ds.startBlock !== undefined &&
+        ds.startBlock <= nextProcessingHeight &&
+        (ds.endBlock ?? Number.MAX_SAFE_INTEGER) >= nextProcessingHeight
+    );
 
     // perform filter for custom ds
     filteredDs = filteredDs.filter((ds) => {

--- a/packages/node-core/src/indexer/indexer.manager.ts
+++ b/packages/node-core/src/indexer/indexer.manager.ts
@@ -146,8 +146,13 @@ export abstract class BaseIndexerManager<
   private assertDataSources(ds: DS[], blockHeight: number) {
     if (!ds.length) {
       logger.error(
-        `Your start block of all the datasources is greater than the current indexed block height in your database. Either change your startBlock (project.yaml) to <= ${blockHeight}
-         or delete your database and start again from the currently specified startBlock`
+        `Issue detected with data sources: \n
+        Either all data sources have a 'startBlock' greater than the current indexed block height (${blockHeight}), 
+        or they have an 'endBlock' less than the current block. \n
+        Solution options: \n
+        1. Adjust 'startBlock' in project.yaml to be less than or equal to ${blockHeight}, 
+           and 'endBlock' to be greater than or equal to ${blockHeight}. \n
+        2. Delete your database and start again with the currently specified 'startBlock' and 'endBlock'.`
       );
       process.exit(1);
     }

--- a/packages/node-core/src/indexer/project.service.spec.ts
+++ b/packages/node-core/src/indexer/project.service.spec.ts
@@ -28,6 +28,7 @@ describe('BaseProjectService', () => {
       null as unknown as any,
       null as unknown as any,
       null as unknown as any,
+      null as unknown as any,
       {dataSources: []} as unknown as ISubqueryProject<any>,
       null as unknown as any,
       null as unknown as any,

--- a/packages/node-core/src/indexer/project.service.spec.ts
+++ b/packages/node-core/src/indexer/project.service.spec.ts
@@ -1,0 +1,84 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {NodeConfig} from '../configure';
+import {BaseDsProcessorService} from './ds-processor.service';
+import {DynamicDsService} from './dynamic-ds.service';
+import {BaseProjectService} from './project.service';
+import {ISubqueryProject} from './types';
+
+class TestProjectService extends BaseProjectService<any, any> {
+  packageVersion = '1.0.0';
+
+  async getBlockTimestamp(height: number): Promise<Date> {
+    return Promise.resolve(new Date());
+  }
+
+  onProjectChange(project: any): void {
+    return;
+  }
+}
+
+describe('BaseProjectService', () => {
+  let service: TestProjectService;
+
+  beforeEach(() => {
+    service = new TestProjectService(
+      null as unknown as BaseDsProcessorService,
+      null as unknown as any,
+      null as unknown as any,
+      null as unknown as any,
+      {dataSources: []} as unknown as ISubqueryProject<any>,
+      null as unknown as any,
+      null as unknown as any,
+      {unsafe: false} as unknown as NodeConfig,
+      {getDynamicDatasources: jest.fn()} as unknown as DynamicDsService<any>,
+      null as unknown as any,
+      null as unknown as any
+    );
+  });
+
+  test('hasDataSourcesAfterHeight', async () => {
+    service.getDataSources = jest.fn().mockResolvedValue([{endBlock: 100}, {endBlock: 200}, {endBlock: 300}]);
+
+    const result = await service.hasDataSourcesAfterHeight(150);
+    expect(result).toBe(true);
+  });
+
+  test('hasDataSourcesAfterHeight - undefined endBlock', async () => {
+    service.getDataSources = jest.fn().mockResolvedValue([{endBlock: 100}, {endBlock: undefined}]);
+
+    const result = await service.hasDataSourcesAfterHeight(150);
+    expect(result).toBe(true);
+  });
+
+  test('maxEndBlockHeight', async () => {
+    service.getDataSources = jest.fn().mockResolvedValue([{endBlock: 100}, {endBlock: 200}, {endBlock: 300}]);
+
+    const result = await service.maxEndBlockHeight();
+    expect(result).toBe(300);
+  });
+
+  test('maxEndBlockHeight - undefined endBlock', async () => {
+    service.getDataSources = jest.fn().mockResolvedValue([{endBlock: 100}, {endBlock: 200}, {endBlock: undefined}]);
+
+    const result = await service.maxEndBlockHeight();
+    expect(result).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  test('getDataSources', async () => {
+    (service as any).project.dataSources = [
+      {startBlock: 100, endBlock: 200},
+      {startBlock: 1, endBlock: 100},
+    ];
+    (service as any).dynamicDsService.getDynamicDatasources = jest
+      .fn()
+      .mockResolvedValue([{startBlock: 150, endBlock: 250}]);
+
+    const result = await service.getDataSources(175);
+    expect(result).toEqual([
+      {startBlock: 100, endBlock: 200},
+      {startBlock: 150, endBlock: 250},
+    ]);
+  });
+});

--- a/packages/node-core/src/indexer/project.service.spec.ts
+++ b/packages/node-core/src/indexer/project.service.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {NodeConfig} from '../configure';
+import {BlockHeightMap} from '../utils/blockHeightMap';
 import {BaseDsProcessorService} from './ds-processor.service';
 import {DynamicDsService} from './dynamic-ds.service';
 import {BaseProjectService} from './project.service';
@@ -39,18 +40,51 @@ describe('BaseProjectService', () => {
     );
   });
 
-  it('hasDataSourcesAfterHeight', async () => {
-    service.getDataSources = jest.fn().mockResolvedValue([{endBlock: 100}, {endBlock: 200}, {endBlock: 300}]);
+  it('hasDataSourcesAfterHeight', () => {
+    (service as any).dynamicDsService.dynamicDatasources = [];
+    (service as any).projectUpgradeService = {
+      projects: [
+        [
+          1,
+          {
+            dataSources: [
+              {startBlock: 1, endBlock: 300},
+              {startBlock: 10, endBlock: 20},
+              {startBlock: 1, endBlock: 100},
+              {startBlock: 50, endBlock: 200},
+              {startBlock: 500},
+            ],
+          },
+        ],
+      ],
+    } as any;
 
-    const result = await service.hasDataSourcesAfterHeight(150);
-    expect(result).toBe(true);
+    const result1 = service.hasDataSourcesAfterHeight(301);
+    expect(result1).toBe(true);
+    const result2 = service.hasDataSourcesAfterHeight(502);
+    expect(result2).toBe(true);
   });
 
-  it('hasDataSourcesAfterHeight - undefined endBlock', async () => {
-    service.getDataSources = jest.fn().mockResolvedValue([{endBlock: 100}, {endBlock: undefined}]);
+  it('hasDataSourcesAfterHeight - no available datasource', () => {
+    (service as any).dynamicDsService.dynamicDatasources = [];
+    (service as any).projectUpgradeService = {
+      projects: [
+        [
+          1,
+          {
+            dataSources: [
+              {startBlock: 1, endBlock: 300},
+              {startBlock: 10, endBlock: 20},
+              {startBlock: 1, endBlock: 100},
+              {startBlock: 50, endBlock: 200},
+            ],
+          },
+        ],
+      ],
+    } as any;
 
-    const result = await service.hasDataSourcesAfterHeight(150);
-    expect(result).toBe(true);
+    const result = service.hasDataSourcesAfterHeight(301);
+    expect(result).toBe(false);
   });
 
   it('getDataSources', async () => {

--- a/packages/node-core/src/indexer/project.service.spec.ts
+++ b/packages/node-core/src/indexer/project.service.spec.ts
@@ -52,20 +52,6 @@ describe('BaseProjectService', () => {
     expect(result).toBe(true);
   });
 
-  test('maxEndBlockHeight', async () => {
-    service.getDataSources = jest.fn().mockResolvedValue([{endBlock: 100}, {endBlock: 200}, {endBlock: 300}]);
-
-    const result = await service.maxEndBlockHeight();
-    expect(result).toBe(300);
-  });
-
-  test('maxEndBlockHeight - undefined endBlock', async () => {
-    service.getDataSources = jest.fn().mockResolvedValue([{endBlock: 100}, {endBlock: 200}, {endBlock: undefined}]);
-
-    const result = await service.maxEndBlockHeight();
-    expect(result).toBe(Number.MAX_SAFE_INTEGER);
-  });
-
   test('getDataSources', async () => {
     (service as any).project.dataSources = [
       {startBlock: 100, endBlock: 200},

--- a/packages/node-core/src/indexer/project.service.spec.ts
+++ b/packages/node-core/src/indexer/project.service.spec.ts
@@ -67,4 +67,70 @@ describe('BaseProjectService', () => {
       {startBlock: 150, endBlock: 250},
     ]);
   });
+
+  test('getDatasourceMap', () => {
+    (service as any).dynamicDsService.dynamicDatasources = [];
+    (service as any).projectUpgradeService = {
+      projects: [
+        [
+          1,
+          {
+            dataSources: [
+              {startBlock: 1, endBlock: 300},
+              {startBlock: 10, endBlock: 20},
+              {startBlock: 1, endBlock: 100},
+              {startBlock: 50, endBlock: 200},
+              {startBlock: 500},
+            ],
+          },
+        ],
+      ],
+    } as any;
+
+    const result = service.getDataSourcesMap();
+    expect(result.getAll()).toEqual(
+      new Map([
+        [
+          1,
+          [
+            {startBlock: 1, endBlock: 300},
+            {startBlock: 1, endBlock: 100},
+          ],
+        ],
+        [
+          10,
+          [
+            {startBlock: 1, endBlock: 300},
+            {startBlock: 1, endBlock: 100},
+            {startBlock: 10, endBlock: 20},
+          ],
+        ],
+        [
+          21,
+          [
+            {startBlock: 1, endBlock: 300},
+            {startBlock: 1, endBlock: 100},
+          ],
+        ],
+        [
+          50,
+          [
+            {startBlock: 1, endBlock: 300},
+            {startBlock: 1, endBlock: 100},
+            {startBlock: 50, endBlock: 200},
+          ],
+        ],
+        [
+          101,
+          [
+            {startBlock: 1, endBlock: 300},
+            {startBlock: 50, endBlock: 200},
+          ],
+        ],
+        [201, [{startBlock: 1, endBlock: 300}]],
+        [301, []],
+        [500, [{startBlock: 500}]],
+      ])
+    );
+  });
 });

--- a/packages/node-core/src/indexer/project.service.spec.ts
+++ b/packages/node-core/src/indexer/project.service.spec.ts
@@ -143,7 +143,7 @@ describe('BaseProjectService', () => {
           [
             1,
             {
-              dataSources: [{startBlock: 1}],
+              dataSources: [{startBlock: 1}, {startBlock: 200}],
             },
           ],
           [

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -268,9 +268,16 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
     return [...dataSources, ...dynamicDs];
   }
 
-  async hasDataSourcesAfterHeight(height: number): Promise<boolean> {
-    const dataSources = await this.getDataSources();
-    return dataSources.some((ds) => ds.endBlock === undefined || ds.endBlock > height);
+  hasDataSourcesAfterHeight(height: number): boolean {
+    const datasourcesMap = this.getDataSourcesMap();
+    //check if there are datasoures for current height
+    if (datasourcesMap.get(height).length) {
+      return true;
+    }
+
+    //check for datasources with height after the current height
+    const dataSources = this.getDataSourcesMap().getAll();
+    return [...dataSources.entries()].some(([dsHeight, ds]) => dsHeight > height && ds.length);
   }
 
   // This gets used when indexing blocks, it needs to be async to ensure dynamicDs is updated within workers

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -256,11 +256,15 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
     return [...dataSources, ...dynamicDs];
   }
 
-  async hasDataSourceWithEndBlockGreaterThan(height: number): Promise<boolean> {
-    const dataSources = this.project.dataSources;
-    const dynamicDs = await this.dynamicDsService.getDynamicDatasources();
+  async hasDataSourcesAfterHeight(height: number): Promise<boolean> {
+    const dataSources = await this.getDataSources();
+    return dataSources.some((ds) => ds.endBlock !== undefined && ds.endBlock > height);
+  }
 
-    return [...dataSources, ...dynamicDs].some((ds) => ds.endBlock !== undefined && ds.endBlock > height);
+  async maxEndBlockHeight(): Promise<number> {
+    const dataSources = await this.getDataSources();
+    const endBlocks = dataSources.map((ds) => (ds.endBlock !== undefined ? ds.endBlock : Number.MAX_SAFE_INTEGER));
+    return Math.max(...endBlocks);
   }
 
   // This gets used when indexing blocks, it needs to be async to ensure dynamicDs is updated within workers

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -256,13 +256,24 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
     return [...dataSources, ...dynamicDs];
   }
 
+  async hasDataSourceWithEndBlockGreaterThan(height: number): Promise<boolean> {
+    const dataSources = this.project.dataSources;
+    const dynamicDs = await this.dynamicDsService.getDynamicDatasources();
+
+    return [...dataSources, ...dynamicDs].some((ds) => ds.endBlock !== undefined && ds.endBlock > height);
+  }
+
   // This gets used when indexing blocks, it needs to be async to ensure dynamicDs is updated within workers
   async getDataSources(blockHeight?: number): Promise<DS[]> {
     const dataSources = this.project.dataSources;
     const dynamicDs = await this.dynamicDsService.getDynamicDatasources();
 
     return [...dataSources, ...dynamicDs].filter(
-      (ds) => blockHeight === undefined || (ds.startBlock !== undefined && ds.startBlock <= blockHeight)
+      (ds) =>
+        blockHeight === undefined ||
+        (ds.startBlock !== undefined &&
+          ds.startBlock <= blockHeight &&
+          (ds.endBlock === undefined || ds.endBlock >= blockHeight))
     );
   }
 

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -258,7 +258,7 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
 
   async hasDataSourcesAfterHeight(height: number): Promise<boolean> {
     const dataSources = await this.getDataSources();
-    return dataSources.some((ds) => ds.endBlock !== undefined && ds.endBlock > height);
+    return dataSources.some((ds) => ds.endBlock === undefined || ds.endBlock > height);
   }
 
   async maxEndBlockHeight(): Promise<number> {

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -261,12 +261,6 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
     return dataSources.some((ds) => ds.endBlock === undefined || ds.endBlock > height);
   }
 
-  async maxEndBlockHeight(): Promise<number> {
-    const dataSources = await this.getDataSources();
-    const endBlocks = dataSources.map((ds) => (ds.endBlock !== undefined ? ds.endBlock : Number.MAX_SAFE_INTEGER));
-    return Math.max(...endBlocks);
-  }
-
   // This gets used when indexing blocks, it needs to be async to ensure dynamicDs is updated within workers
   async getDataSources(blockHeight?: number): Promise<DS[]> {
     const dataSources = this.project.dataSources;

--- a/packages/node-core/src/indexer/types.ts
+++ b/packages/node-core/src/indexer/types.ts
@@ -49,5 +49,4 @@ export interface IProjectService<DS> {
   getStartBlockFromDataSources(): number;
   getDataSourcesMap(): BlockHeightMap<DS[]>;
   hasDataSourcesAfterHeight(height: number): Promise<boolean>;
-  maxEndBlockHeight(): Promise<number>;
 }

--- a/packages/node-core/src/indexer/types.ts
+++ b/packages/node-core/src/indexer/types.ts
@@ -48,4 +48,5 @@ export interface IProjectService<DS> {
   getDataSources(blockHeight?: number): Promise<DS[]>;
   getStartBlockFromDataSources(): number;
   getDataSourcesMap(): BlockHeightMap<DS[]>;
+  hasDataSourceWithEndBlockGreaterThan(height: number): Promise<boolean>;
 }

--- a/packages/node-core/src/indexer/types.ts
+++ b/packages/node-core/src/indexer/types.ts
@@ -48,5 +48,5 @@ export interface IProjectService<DS> {
   getDataSources(blockHeight?: number): Promise<DS[]>;
   getStartBlockFromDataSources(): number;
   getDataSourcesMap(): BlockHeightMap<DS[]>;
-  hasDataSourcesAfterHeight(height: number): Promise<boolean>;
+  hasDataSourcesAfterHeight(height: number): boolean;
 }

--- a/packages/node-core/src/indexer/types.ts
+++ b/packages/node-core/src/indexer/types.ts
@@ -48,5 +48,6 @@ export interface IProjectService<DS> {
   getDataSources(blockHeight?: number): Promise<DS[]>;
   getStartBlockFromDataSources(): number;
   getDataSourcesMap(): BlockHeightMap<DS[]>;
-  hasDataSourceWithEndBlockGreaterThan(height: number): Promise<boolean>;
+  hasDataSourcesAfterHeight(height: number): Promise<boolean>;
+  maxEndBlockHeight(): Promise<number>;
 }

--- a/packages/node-core/src/utils/endBlock.ts
+++ b/packages/node-core/src/utils/endBlock.ts
@@ -1,0 +1,9 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {BaseDataSource} from '@subql/common';
+
+export function maxEndBlockHeight<DS extends BaseDataSource>(dataSources: DS[]): number {
+  const endBlocks = dataSources.map((ds) => (ds.endBlock !== undefined ? ds.endBlock : Number.MAX_SAFE_INTEGER));
+  return Math.max(...endBlocks);
+}

--- a/packages/node-core/src/utils/endBlock.ts
+++ b/packages/node-core/src/utils/endBlock.ts
@@ -1,9 +1,0 @@
-// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
-// SPDX-License-Identifier: GPL-3.0
-
-import {BaseDataSource} from '@subql/common';
-
-export function maxEndBlockHeight<DS extends BaseDataSource>(dataSources: DS[]): number {
-  const endBlocks = dataSources.map((ds) => (ds.endBlock !== undefined ? ds.endBlock : Number.MAX_SAFE_INTEGER));
-  return Math.max(...endBlocks);
-}

--- a/packages/types-core/src/project/versioned/base.ts
+++ b/packages/types-core/src/project/versioned/base.ts
@@ -16,6 +16,11 @@ export interface BaseDataSource<H extends BaseHandler = BaseHandler, M extends B
    */
   startBlock?: number;
   /**
+   * The ending block number for the datasource (optional).
+   * @type {number}
+   */
+  endBlock?: number;
+  /**
    * The mapping associated with the datasource.
    * This contains the handlers.
    * @type {M}
@@ -69,4 +74,5 @@ export interface TemplateBase {
   name: string;
 }
 
-export type BaseTemplateDataSource<DS extends BaseDataSource = BaseDataSource> = Omit<DS, 'startBlock'> & TemplateBase;
+export type BaseTemplateDataSource<DS extends BaseDataSource = BaseDataSource> = Omit<DS, 'startBlock' | 'endBlock'> &
+  TemplateBase;


### PR DESCRIPTION
# Description
Allow an optional endBlock on the datasource. Handlers in that datasource will only run from startBlock to endBlock

Fixes #2008 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
