### PR TITLE
revert typo fix for chaintypes

### DIFF
--- a/packages/common/src/project/versioned/v1_0_0/models.ts
+++ b/packages/common/src/project/versioned/v1_0_0/models.ts
@@ -146,7 +146,7 @@ export class CommonProjectNetworkV1_0_0<C = any> implements IProjectNetworkConfi
   @IsString()
   chainId: string;
   @IsOptional()
-  chainTypes?: C;
+  chaintypes?: C; // ensure lowercase to keep consistency
   @IsOptional()
   @IsArray()
   bypassBlocks?: (number | `${number}-${number}`)[];


### PR DESCRIPTION
Revert the chainTypes typo fix
https://github.com/subquery/subql/pull/2069/files

in order to ensure consistency, we will be going with `chaintypes` 

Cosmos will be updated to align with this
https://github.com/subquery/subql-cosmos/pull/180
