### PR TITLE
check for ts manifest before building it

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Codegen expecting a ts manifest but not a yaml manifest (#2084)
 
 ## [4.0.1] - 2023-10-10
 ### Fixed

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import {Command, Flags} from '@oclif/core';
 import glob from 'glob';
 import {runWebpack} from '../../controller/build-controller';
-import {resolveToAbsolutePath, buildManifestFromLocation} from '../../utils';
+import {resolveToAbsolutePath, buildManifestFromLocation, checkForTsManifest} from '../../utils';
 
 export default class Build extends Command {
   static description = 'Build this SubQuery project code';
@@ -27,6 +27,10 @@ export default class Build extends Command {
 
       assert(existsSync(location), 'Argument `location` is not a valid directory or file');
       const directory = lstatSync(location).isDirectory() ? location : path.dirname(location);
+
+      if (checkForTsManifest(location)) {
+        await buildManifestFromLocation(location, this);
+      }
 
       // Get the output location from the project package.json main field
       const pjson = JSON.parse(readFileSync(path.join(directory, 'package.json')).toString());

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1,7 +1,8 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {readFileSync} from 'fs';
+import assert from 'assert';
+import {existsSync, lstatSync, readFileSync} from 'fs';
 import path from 'path';
 import {Command, Flags} from '@oclif/core';
 import glob from 'glob';
@@ -24,7 +25,8 @@ export default class Build extends Command {
       const location = flags.location ? resolveToAbsolutePath(flags.location) : process.cwd();
       const isDev = flags.mode === 'development' || flags.mode === 'dev';
 
-      const directory = await buildManifestFromLocation(location, this);
+      assert(existsSync(location), 'Argument `location` is not a valid directory or file');
+      const directory = lstatSync(location).isDirectory() ? location : path.dirname(location);
 
       // Get the output location from the project package.json main field
       const pjson = JSON.parse(readFileSync(path.join(directory, 'package.json')).toString());

--- a/packages/cli/src/commands/codegen/index.ts
+++ b/packages/cli/src/commands/codegen/index.ts
@@ -4,7 +4,7 @@
 import {Command, Flags} from '@oclif/core';
 import {getProjectRootAndManifest, getSchemaPath} from '@subql/common';
 import {codegen} from '../../controller/codegen-controller';
-import {resolveToAbsolutePath, buildManifestFromLocation} from '../../utils';
+import {resolveToAbsolutePath, buildManifestFromLocation, checkForTsManifest} from '../../utils';
 
 export default class Codegen extends Command {
   static description = 'Generate schemas for graph node';
@@ -27,7 +27,9 @@ export default class Codegen extends Command {
 
     const projectPath = resolveToAbsolutePath(file ?? location ?? process.cwd());
 
-    await buildManifestFromLocation(projectPath, this);
+    if (checkForTsManifest(projectPath)) {
+      await buildManifestFromLocation(projectPath, this);
+    }
 
     const {manifests, root} = getProjectRootAndManifest(projectPath);
 

--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -51,3 +51,16 @@ async function generateManifestFromTs(projectManifestEntry: string, command: Com
     throw new Error(`Failed to build ${projectManifestEntry}: ${error}`);
   }
 }
+
+export function checkForTsManifest(location: string): boolean {
+  let projectManifestEntry: string;
+  if (lstatSync(location).isDirectory()) {
+    projectManifestEntry = path.join(location, DEFAULT_TS_MANIFEST);
+  } else if (lstatSync(location).isFile()) {
+    projectManifestEntry = location;
+  } else {
+    throw new Error('Argument `location` is not a valid directory or file');
+  }
+
+  return existsSync(projectManifestEntry) && projectManifestEntry.endsWith('.ts');
+}


### PR DESCRIPTION
# Description
Currently, codegen assumes that the default ts manifest exists and tries to build it. We should check if a ts manifest exists before building it

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
