### PR TITLE
change to build each time

### DIFF
--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -29,17 +29,11 @@ export async function buildManifestFromLocation(location: string, command: Comma
   } else {
     command.error('Argument `location` is not a valid directory or file');
   }
-  // Only build when ProjectYamlPath not exist and projectManifestEntry is in typescript
-  if (
-    !existsSync(tsProjectYamlPath(projectManifestEntry)) &&
-    existsSync(projectManifestEntry) &&
-    extensionIsTs(path.extname(projectManifestEntry))
-  ) {
-    try {
-      await generateManifestFromTs(projectManifestEntry, command);
-    } catch (e) {
-      throw new Error(`Failed to generate manifest from typescript ${projectManifestEntry}, ${e.message}`);
-    }
+  // We compile from TypeScript every time, even if the current YAML file exists, to ensure that the YAML file remains up-to-date with the latest changes
+  try {
+    await generateManifestFromTs(projectManifestEntry, command);
+  } catch (e) {
+    throw new Error(`Failed to generate manifest from typescript ${projectManifestEntry}, ${e.message}`);
   }
   return directory;
 }


### PR DESCRIPTION
# Description

Before we check if current yaml exist and we will ignore the build, but seems if user make any update to ts manifest will require remove yaml then rebuild. To reduce the steps, we removed the check, to ensure that the YAML file remains up-to-date with the latest changes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
