### PR TITLE
Fix types-core dependency missing

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,11 +15,13 @@
     "src/global.d.ts",
     "/dist"
   ],
+  "dependencies": {
+    "@subql/types-core": "workspace:*"
+  },
   "peerDependencies": {
     "@polkadot/api": "^10"
   },
   "devDependencies": {
-    "@polkadot/api": "^10",
-    "@subql/types-core": "workspace:*"
+    "@polkadot/api": "^10"
   }
 }


### PR DESCRIPTION
# Description
`@subql/types-core` was a dev dependency but it should be a direct dependency.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
