### PR TITLE
Add the ability to scope debug logging

### DIFF
--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -19,7 +19,7 @@ export interface IConfig {
   readonly batchSize: number;
   readonly timeout: number;
   readonly blockTime: number;
-  readonly debug: boolean;
+  readonly debug?: string;
   readonly preferRange: boolean;
   readonly networkEndpoint?: string[];
   readonly primaryNetworkEndpoint?: string;
@@ -62,7 +62,7 @@ const DEFAULT_CONFIG = {
   timeout: 900,
   blockTime: 6000,
   preferRange: false,
-  debug: false,
+  debug: undefined,
   queryLimit: 100,
   indexCountLimit: 10,
   timestampField: true,
@@ -177,7 +177,7 @@ export class NodeConfig<C extends IConfig = IConfig> implements IConfig {
     return this._config.blockTime;
   }
 
-  get debug(): boolean {
+  get debug(): string | undefined {
     return this._config.debug;
   }
 

--- a/packages/node-core/src/configure/configure.module.ts
+++ b/packages/node-core/src/configure/configure.module.ts
@@ -5,7 +5,7 @@ import {handleCreateSubqueryProjectError, LocalReader, makeTempDir, ReaderFactor
 import {Reader} from '@subql/types-core';
 import {camelCase, isNil, omitBy} from 'lodash';
 import {ISubqueryProject} from '../indexer';
-import {getLogger, setLevel} from '../logger';
+import {getLogger, setDebugFilter} from '../logger';
 import {defaultSubqueryName, rebaseArgsWithManifest} from '../utils';
 import {IConfig, NodeConfig} from './NodeConfig';
 import {IProjectUpgradeService, ProjectUpgradeSevice, upgradableSubqueryProject} from './ProjectUpgrade.service';
@@ -126,7 +126,7 @@ export async function registerApp<P extends ISubqueryProject>(
   }
 
   if (config.debug) {
-    setLevel('debug');
+    setDebugFilter(config.debug);
   }
 
   const project = await createProject(

--- a/packages/node-core/src/db/db.module.ts
+++ b/packages/node-core/src/db/db.module.ts
@@ -59,7 +59,8 @@ const sequelizeFactory = (option: SequelizeOption) => async () => {
 };
 
 const buildSequelizeOptions = (nodeConfig: NodeConfig, option: DbOption): SequelizeOption => {
-  const logger = getLogger('db');
+  const logger = getLogger('SQL');
+
   return {
     ...option,
     dialect: 'postgres',
@@ -72,11 +73,9 @@ const buildSequelizeOptions = (nodeConfig: NodeConfig, option: DbOption): Sequel
         cert: nodeConfig.postgresClientCert,
       },
     },
-    logging: nodeConfig.debug
-      ? (sql: string, timing?: number) => {
-          logger.debug(sql);
-        }
-      : false,
+    logging: (sql: string, timing?: number) => {
+      logger.debug(sql);
+    },
   };
 };
 
@@ -102,7 +101,6 @@ export class DbModule {
   }
 
   static forRoot(option: DbOption = DEFAULT_DB_OPTION): DynamicModule {
-    const logger = getLogger('db');
     return {
       module: DbModule,
       providers: [

--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -257,6 +257,9 @@ export class DictionaryService {
     }
 
     const {query, variables} = this.dictionaryQuery(startBlock, queryEndBlock, batchSize, conditions);
+
+    logger.debug(`query: ${query}`);
+    logger.debug(`variables: ${JSON.stringify(variables, null, 2)}`);
     try {
       const resp = await timeout(
         this.client.query({

--- a/packages/node-core/src/indexer/poi/poi.service.spec.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.spec.ts
@@ -21,7 +21,7 @@ jest.mock('@subql/x-sequelize', () => {
 function createPoiService(): PoiService {
   const nodeConfig = {
     proofOfIndex: true,
-    debug: false,
+    debug: '',
   } as NodeConfig;
 
   const sequelize = new Sequelize();

--- a/packages/node-core/src/logger.ts
+++ b/packages/node-core/src/logger.ts
@@ -8,11 +8,16 @@ import Pino from 'pino';
 
 let logger: Logger;
 
-export function initLogger(debug = false, outputFmt?: 'json' | 'colored', logLevel?: string): void {
+export function initLogger(
+  debug: string | undefined = undefined,
+  outputFmt?: 'json' | 'colored',
+  logLevel?: string
+): void {
   logger = new Logger({
-    level: debug ? 'debug' : logLevel,
+    level: debug === '*' ? 'debug' : logLevel,
     outputFormat: outputFmt,
     nestedKey: 'payload',
+    debugFilter: !debug || debug === '*' ? undefined : debug.split(','),
   });
 }
 
@@ -27,6 +32,13 @@ export function getLogger(category: string): Pino.Logger {
 
 export function setLevel(level: Pino.LevelWithSilent): void {
   logger.setLevel(level);
+}
+
+export function setDebugFilter(debug: string | undefined): void {
+  if (debug === '*') {
+    logger.setLevel('debug');
+  }
+  logger.setDebugFilter(!debug || debug === '*' ? [] : debug.split(','));
 }
 
 export class NestLogger implements LoggerService {

--- a/packages/node/src/indexer/worker/worker.ts
+++ b/packages/node/src/indexer/worker/worker.ts
@@ -36,7 +36,7 @@ const logger = getLogger(`worker #${threadId}`);
 async function initWorker(startHeight: number): Promise<void> {
   try {
     const app = await NestFactory.create(WorkerModule, {
-      logger: new NestLogger(argv.debug), // TIP: If the worker is crashing comment out this line for better logging
+      logger: new NestLogger(!!argv.debug), // TIP: If the worker is crashing comment out this line for better logging
     });
 
     await app.init();

--- a/packages/node/src/init.ts
+++ b/packages/node/src/init.ts
@@ -19,12 +19,11 @@ const logger = getLogger('subql-node');
 notifyUpdates(pjson, logger);
 
 export async function bootstrap(): Promise<void> {
-  const debug = argv.debug;
   const port = await getValidPort(argv.port);
 
   try {
     const app = await NestFactory.create(AppModule, {
-      logger: new NestLogger(debug),
+      logger: new NestLogger(!!argv.debug),
     });
     await app.init();
 

--- a/packages/node/src/subcommands/testing.service.ts
+++ b/packages/node/src/subcommands/testing.service.ts
@@ -47,7 +47,7 @@ export class TestingService extends BaseTestingService<
     const testContext = await NestFactory.createApplicationContext(
       TestingModule,
       {
-        logger: new NestLogger(this.nodeConfig.debug),
+        logger: new NestLogger(!!this.nodeConfig.debug),
       },
     );
 

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -13,7 +13,7 @@ export const yargsOptions = yargs(hideBin(process.argv))
     builder: {},
     handler: (argv) => {
       initLogger(
-        argv.debug as boolean,
+        argv.debug as string,
         argv.outputFmt as 'json' | 'colored',
         argv.logLevel as string | undefined,
       );
@@ -30,7 +30,7 @@ export const yargsOptions = yargs(hideBin(process.argv))
     builder: {},
     handler: (argv) => {
       initLogger(
-        argv.debug as boolean,
+        argv.debug as string,
         argv.outputFmt as 'json' | 'colored',
         argv.logLevel as string | undefined,
       );
@@ -53,7 +53,7 @@ export const yargsOptions = yargs(hideBin(process.argv))
       }),
     handler: (argv) => {
       initLogger(
-        argv.debug as boolean,
+        argv.debug as string,
         argv.outputFmt as 'json' | 'colored',
         argv.logLevel as string | undefined,
       );
@@ -250,10 +250,8 @@ export const yargsOptions = yargs(hideBin(process.argv))
     },
     debug: {
       demandOption: false,
-      describe:
-        'Show debug information to console output. will forcefully set log level to debug',
-      type: 'boolean',
-      default: false,
+      describe: `Enable debug logging for specific scopes, this will override log-level. "*" will enable debug everywhere, or comma separated strings for specific scopes. e.g. "SQL,dictionary"`,
+      type: 'string',
     },
     ipfs: {
       demandOption: false,

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -252,7 +252,6 @@ export type SubstrateDatasource = SubstrateRuntimeDatasource | SubstrateCustomDa
  * Represents a custom datasource for Substrate.
  * @interface
  * @template K - The kind of the datasource (default: string).
- * @template T - The filter type for the datasource (default: SubstrateNetworkFilter).
  * @template M - The mapping type for the datasource (default: SubstrateMapping<SubstrateCustomHandler>).
  * @template O - The processor options (default: any).
  */


### PR DESCRIPTION
# Description
* Changes the `debug` flag from boolean to a string. This means you can scope areas to enable debug logging.
  * `--debug="*"` will enable debug logging everywhere this is equivalent to `--debug=true` before this change
  * `--debug="SQL,dictionary"` will log the dictionary and SQL. Scopes should be comma separated.
* Add logging for dictionary queries and variables

Fixes https://github.com/subquery/subql/issues/2049

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
