### PR TITLE
Add logging for POI migration

### DIFF
--- a/packages/node-core/src/indexer/poi/poi.service.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.ts
@@ -101,6 +101,7 @@ export class PoiService implements OnApplicationShutdown {
       return;
     }
     try {
+      logger.info('Migrating POI table, this may take some time');
       // Remove and Change column from sequelize not work, it only applies to public schema
       // https://github.com/sequelize/sequelize/issues/13365
       // await this.poiRepo?.model.sequelize?.getQueryInterface().changeColumn(tableName,'mmrRoot',{})
@@ -175,6 +176,8 @@ export class PoiService implements OnApplicationShutdown {
     if (genesisPoi && (genesisPoi.hash === null || genesisPoi.parentHash === null)) {
       this.createGenesisPoi(genesisPoi);
     }
+
+    logger.info('Migrating POI completed.');
   }
 
   async ensureGenesisPoi(height: number) {


### PR DESCRIPTION
# Description
POI migration can take a long time and currently there is no logging to know that its happening, it may appear to users that the node is stuck. 

This PR adds logging at the start and end of migration.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
