### PR TITLE
skip managing connection pool for single endpoint

### DIFF
--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -99,7 +99,7 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
               if (await this.poolStateManager.getFieldValue(endpoint, 'rateLimited')) {
                 logger.info('throtling on ratelimited endpoint');
                 const backoffDelay = await this.poolStateManager.getFieldValue(endpoint, 'backoffDelay');
-                await delay(backoffDelay);
+                await delay(backoffDelay / 1000);
               }
 
               const start = Date.now();

--- a/packages/node-core/src/indexer/connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.ts
@@ -187,6 +187,9 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
   //eslint-disable-next-line @typescript-eslint/require-await
   async removeFromConnections(endpoint: string): Promise<void> {
     delete this.pool[endpoint];
+    if (Object.keys(this.pool).length === 0) {
+      process.exit(1);
+    }
   }
 
   //eslint-disable-next-line @typescript-eslint/require-await
@@ -198,7 +201,7 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
 
   //eslint-disable-next-line @typescript-eslint/require-await
   async handleApiError(endpoint: string, errorType: ApiErrorType): Promise<void> {
-    if (this.pool[endpoint].failed || this.pool[endpoint].rateLimited) {
+    if (Object.keys(this.pool).length === 1 || this.pool[endpoint].failed || this.pool[endpoint].rateLimited) {
       //if this api was used again then it must be in the same batch of blocks
       return;
     }

--- a/packages/node-core/src/indexer/connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.ts
@@ -3,13 +3,12 @@
 
 import {OnApplicationShutdown} from '@nestjs/common';
 import chalk from 'chalk';
-import {toNumber} from 'lodash';
 import {ApiErrorType} from '../api.connection.error';
 import {IApiConnectionSpecific} from '../api.service';
 import {getLogger} from '../logger';
 import {errorTypeToScoreAdjustment} from './connectionPool.service';
 
-const RETRY_DELAY = 60 * 1000;
+const RETRY_DELAY = 60; // second
 const MAX_FAILURES = 5;
 const RESPONSE_TIME_WEIGHT = 0.7;
 const FAILURE_WEIGHT = 0.3;

--- a/packages/node-core/src/indexer/connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.ts
@@ -8,7 +8,7 @@ import {IApiConnectionSpecific} from '../api.service';
 import {getLogger} from '../logger';
 import {errorTypeToScoreAdjustment} from './connectionPool.service';
 
-const RETRY_DELAY = 10 * 1000;
+const RETRY_DELAY = 60 * 1000;
 const MAX_FAILURES = 5;
 const RESPONSE_TIME_WEIGHT = 0.7;
 const FAILURE_WEIGHT = 0.3;

--- a/packages/node-core/src/indexer/connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.ts
@@ -91,6 +91,7 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
 
       if (rateLimitedEndpoints.length === 0) {
         // If no rate-limited endpoints found, return undefined
+        // FIXME: We better block the promise until one endpoint is recovered from suspension
         return undefined;
       }
 

--- a/packages/node-core/src/indexer/connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.ts
@@ -8,7 +8,7 @@ import {IApiConnectionSpecific} from '../api.service';
 import {getLogger} from '../logger';
 import {errorTypeToScoreAdjustment} from './connectionPool.service';
 
-const RETRY_DELAY = 60; // second
+const RETRY_DELAY = 10 * 1000;
 const MAX_FAILURES = 5;
 const RESPONSE_TIME_WEIGHT = 0.7;
 const FAILURE_WEIGHT = 0.3;


### PR DESCRIPTION
# Description
I have encountered connection recovering issue when single endpoint was used, and the total connections was drop to 0.

This pr is to skip that part of logic.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
