### PR TITLE
Fix `init` yaml readers/writers

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed yaml readers/writers on `init` command (#2082)
 
 ## [4.0.2] - 2023-10-11
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
     "fuzzy": "^0.1.3",
     "inquirer": "^8.2.0",
     "inquirer-autocomplete-prompt": "^1.4.0",
+    "json5": "^2.2.3",
     "node-fetch": "2.6.7",
     "rimraf": "^3.0.2",
     "semver": "^7.5.4",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -201,11 +201,11 @@ export default class Init extends Command {
       required: false,
     });
     // Should assume all project endpoints will be string[]
-    if (!Array.isArray(this.project.endpoint)) {
-      this.project.endpoint = [userInput];
-    }
+    // if (!Array.isArray(this.project.endpoint)) {
+    //   this.project.endpoint = [userInput];
+    // }
     if (!this.project.endpoint.includes(userInput)) {
-      this.project.endpoint.push(userInput);
+      (this.project.endpoint as string[]).push(userInput);
     }
     const descriptionHint = defaultDescription.substring(0, 40).concat('...');
     this.project.author = await cli.prompt('Author', {required: true, default: defaultAuthor});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -200,10 +200,6 @@ export default class Init extends Command {
       default: defaultEndpoint[0] ?? 'wss://polkadot.api.onfinality.io/public-ws',
       required: false,
     });
-    // Should assume all project endpoints will be string[]
-    // if (!Array.isArray(this.project.endpoint)) {
-    //   this.project.endpoint = [userInput];
-    // }
     if (!this.project.endpoint.includes(userInput)) {
       (this.project.endpoint as string[]).push(userInput);
     }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -168,6 +168,7 @@ export default class Init extends Command {
         }
       });
     this.projectPath = await cloneProjectTemplate(this.location, this.project.name, selectedProject);
+
     await this.setupProject(flags);
 
     if (await validateEthereumProjectManifest(this.projectPath)) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -193,27 +193,20 @@ export default class Init extends Command {
   }
 
   async setupProject(flags: any): Promise<void> {
-    const [defaultSpecVersion, defaultEndpoint, defaultAuthor, defaultDescription] = await readDefaults(
-      this.projectPath
-    );
+    const [defaultEndpoint, defaultAuthor, defaultDescription] = await readDefaults(this.projectPath);
 
-    // Should use template specVersion as default, otherwise use user provided
-    flags.specVersion = defaultSpecVersion ?? flags.specVersion;
-
-    this.project.endpoint = defaultEndpoint;
+    this.project.endpoint = !Array.isArray(defaultEndpoint) ? [defaultEndpoint] : defaultEndpoint;
     const userInput = await cli.prompt('RPC endpoint:', {
       default: defaultEndpoint[0] ?? 'wss://polkadot.api.onfinality.io/public-ws',
       required: false,
     });
     // Should assume all project endpoints will be string[]
-    if (Array.isArray(this.project.endpoint)) {
-      if (!this.project.endpoint.includes(userInput)) {
-        this.project.endpoint.push(userInput);
-      }
-    } else {
+    if (!Array.isArray(this.project.endpoint)) {
       this.project.endpoint = [userInput];
     }
-
+    if (!this.project.endpoint.includes(userInput)) {
+      this.project.endpoint.push(userInput);
+    }
     const descriptionHint = defaultDescription.substring(0, 40).concat('...');
     this.project.author = await cli.prompt('Author', {required: true, default: defaultAuthor});
     this.project.description = await cli

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -210,10 +210,10 @@ export default class Init extends Command {
       required: true,
     });
 
-    this.project.repository = await cli.prompt('Git repository', {required: false, default: defaultRepository});
+    // this.project.repository = await cli.prompt('Git repository', {required: false, default: defaultRepository});
 
     const descriptionHint = defaultDescription.substring(0, 40).concat('...');
-    this.project.author = await cli.prompt('Author', {required: true, default: defaultAuthor});
+    // this.project.author = await cli.prompt('Author', {required: true, default: defaultAuthor});
     this.project.description = await cli
       .prompt('Description', {
         required: false,
@@ -223,8 +223,8 @@ export default class Init extends Command {
         return description === descriptionHint ? defaultDescription : description;
       });
 
-    this.project.version = await cli.prompt('Version', {required: true, default: defaultVersion});
-    this.project.license = await cli.prompt('License', {required: true, default: defaultLicense});
+    // this.project.version = await cli.prompt('Version', {required: true, default: defaultVersion});
+    // this.project.license = await cli.prompt('License', {required: true, default: defaultLicense});
 
     cli.action.start('Preparing project');
     await prepare(this.projectPath, this.project);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -204,6 +204,7 @@ export default class Init extends Command {
       default: defaultEndpoint[0] ?? 'wss://polkadot.api.onfinality.io/public-ws',
       required: false,
     });
+    // Should assume all project endpoints will be string[]
     if (Array.isArray(this.project.endpoint)) {
       if (!this.project.endpoint.includes(userInput)) {
         this.project.endpoint.push(userInput);

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -10,3 +10,7 @@ export const ROOT_API_URL_PROD = 'https://api.subquery.network';
 export const BASE_PROJECT_URL = 'https://project.subquery.network';
 
 export const BASE_TEMPLATE_URl = 'https://templates.subquery.network';
+
+// Regex for cold tsManifest
+export const ENDPOINT_REG = /endpoint:\s*\[\s*([\s\S]*?)\s*\]/;
+export const SPEC_VERSION_REG = /specVersion:\s*["'](.*?)["']/;

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -12,5 +12,6 @@ export const BASE_PROJECT_URL = 'https://project.subquery.network';
 export const BASE_TEMPLATE_URl = 'https://templates.subquery.network';
 
 // Regex for cold tsManifest
-export const ENDPOINT_REG = /endpoint:\s*(\[?\s*['"]([\s\S]*?)['"]\s*\]?)/;
+// export const ENDPOINT_REG = /endpoint:\s*(?:\[)?\s*['"]([\s\S]+?)['"]\s*(?:\])?/;
+export const ENDPOINT_REG = /endpoint:\s*((?:\[\s*['"][^'"]+['"]\s*(?:,\s*['"][^'"]+['"]\s*)*\])|['"][^'"]+['"])/;
 export const SPEC_VERSION_REG = /specVersion:\s*["'](.*?)["']/;

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -12,8 +12,4 @@ export const BASE_PROJECT_URL = 'https://project.subquery.network';
 export const BASE_TEMPLATE_URl = 'https://templates.subquery.network';
 
 // Regex for cold tsManifest
-// export const ENDPOINT_REG = /endpoint:\s*(?:\[)?\s*['"]([\s\S]+?)['"]\s*(?:\])?/;
-// eslint-disable-next-line no-useless-backreference
-// export const ENDPOINT_REG = /endpoint:\s*((?:\[\s*("|'|`)(\S*)\1(?:,\s*(("|'|`)(\S*)\1)\s*)*\])|("|'|`)(\S*)\1)/;
-// export const ENDPOINT_REG = /endpoint:\s*((?:\[.*?\])|(['"`].*?['"`]))/;
 export const ENDPOINT_REG = /endpoint:\s*(\[[^\]]+\]|['"`][^'"`]+['"`])/;

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -12,5 +12,5 @@ export const BASE_PROJECT_URL = 'https://project.subquery.network';
 export const BASE_TEMPLATE_URl = 'https://templates.subquery.network';
 
 // Regex for cold tsManifest
-export const ENDPOINT_REG = /endpoint:\s*\[\s*([\s\S]*?)\s*\]/;
+export const ENDPOINT_REG = /endpoint:\s*(\[?\s*['"]([\s\S]*?)['"]\s*\]?)/;
 export const SPEC_VERSION_REG = /specVersion:\s*["'](.*?)["']/;

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -13,5 +13,7 @@ export const BASE_TEMPLATE_URl = 'https://templates.subquery.network';
 
 // Regex for cold tsManifest
 // export const ENDPOINT_REG = /endpoint:\s*(?:\[)?\s*['"]([\s\S]+?)['"]\s*(?:\])?/;
-export const ENDPOINT_REG = /endpoint:\s*((?:\[\s*['"][^'"]+['"]\s*(?:,\s*['"][^'"]+['"]\s*)*\])|['"][^'"]+['"])/;
-export const SPEC_VERSION_REG = /specVersion:\s*["'](.*?)["']/;
+// eslint-disable-next-line no-useless-backreference
+// export const ENDPOINT_REG = /endpoint:\s*((?:\[\s*("|'|`)(\S*)\1(?:,\s*(("|'|`)(\S*)\1)\s*)*\])|("|'|`)(\S*)\1)/;
+// export const ENDPOINT_REG = /endpoint:\s*((?:\[.*?\])|(['"`].*?['"`]))/;
+export const ENDPOINT_REG = /endpoint:\s*(\[[^\]]+\]|['"`][^'"`]+['"`])/;

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -4,6 +4,7 @@
 import * as fs from 'fs';
 import os from 'os';
 import path from 'path';
+import {extractDefaults, findReplace} from '@subql/common';
 import git from 'simple-git';
 import {
   cloneProjectGit,
@@ -60,5 +61,22 @@ describe('Cli can create project (mocked)', () => {
   });
   it('fetch example projects', async () => {
     expect((await fetchExampleProjects('evm', '1')).length).toBeGreaterThan(0);
+  });
+  it('readDefaults using regex', async () => {
+    const manifest = (await fs.promises.readFile(path.join(__dirname, '../../test/schemaTest/project.ts'))).toString();
+    expect(extractDefaults(manifest)).toStrictEqual({
+      specVersion: '1.0.0',
+      endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws', 'wss://acala-rpc-0.aca-api.network'],
+    });
+  });
+  it('findReplace using regex', async () => {
+    const manifest = (await fs.promises.readFile(path.join(__dirname, '../../test/schemaTest/project.ts'))).toString();
+    const v = findReplace(
+      manifest,
+      /endpoint:\s*\[\s*([\s\S]*?)\s*\]/,
+      "endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws']"
+    );
+
+    console.log(v);
   });
 });

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -4,6 +4,7 @@
 import * as fs from 'fs';
 import os from 'os';
 import path from 'path';
+import {DEFAULT_TS_MANIFEST} from '@subql/common';
 import git from 'simple-git';
 import {ENDPOINT_REG} from '../constants';
 import {extractFromTs, findReplace, validateEthereumTsManifest} from '../utils';
@@ -47,13 +48,13 @@ describe('Cli can create project (mocked)', () => {
   let originalManifest: string;
   let originalPackage: string;
   beforeAll(async () => {
-    originalManifest = (await fs.promises.readFile(`${projectPath}/project.ts`)).toString();
+    originalManifest = (await fs.promises.readFile(`${projectPath}/${DEFAULT_TS_MANIFEST}`)).toString();
     originalPackage = (await fs.promises.readFile(`${projectPath}/package.json`)).toString();
   });
 
   afterAll(async () => {
     // resort original after the test
-    await fs.promises.writeFile(path.join(projectPath, 'project.ts'), originalManifest);
+    await fs.promises.writeFile(path.join(projectPath, DEFAULT_TS_MANIFEST), originalManifest);
     await fs.promises.writeFile(path.join(projectPath, 'package.json'), originalPackage);
   });
   it('throw error when git clone failed', async () => {
@@ -80,7 +81,9 @@ describe('Cli can create project (mocked)', () => {
     expect((await fetchExampleProjects('evm', '1')).length).toBeGreaterThan(0);
   });
   it('readDefaults using regex', async () => {
-    const manifest = (await fs.promises.readFile(path.join(__dirname, '../../test/schemaTest/project.ts'))).toString();
+    const manifest = (
+      await fs.promises.readFile(path.join(__dirname, `../../test/schemaTest/${DEFAULT_TS_MANIFEST}`))
+    ).toString();
     expect(
       extractFromTs(manifest, {
         endpoint: ENDPOINT_REG,
@@ -126,7 +129,9 @@ describe('Cli can create project (mocked)', () => {
     });
   });
   it('findReplace using regex', async () => {
-    const manifest = (await fs.promises.readFile(path.join(__dirname, '../../test/schemaTest/project.ts'))).toString();
+    const manifest = (
+      await fs.promises.readFile(path.join(__dirname, `../../test/schemaTest/${DEFAULT_TS_MANIFEST}`))
+    ).toString();
     const v = findReplace(manifest, ENDPOINT_REG, "endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws']");
 
     expect(
@@ -136,7 +141,9 @@ describe('Cli can create project (mocked)', () => {
     ).toStrictEqual({endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws']});
   });
   it('findReplace with string endpoints', async () => {
-    const manifest = (await fs.promises.readFile(path.join(__dirname, '../../test/schemaTest/project.ts'))).toString();
+    const manifest = (
+      await fs.promises.readFile(path.join(__dirname, `../../test/schemaTest/${DEFAULT_TS_MANIFEST}`))
+    ).toString();
     const v = findReplace(manifest, ENDPOINT_REG, "endpoint: 'wss://acala-polkadot.api.onfinality.io/public-ws'");
 
     expect(
@@ -173,7 +180,7 @@ describe('Cli can create project (mocked)', () => {
     expect(projectPackage.description).toBe(project.description);
     expect(projectPackage.author).toBe(project.author);
 
-    const updatedManifest = await fs.promises.readFile(`${projectPath}/project.ts`);
+    const updatedManifest = await fs.promises.readFile(`${projectPath}/${DEFAULT_TS_MANIFEST}`);
     const extractedValues = extractFromTs(updatedManifest.toString(), {
       endpoint: ENDPOINT_REG,
     });

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -105,12 +105,21 @@ describe('Cli can create project (mocked)', () => {
     const manifest = (await fs.promises.readFile(path.join(__dirname, '../../test/schemaTest/project.ts'))).toString();
     const v = findReplace(manifest, ENDPOINT_REG, "endpoint: 'wss://acala-polkadot.api.onfinality.io/public-ws'");
 
-    console.log(v);
-    // expect(extractFromTs(v, {
-    //   endpoint: ENDPOINT_REG
-    // })).toStrictEqual(
-    //     {endpoint: ["wss://acala-polkadot.api.onfinality.io/public-ws"]}
-    // )
+    expect(
+      extractFromTs(v, {
+        endpoint: ENDPOINT_REG,
+      })
+    ).toStrictEqual({endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws']});
+  });
+  it('able to extract string endpoints', () => {
+    expect(
+      extractFromTs(
+        `
+      endpoint: 'wss://aaa'
+    `,
+        {endpoint: ENDPOINT_REG}
+      )
+    ).toStrictEqual({endpoint: ['wss://aaa']});
   });
   it('Ensure prepareManifest and preparePackage correctness for project.ts', async () => {
     const project = {

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import os from 'os';
 import path from 'path';
 import git from 'simple-git';
-import {ENDPOINT_REG, SPEC_VERSION_REG} from '../constants';
+import {ENDPOINT_REG} from '../constants';
 import {extractFromTs, findReplace, validateEthereumTsManifest} from '../utils';
 import {
   cloneProjectGit,
@@ -83,11 +83,9 @@ describe('Cli can create project (mocked)', () => {
     const manifest = (await fs.promises.readFile(path.join(__dirname, '../../test/schemaTest/project.ts'))).toString();
     expect(
       extractFromTs(manifest, {
-        specVersion: SPEC_VERSION_REG,
         endpoint: ENDPOINT_REG,
       })
     ).toStrictEqual({
-      specVersion: '1.0.0',
       endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws', 'wss://acala-rpc-0.aca-api.network'],
     });
   });
@@ -146,7 +144,6 @@ describe('Cli can create project (mocked)', () => {
       name: 'test-1',
       endpoint: ['https://zzz', 'https://bbb'],
       author: 'bz888',
-      specVersion: '1.0.0',
       description: 'tester project',
     };
 
@@ -162,11 +159,9 @@ describe('Cli can create project (mocked)', () => {
 
     const updatedManifest = await fs.promises.readFile(`${projectPath}/project.ts`);
     const extractedValues = extractFromTs(updatedManifest.toString(), {
-      specVersion: SPEC_VERSION_REG,
       endpoint: ENDPOINT_REG,
     });
     expect(extractedValues.endpoint).toStrictEqual(project.endpoint);
-    expect(extractedValues.specVersion).toBe(project.specVersion);
     expect(originalManifest).not.toBe(updatedManifest.toString());
     expect(originalPackage).not.toBe(packageData.toString());
   });

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -89,24 +89,40 @@ describe('Cli can create project (mocked)', () => {
       endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws', 'wss://acala-rpc-0.aca-api.network'],
     });
   });
-  it('readDefaults using regex single endpoint', () => {
+  it('Ensure regex correctness for ENDPOINT_REG', () => {
+    expect(
+      extractFromTs(`endpoint: 'wss://acala-polkadot.api.onfinality.io/public-ws'`, {
+        endpoint: ENDPOINT_REG,
+      })
+    ).toStrictEqual({
+      endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws'],
+    });
+    expect(
+      extractFromTs('endpoint: `wss://acala-polkadot.api.onfinality.io/public-ws`', {
+        endpoint: ENDPOINT_REG,
+      })
+    ).toStrictEqual({
+      endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws'],
+    });
+    expect(
+      extractFromTs('endpoint: [`wss://acala-polkadot.api.onfinality.io/public-ws`]', {
+        endpoint: ENDPOINT_REG,
+      })
+    ).toStrictEqual({
+      endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws'],
+    });
     expect(
       extractFromTs(
-        `
-      network: {
-    chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
-    endpoint: 'wss://acala-polkadot.api.onfinality.io/public-ws',
-    dictionary: 'https://api.subquery.network/sq/subquery/acala-dictionary',
-    chaintypes: {
-      file: './dist/chaintypes.js',
-    },
-  },`,
+        "endpoint: [`wss://acala-polkadot.api.onfinality.io/public-ws`, 'wss://acala-polkadot.api.onfinality.io/public-ws']",
         {
           endpoint: ENDPOINT_REG,
         }
       )
     ).toStrictEqual({
-      endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws'],
+      endpoint: [
+        'wss://acala-polkadot.api.onfinality.io/public-ws',
+        'wss://acala-polkadot.api.onfinality.io/public-ws',
+      ],
     });
   });
   it('findReplace using regex', async () => {

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -4,13 +4,15 @@
 import * as fs from 'fs';
 import os from 'os';
 import path from 'path';
-import {extractDefaults, findReplace} from '@subql/common';
 import git from 'simple-git';
+import {extractFromTs, findReplace} from '../utils';
 import {
   cloneProjectGit,
   fetchExampleProjects,
   fetchNetworks,
   fetchTemplates,
+  prepareManifest,
+  preparePackage,
   validateEthereumProjectManifest,
 } from './init-controller';
 
@@ -64,7 +66,12 @@ describe('Cli can create project (mocked)', () => {
   });
   it('readDefaults using regex', async () => {
     const manifest = (await fs.promises.readFile(path.join(__dirname, '../../test/schemaTest/project.ts'))).toString();
-    expect(extractDefaults(manifest)).toStrictEqual({
+    expect(
+      extractFromTs(manifest, {
+        specVersion: /specVersion:\s*["'](.*?)["']/,
+        endpoint: /endpoint:\s*\[\s*([\s\S]*?)\s*\]/,
+      })
+    ).toStrictEqual({
       specVersion: '1.0.0',
       endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws', 'wss://acala-rpc-0.aca-api.network'],
     });
@@ -78,5 +85,21 @@ describe('Cli can create project (mocked)', () => {
     );
 
     console.log(v);
+  });
+  it('Ensure prepareManifest and preparePackage correctness for project.ts', async () => {
+    const projectPath = path.join(__dirname, '../../test/schemaTest/');
+    const project = {
+      name: 'test-1',
+      endpoint: ['https://zzz', 'https://bbb'],
+      author: 'bz888',
+      specVersion: '1.0.0',
+    };
+
+    await prepareManifest(projectPath, project);
+    await preparePackage(projectPath, project);
+    // extract endpoint and specVersion
+    // require from package.json to ensure data is correct
+
+    // backwards compatibility
   });
 });

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -91,6 +91,26 @@ describe('Cli can create project (mocked)', () => {
       endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws', 'wss://acala-rpc-0.aca-api.network'],
     });
   });
+  it('readDefaults using regex single endpoint', () => {
+    expect(
+      extractFromTs(
+        `
+      network: {
+    chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
+    endpoint: 'wss://acala-polkadot.api.onfinality.io/public-ws',
+    dictionary: 'https://api.subquery.network/sq/subquery/acala-dictionary',
+    chaintypes: {
+      file: './dist/chaintypes.js',
+    },
+  },`,
+        {
+          endpoint: ENDPOINT_REG,
+        }
+      )
+    ).toStrictEqual({
+      endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws'],
+    });
+  });
   it('findReplace using regex', async () => {
     const manifest = (await fs.promises.readFile(path.join(__dirname, '../../test/schemaTest/project.ts'))).toString();
     const v = findReplace(manifest, ENDPOINT_REG, "endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws']");

--- a/packages/cli/src/controller/init-controller.test.ts
+++ b/packages/cli/src/controller/init-controller.test.ts
@@ -7,7 +7,7 @@ import {promisify} from 'util';
 import {makeTempDir} from '@subql/common';
 import rimraf from 'rimraf';
 import {parseDocument, Document} from 'yaml';
-import {isProjectSpecV0_2_0, isProjectSpecV1_0_0, ProjectSpecBase} from '../types';
+import {isProjectSpecV0_2_0, isProjectSpecV1_0_0, ProjectSpecBase, ProjectSpecV1_0_0} from '../types';
 import {
   cloneProjectGit,
   cloneProjectTemplate,
@@ -24,7 +24,6 @@ async function testYAML(projectPath: string, project: ProjectSpecBase): Promise<
 
   const clonedData = data.clone();
   clonedData.set('description', project.description ?? data.get('description'));
-  clonedData.set('repository', project.repository ?? '');
 
   // network type should be collection
   const network: any = clonedData.get('network');
@@ -56,14 +55,11 @@ jest.setTimeout(30000);
 
 const projectSpec = {
   name: 'mocked_starter',
-  repository: '',
-  endpoint: 'wss://rpc.polkadot.io/public-ws',
+  endpoint: ['wss://rpc.polkadot.io/public-ws'],
   specVersion: '1.0.0',
   author: 'jay',
   description: 'this is test for init controller',
   chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
-  version: '',
-  license: '',
 };
 
 describe('Cli can create project', () => {
@@ -115,14 +111,11 @@ describe('Cli can create project', () => {
       projects.find((p) => p.name === 'Polkadot-starter')
     );
     await prepare(projectPath, projectSpec);
-    const [specVersion, repository, endpoint, author, version, description, license] = await readDefaults(projectPath);
+    const [specVersion, endpoint, author, description] = await readDefaults(projectPath);
     expect(projectSpec.specVersion).toEqual(specVersion);
-    expect(projectSpec.repository).toEqual(repository);
     expect(projectSpec.endpoint).toEqual(endpoint);
     expect(projectSpec.author).toEqual(author);
-    expect(projectSpec.version).toEqual(version);
     expect(projectSpec.description).toEqual(description);
-    expect(projectSpec.license).toEqual(license);
   });
 
   it('allow git from sub directory', async () => {

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -127,7 +127,7 @@ export async function cloneProjectTemplate(
   //use sparse-checkout to clone project to temp directory
   await git(tempPath).init().addRemote('origin', selectedProject.remote);
   await git(tempPath).raw('sparse-checkout', 'set', `${selectedProject.path}`);
-  await git(tempPath).raw('pull', 'origin', '7600e6cd7c275f37418b07bf854f606fb5f35796');
+  await git(tempPath).raw('pull', 'origin', 'main');
   // Copy content to project path
   copySync(path.join(tempPath, `${selectedProject.path}`), projectPath);
   // Clean temp folder

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -165,7 +165,7 @@ export async function prepare(projectPath: string, project: ProjectSpecBase): Pr
   try {
     await prepareManifest(projectPath, project);
   } catch (e) {
-    throw new Error('Failed to prepare read or write manifest while preparing the project' + `${e}`);
+    throw new Error('Failed to prepare read or write manifest while preparing the project');
   }
   try {
     await preparePackage(projectPath, project);

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -128,7 +128,7 @@ export async function cloneProjectTemplate(
   //use sparse-checkout to clone project to temp directory
   await git(tempPath).init().addRemote('origin', selectedProject.remote);
   await git(tempPath).raw('sparse-checkout', 'set', `${selectedProject.path}`);
-  await git(tempPath).raw('pull', 'origin', '682792813917d5274d2619136b74219fa976ab2f');
+  await git(tempPath).raw('pull', 'origin', 'main');
   // Copy content to project path
   copySync(path.join(tempPath, `${selectedProject.path}`), projectPath);
   // Clean temp folder

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {promisify} from 'util';
-import {mapToObject, ReaderFactory, toJsonObject} from '@subql/common';
+import {DEFAULT_MANIFEST, mapToObject, ReaderFactory, toJsonObject} from '@subql/common';
 import {parseSubstrateProjectManifest, ProjectManifestV1_0_0Impl} from '@subql/common-substrate';
 import {create} from 'ipfs-http-client';
 import rimraf from 'rimraf';
@@ -109,7 +109,7 @@ describe('Cli publish', () => {
 
   it('upload project from a manifest', async () => {
     projectDir = await createTestProject(projectSpecV0_2_0);
-    const manifestPath = path.resolve(projectDir, 'project.yaml');
+    const manifestPath = path.resolve(projectDir, DEFAULT_MANIFEST);
     const testManifestPath = path.resolve(projectDir, 'test.yaml');
     fs.renameSync(manifestPath, testManifestPath);
     await expect(Publish.run(['-f', testManifestPath])).resolves.not.toThrow();

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -19,35 +19,26 @@ import {uploadFile, uploadToIpfs} from './publish-controller';
 
 const projectSpecV0_0_1: ProjectSpecV0_0_1 = {
   name: 'mocked_starter',
-  repository: '',
   endpoint: 'wss://rpc.polkadot.io/public-ws',
   author: 'jay',
   description: 'this is test for init controller',
-  version: '',
-  license: '',
 };
 
 const projectSpecV0_2_0: ProjectSpecV0_2_0 = {
   name: 'mocked_starter',
-  repository: '',
   genesisHash: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
   endpoint: 'wss://rpc.polkadot.io/public-ws',
   author: 'jay',
   description: 'this is test for init controller',
-  version: '',
-  license: '',
 };
 
 // eslint-disable-next-line jest/no-export
 export const projectSpecV1_0_0: ProjectSpecV1_0_0 = {
   name: 'mocked_starter',
-  repository: '',
   chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
   endpoint: 'wss://rpc.polkadot.io/public-ws',
   author: 'jay',
   description: 'this is test for init controller',
-  version: '',
-  license: '',
   runner: {
     node: {
       name: '@subql/node',

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -7,8 +7,7 @@ export interface ProjectSpecBase {
   name: string;
   author: string;
   description?: string;
-  endpoint: string[];
-  specVersion: string;
+  endpoint: string[] | string;
 }
 
 export interface QueryAdvancedOpts {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -5,12 +5,10 @@ import {RunnerSpecs} from '@subql/types-core';
 
 export interface ProjectSpecBase {
   name: string;
-  repository?: string;
   author: string;
   description?: string;
-  version: string;
-  license: string;
-  endpoint: string;
+  endpoint: string[];
+  specVersion: string;
 }
 
 export interface QueryAdvancedOpts {

--- a/packages/cli/src/utils/utils.ts
+++ b/packages/cli/src/utils/utils.ts
@@ -122,23 +122,19 @@ export function extractFromTs(
     const match = manifest.match(patterns[key]);
 
     if (key === 'endpoint' && match) {
-      const cleanedMatch = match[1].trim().replace(/['"]/g, '');
-
-      if (cleanedMatch.startsWith('[')) {
-        result[key] = cleanedMatch
+      if (match[1].startsWith('[')) {
+        result[key] = match[1]
           .slice(1, -1)
           .split(',')
           .map((s) => s.trim().replace(/['"]/g, ''))
           .filter(Boolean);
       } else {
-        result[key] = [cleanedMatch];
+        result[key] = [match[1].trim().replace(/['"]/g, '')];
       }
     } else {
       result[key] = match ? match[1] : null;
     }
   }
-
-  return result;
 
   return result;
 }

--- a/packages/cli/src/utils/utils.ts
+++ b/packages/cli/src/utils/utils.ts
@@ -9,6 +9,7 @@ import axios from 'axios';
 import cli, {ux} from 'cli-ux';
 import ejs from 'ejs';
 import inquirer, {Inquirer} from 'inquirer';
+import JSON5 from 'json5';
 import rimraf from 'rimraf';
 
 export async function delay(sec: number): Promise<void> {
@@ -122,15 +123,9 @@ export function extractFromTs(
     const match = manifest.match(patterns[key]);
 
     if (key === 'endpoint' && match) {
-      if (match[1].startsWith('[')) {
-        result[key] = match[1]
-          .slice(1, -1)
-          .split(',')
-          .map((s) => s.trim().replace(/['"]/g, ''))
-          .filter(Boolean);
-      } else {
-        result[key] = [match[1].trim().replace(/['"]/g, '')];
-      }
+      const inputStr = match[1].replace(/`/g, '"');
+      const jsonOutput = JSON5.parse(inputStr);
+      result[key] = Array.isArray(jsonOutput) ? jsonOutput : [jsonOutput];
     } else {
       result[key] = match ? match[1] : null;
     }

--- a/packages/cli/src/utils/utils.ts
+++ b/packages/cli/src/utils/utils.ts
@@ -109,7 +109,6 @@ export function isValidEnum<T extends Record<string, string>>(enumType: T, input
 }
 
 export function findReplace(manifest: string, replacer: RegExp, value: string): string {
-  console.log(manifest.replace(replacer, value));
   return manifest.replace(replacer, value);
 }
 
@@ -132,4 +131,10 @@ export function extractFromTs(
   }
 
   return result;
+}
+
+// Cold validate on ts manifest, for generate scaffold command
+export function validateEthereumTsManifest(manifest: string): boolean {
+  const pattern = /"@subql\/types-ethereum"/;
+  return !!pattern.test(manifest);
 }

--- a/packages/cli/src/utils/utils.ts
+++ b/packages/cli/src/utils/utils.ts
@@ -120,21 +120,32 @@ export function extractFromTs(
 
   for (const key in patterns) {
     const match = manifest.match(patterns[key]);
+
     if (key === 'endpoint' && match) {
-      result[key] = match[1]
-        .split(',')
-        .map((s) => s.trim().replace(/['"]/g, ''))
-        .filter(Boolean);
+      const cleanedMatch = match[1].trim().replace(/['"]/g, '');
+
+      if (cleanedMatch.startsWith('[')) {
+        result[key] = cleanedMatch
+          .slice(1, -1)
+          .split(',')
+          .map((s) => s.trim().replace(/['"]/g, ''))
+          .filter(Boolean);
+      } else {
+        result[key] = [cleanedMatch];
+      }
     } else {
       result[key] = match ? match[1] : null;
     }
   }
 
   return result;
+
+  return result;
 }
 
 // Cold validate on ts manifest, for generate scaffold command
 export function validateEthereumTsManifest(manifest: string): boolean {
-  const pattern = /"@subql\/types-ethereum"/;
-  return !!pattern.test(manifest);
+  const typePattern = /@subql\/types-ethereum/;
+  const nodePattern = /@subql\/node-ethereum/;
+  return !!typePattern.test(manifest) && !!nodePattern.test(manifest);
 }

--- a/packages/cli/src/utils/utils.ts
+++ b/packages/cli/src/utils/utils.ts
@@ -107,3 +107,29 @@ export function resolveToAbsolutePath(inputPath: string): string {
 export function isValidEnum<T extends Record<string, string>>(enumType: T, input: string): input is T[keyof T] {
   return Object.values(enumType).includes(input);
 }
+
+export function findReplace(manifest: string, replacer: RegExp, value: string): string {
+  console.log(manifest.replace(replacer, value));
+  return manifest.replace(replacer, value);
+}
+
+export function extractFromTs(
+  manifest: string,
+  patterns: {[key: string]: RegExp}
+): {[key: string]: string | string[] | null} {
+  const result: {[key: string]: string | string[] | null} = {};
+
+  for (const key in patterns) {
+    const match = manifest.match(patterns[key]);
+    if (key === 'endpoint' && match) {
+      result[key] = match[1]
+        .split(',')
+        .map((s) => s.trim().replace(/['"]/g, ''))
+        .filter(Boolean);
+    } else {
+      result[key] = match ? match[1] : null;
+    }
+  }
+
+  return result;
+}

--- a/packages/cli/test/schemaTest/package.json
+++ b/packages/cli/test/schemaTest/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "test-1",
+  "version": "0.0.1",
+  "description": "tester project",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "subql build",
+    "codegen": "subql codegen",
+    "start:docker": "docker-compose pull && docker-compose up --remove-orphans",
+    "dev": "subql codegen && subql build && docker-compose pull && docker-compose up --remove-orphans",
+    "prepack": "rm -rf dist && npm run build",
+    "test": "subql build && subql-node-ethereum test"
+  },
+  "homepage": "https://github.com/subquery/ethereum-subql-starter",
+  "repository": "github:subquery/ethereum-subql-starter",
+  "files": [
+    "dist",
+    "schema.graphql",
+    "project.yaml"
+  ],
+  "author": "bz888",
+  "license": "MIT",
+  "dependencies": {
+    "@subql/common": "latest",
+    "@subql/types-ethereum": "latest",
+    "@subql/validator": "latest",
+    "assert": "^2.0.0"
+  },
+  "devDependencies": {
+    "@subql/cli": "latest",
+    "@subql/types": "latest",
+    "@subql/testing": "latest",
+    "@subql/node-ethereum": "latest",
+    "ethers": "^5.7.2",
+    "typescript": "4.5.5"
+  }
+}

--- a/packages/cli/test/schemaTest/project.ts
+++ b/packages/cli/test/schemaTest/project.ts
@@ -35,7 +35,7 @@ const project: SubstrateProject = {
      * You can get them from OnFinality for free https://app.onfinality.io
      * https://documentation.onfinality.io/support/the-enhanced-api-service
      */
-    endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws', 'wss://acala-rpc-0.aca-api.network'],
+    endpoint: ['https://zzz', 'https://bbb'],
     dictionary: 'https://api.subquery.network/sq/subquery/acala-dictionary',
     chaintypes: {
       file: './dist/chaintypes.js',

--- a/packages/cli/test/schemaTest/project.ts
+++ b/packages/cli/test/schemaTest/project.ts
@@ -27,7 +27,7 @@ const project: SubstrateProject = {
   },
   network: {
     chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
-    endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws', 'wss://acala-rpc-0.aca-api.network'],
+    endpoint: [`wss://acala-polkadot.api.onfinality.io/public-ws`, 'wss://acala-rpc-0.aca-api.network'],
     dictionary: 'https://api.subquery.network/sq/subquery/acala-dictionary',
     chaintypes: {
       file: './dist/chaintypes.js',

--- a/packages/cli/test/schemaTest/project.ts
+++ b/packages/cli/test/schemaTest/project.ts
@@ -1,0 +1,79 @@
+import {
+  SubstrateDatasourceKind,
+  SubstrateHandlerKind,
+  SubstrateProject,
+  // @ts-ignore
+} from '@subql/types';
+
+// Can expand the Datasource processor types via the genreic param
+const project: SubstrateProject = {
+  specVersion: '1.0.0',
+  version: '0.0.1',
+  name: 'acala-starter',
+  description:
+    'This project can be used as a starting point for developing your SubQuery project. It indexes all transfers on Acala network',
+  runner: {
+    node: {
+      name: '@subql/node',
+      version: '>=3.0.1',
+    },
+    query: {
+      name: '@subql/query',
+      version: '*',
+    },
+  },
+  schema: {
+    file: './schema.graphql',
+  },
+  network: {
+    /* The genesis hash of the network (hash of block 0) */
+    chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
+    /**
+     * This endpoint must be a public non-pruned archive node
+     * Public nodes may be rate limited, which can affect indexing speed
+     * When developing your project we suggest getting a private API key
+     * You can get them from OnFinality for free https://app.onfinality.io
+     * https://documentation.onfinality.io/support/the-enhanced-api-service
+     */
+    endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws', 'wss://acala-rpc-0.aca-api.network'],
+    dictionary: 'https://api.subquery.network/sq/subquery/acala-dictionary',
+    chaintypes: {
+      file: './dist/chaintypes.js',
+    },
+  },
+  dataSources: [
+    {
+      kind: SubstrateDatasourceKind.Runtime,
+      startBlock: 1,
+      mapping: {
+        file: './dist/index.js',
+        handlers: [
+          /*{
+                      kind: SubstrateHandlerKind.Block,
+                      handler: "handleBlock",
+                      filter: {
+                        modulo: 100,
+                      },
+                    },*/
+          /*{
+                      kind: SubstrateHandlerKind.Call,
+                      handler: "handleCall",
+                      filter: {
+                        module: "balances",
+                      },
+                    },*/
+          {
+            kind: SubstrateHandlerKind.Event,
+            handler: 'handleEvent',
+            filter: {
+              module: 'balances',
+              method: 'Transfer',
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export default project;

--- a/packages/cli/test/schemaTest/project.ts
+++ b/packages/cli/test/schemaTest/project.ts
@@ -26,16 +26,8 @@ const project: SubstrateProject = {
     file: './schema.graphql',
   },
   network: {
-    /* The genesis hash of the network (hash of block 0) */
     chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
-    /**
-     * This endpoint must be a public non-pruned archive node
-     * Public nodes may be rate limited, which can affect indexing speed
-     * When developing your project we suggest getting a private API key
-     * You can get them from OnFinality for free https://app.onfinality.io
-     * https://documentation.onfinality.io/support/the-enhanced-api-service
-     */
-    endpoint: ['https://zzz', 'https://bbb'],
+    endpoint: ['wss://acala-polkadot.api.onfinality.io/public-ws', 'wss://acala-rpc-0.aca-api.network'],
     dictionary: 'https://api.subquery.network/sq/subquery/acala-dictionary',
     chaintypes: {
       file: './dist/chaintypes.js',
@@ -48,20 +40,6 @@ const project: SubstrateProject = {
       mapping: {
         file: './dist/index.js',
         handlers: [
-          /*{
-                      kind: SubstrateHandlerKind.Block,
-                      handler: "handleBlock",
-                      filter: {
-                        modulo: 100,
-                      },
-                    },*/
-          /*{
-                      kind: SubstrateHandlerKind.Call,
-                      handler: "handleCall",
-                      filter: {
-                        module: "balances",
-                      },
-                    },*/
           {
             kind: SubstrateHandlerKind.Event,
             handler: 'handleEvent',

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -16,5 +16,6 @@
     {"path": "../utils"},
     {"path": "../validator"}
   ],
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["test/schemaTest/project.ts"]
 }

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -294,3 +294,36 @@ export class FileReferenceImp<T> implements ValidatorConstraintInterface {
 }
 
 export const tsProjectYamlPath = (tsManifestEntry: string) => tsManifestEntry.replace('.ts', '.yaml');
+
+export function findReplace(manifest: string, replacer: RegExp, value: string): string {
+  return manifest.replace(replacer, value);
+}
+
+// export function finder(manifest: string, reg: RegExp): string {
+//   return manifest.match(reg)
+// }
+export function extractDefaults(manifest: string): {[key: string]: string | string[] | null} {
+  const patterns: {[key: string]: RegExp} = {
+    specVersion: /specVersion:\s*["'](.*?)["']/, // this should always be 1.0.0
+    // repository: /repository:\s*["'](.*?)["']/,
+    // author will also be moved to package.json
+    // description: /description:\s*["'](.*?)["']/, should be from package.json
+    endpoint: /endpoint:\s*\[\s*([\s\S]*?)\s*\]/,
+  };
+
+  const result: {[key: string]: string | string[] | null} = {};
+
+  for (const key in patterns) {
+    const match = manifest.match(patterns[key]);
+    if (key === 'endpoint' && match) {
+      result[key] = match[1]
+        .split(',')
+        .map((s) => s.trim().replace(/^"(.+?)"$/, '$1'))
+        .filter(Boolean);
+    } else {
+      result[key] = match ? match[1] : null;
+    }
+  }
+
+  return result;
+}

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -294,36 +294,3 @@ export class FileReferenceImp<T> implements ValidatorConstraintInterface {
 }
 
 export const tsProjectYamlPath = (tsManifestEntry: string) => tsManifestEntry.replace('.ts', '.yaml');
-
-export function findReplace(manifest: string, replacer: RegExp, value: string): string {
-  return manifest.replace(replacer, value);
-}
-
-// export function finder(manifest: string, reg: RegExp): string {
-//   return manifest.match(reg)
-// }
-export function extractDefaults(manifest: string): {[key: string]: string | string[] | null} {
-  const patterns: {[key: string]: RegExp} = {
-    specVersion: /specVersion:\s*["'](.*?)["']/, // this should always be 1.0.0
-    // repository: /repository:\s*["'](.*?)["']/,
-    // author will also be moved to package.json
-    // description: /description:\s*["'](.*?)["']/, should be from package.json
-    endpoint: /endpoint:\s*\[\s*([\s\S]*?)\s*\]/,
-  };
-
-  const result: {[key: string]: string | string[] | null} = {};
-
-  for (const key in patterns) {
-    const match = manifest.match(patterns[key]);
-    if (key === 'endpoint' && match) {
-      result[key] = match[1]
-        .split(',')
-        .map((s) => s.trim().replace(/^"(.+?)"$/, '$1'))
-        .filter(Boolean);
-    } else {
-      result[key] = match ? match[1] : null;
-    }
-  }
-
-  return result;
-}

--- a/packages/validator/src/rules/require-valid-runner.ts
+++ b/packages/validator/src/rules/require-valid-runner.ts
@@ -13,7 +13,7 @@ export class RequireValidRunner implements Rule {
     const schema = ctx.data.schema;
     if (schema.isV1_0_0) {
       try {
-        schema.toDeployment();
+        schema.asImpl.deployment;
       } catch (e) {
         return false;
       }

--- a/packages/validator/src/validator.spec.ts
+++ b/packages/validator/src/validator.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {IPFS_NODE_ENDPOINT, NETWORK_FAMILY} from '@subql/common';
+import {IPFS_NODE_ENDPOINT} from '@subql/common';
 import {commonRules, deploymentRules} from './rules';
 import {Validator} from './validator';
 
@@ -14,6 +14,7 @@ describe('Validate project with manifest spec 1.0.0, auto identify network', () 
     expect(result.filter((r) => r.valid).length).toBe(result.length);
   });
 
+  // No longer supported ?
   it('should validate get reports', async () => {
     const url = 'https://github.com/subquery/tutorials-frontier-evm-starter';
     const v = await Validator.create(url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6246,6 +6246,7 @@ __metadata:
     fuzzy: ^0.1.3
     inquirer: ^8.2.0
     inquirer-autocomplete-prompt: ^1.4.0
+    json5: ^2.2.3
     node-fetch: 2.6.7
     oclif: ^3.15.0
     rimraf: ^3.0.2


### PR DESCRIPTION
# Description

Currently with the introduction of ts manifest, most of the pre-yarn yaml function are failing

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
