### PR TITLE
Fix issue with options not being clonable

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Store operations failing with workers when options are provided (#2092)
 
 ## [6.0.0] - 2023-10-11
 ### Changed
@@ -423,7 +425,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move blockchain agnostic code from `node` to `node-core` package. (#1222)
 
 [Unreleased]: https://github.com/subquery/subql/compare/node-core/6.0.0...HEAD
-[5.0.4]: https://github.com/subquery/subql/compare/node-core/5.0.3...node-core/6.0.0
+[6.0.0]: https://github.com/subquery/subql/compare/node-core/5.0.3...node-core/6.0.0
 [5.0.3]: https://github.com/subquery/subql/compare/node-core/5.0.2...node-core/5.0.3
 [5.0.2]: https://github.com/subquery/subql/compare/node-core/5.0.1...node-core/5.0.2
 [5.0.1]: https://github.com/subquery/subql/compare/node-core/4.2.3...node-core/5.0.1

--- a/packages/node-core/src/indexer/worker/test.store.worker.ts
+++ b/packages/node-core/src/indexer/worker/test.store.worker.ts
@@ -1,0 +1,25 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {Store} from '@subql/types-core';
+import {WorkerHost} from './worker.builder';
+import {hostStoreKeys, hostStoreToStore} from './worker.store.service';
+
+let store: Store | null = null;
+
+async function callStoreFunction(name: string, args: any[]) {
+  if (store === null) {
+    throw new Error('Store is null');
+  }
+  const res = await (store as any)[name as any](...args);
+}
+
+const host = WorkerHost.create(
+  hostStoreKeys,
+  {
+    callStoreFunction,
+  },
+  null as any
+);
+
+store = hostStoreToStore(host as any);

--- a/packages/node-core/src/indexer/worker/worker.builder.ts
+++ b/packages/node-core/src/indexer/worker/worker.builder.ts
@@ -176,7 +176,6 @@ export class Worker<T extends AsyncMethods> extends WorkerIO {
     super(worker, workerFns as string[], hostFns, getLogger(`worker: ${worker.threadId}`));
 
     this.worker.on('error', (error) => {
-      console.log('WORKRE ERRIR', error);
       this.logger.error(error, 'Worker error');
     });
 

--- a/packages/node-core/src/indexer/worker/worker.builder.ts
+++ b/packages/node-core/src/indexer/worker/worker.builder.ts
@@ -166,10 +166,17 @@ export class WorkerHost<T extends AsyncMethods> extends WorkerIO {
 export class Worker<T extends AsyncMethods> extends WorkerIO {
   private _reqCounter = 0;
 
-  private constructor(private worker: workers.Worker, workerFns: (keyof T)[], hostFns: AsyncMethods) {
+  /**
+   * @param worker - the nodejs worker
+   * @param workerFns - functions that the worker exposes to be called from the main thread
+   * @param hostFns - functions the host exposes to the worker
+   * @param exitMain - if true, when a worker exits the host will also exit
+   * */
+  private constructor(private worker: workers.Worker, workerFns: (keyof T)[], hostFns: AsyncMethods, exitMain = true) {
     super(worker, workerFns as string[], hostFns, getLogger(`worker: ${worker.threadId}`));
 
     this.worker.on('error', (error) => {
+      console.log('WORKRE ERRIR', error);
       this.logger.error(error, 'Worker error');
     });
 
@@ -179,7 +186,9 @@ export class Worker<T extends AsyncMethods> extends WorkerIO {
 
     this.worker.on('exit', (code) => {
       this.logger.error(`Worker exited with code ${code}`);
-      process.exit(code);
+      if (exitMain) {
+        process.exit(code);
+      }
     });
   }
 
@@ -187,14 +196,16 @@ export class Worker<T extends AsyncMethods> extends WorkerIO {
     path: string,
     workerFns: (keyof T)[],
     hostFns: H,
-    root: string
+    root: string,
+    exitMain = true
   ): Worker<T> & T {
     const worker = new Worker(
       new workers.Worker(path, {
         argv: [...process.argv, '--root', root],
       }),
       workerFns,
-      hostFns
+      hostFns,
+      exitMain
     );
 
     return worker as Worker<T> & T;

--- a/packages/node-core/src/indexer/worker/worker.store.service.test.ts
+++ b/packages/node-core/src/indexer/worker/worker.store.service.test.ts
@@ -1,0 +1,89 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import assert from 'assert';
+import path from 'path';
+import {Store, Entity, FunctionPropertyNames} from '@subql/types-core';
+import {Worker} from './worker.builder';
+import {HostStore, storeHostFunctions} from './worker.store.service';
+
+type EntityProps = Omit<EntityCls, NonNullable<FunctionPropertyNames<EntityCls>> | '_name'>;
+
+class EntityCls implements Entity {
+  constructor(public id: string, public field: string) {}
+
+  get _name(): string {
+    return 'EntityCls';
+  }
+
+  async save(): Promise<void> {
+    return Promise.resolve();
+  }
+  static async remove(id: string): Promise<void> {
+    assert(id !== null, 'Cannot remove Entity entity without an ID');
+    return Promise.resolve();
+  }
+
+  static async get(id: string): Promise<EntityCls | undefined> {
+    assert(id !== null && id !== undefined, 'Cannot get Entity entity without an ID');
+    return Promise.resolve(undefined);
+  }
+
+  static create(record: EntityProps): EntityCls {
+    assert(typeof record.id === 'string', 'id must be provided');
+    const entity = new this(record.id, record.field);
+    Object.assign(entity, record);
+    return entity;
+  }
+}
+
+type TestWorker = {callStoreFunction: (name: string, args: any[]) => Promise<void>};
+
+describe('Worker Store Service', () => {
+  let store: Store;
+  let worker: Worker<HostStore> & TestWorker;
+
+  beforeEach(() => {
+    store = {
+      get: jest.fn(),
+      getByField: jest.fn(() => Promise.resolve([/*{ field: '1'} as any*/ new EntityCls('1', '1') as any])),
+      getByFields: jest.fn(),
+      getOneByField: jest.fn(),
+      set: jest.fn(),
+      bulkCreate: jest.fn(),
+      bulkUpdate: jest.fn(),
+      remove: jest.fn(),
+      bulkRemove: jest.fn(),
+    };
+
+    worker = Worker.create<TestWorker, HostStore>(
+      path.resolve(__dirname, '../../../dist/indexer/worker/test.store.worker.js'),
+      ['callStoreFunction'],
+      storeHostFunctions(store),
+      '', // ROOT not needed,
+      false
+    );
+  });
+
+  afterEach(async () => {
+    await worker.terminate();
+  });
+
+  it('can make a request with an object', async () => {
+    const spy = jest.spyOn(store, 'getByField');
+
+    await worker.callStoreFunction('getByField', ['Entity', 'field', '1', {offset: 0, limit: 1}]);
+
+    expect(spy).toHaveBeenCalledWith('Entity', 'field', '1', {offset: 0, limit: 1});
+  });
+
+  it('can make a respone with an object', async () => {
+    const spy = jest.spyOn(store, 'set');
+
+    const entity = new EntityCls('1', '1');
+
+    await worker.callStoreFunction('set', ['Entity', '1', entity]);
+
+    expect(spy).toHaveBeenCalledWith('Entity', '1', entity);
+  });
+});

--- a/packages/node-core/src/indexer/worker/worker.store.service.ts
+++ b/packages/node-core/src/indexer/worker/worker.store.service.ts
@@ -1,8 +1,26 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {Store,FieldsExpression} from '@subql/types-core';
-import {classToPlain} from 'class-transformer';
+import * as util from 'util';
+import {Store, FieldsExpression} from '@subql/types-core';
+
+/**
+ * Proxy objects aren't serializable between worker threads.
+ * VM2 Seems to have objects come out as proxy objects.
+ * NOTE do not use this on return types, if used on an entity it would strip all functions and have a plain object
+ * */
+function unwrapProxy<T = any>(input: T): T {
+  if (!util.types.isProxy(input)) {
+    return input;
+  }
+
+  return {...input};
+}
+
+/* Unwraps any arguments to a function that are proxy objects */
+function unwrapProxyArgs<T extends Array<any>, R>(fn: (...args: T) => R): (...args: T) => R {
+  return (...args: T) => fn(...(args.map(unwrapProxy) as T));
+}
 
 export type HostStore = {
   // This matches the store interface
@@ -42,15 +60,15 @@ export const hostStoreKeys: (keyof HostStore)[] = [
 // We don't need the funcitons to be included
 export const hostStoreToStore = (host: HostStore): Store => {
   return {
-    get: host.storeGet,
-    getByField: host.storeGetByField,
-    getByFields: host.storeGetByFields,
-    getOneByField: host.storeGetOneByField,
-    set: (entity, id, data) => host.storeSet(entity, id, classToPlain(data)),
-    bulkCreate: (entity, data) => host.storeBulkCreate(entity, classToPlain(data) as any[]),
-    bulkUpdate: (entity, data, fields) => host.storeBulkUpdate(entity, classToPlain(data) as any[], fields),
-    remove: host.storeRemove,
-    bulkRemove: host.storeBulkRemove,
+    get: unwrapProxyArgs(host.storeGet),
+    getByField: unwrapProxyArgs(host.storeGetByField),
+    getByFields: unwrapProxyArgs(host.storeGetByFields),
+    getOneByField: unwrapProxyArgs(host.storeGetOneByField),
+    set: unwrapProxyArgs(host.storeSet),
+    bulkCreate: unwrapProxyArgs(host.storeBulkCreate),
+    bulkUpdate: unwrapProxyArgs(host.storeBulkUpdate),
+    remove: unwrapProxyArgs(host.storeRemove),
+    bulkRemove: unwrapProxyArgs(host.storeBulkRemove),
   };
 };
 


### PR DESCRIPTION
# Description
Objects coming out of the sandbox are proxy objects, they cannot be passed though worker threads to the host/main thread. We previously had fixes for the entities but not options. 

We now check if they are proxy objects and if they are we clone them, this works for entities and options as well as any other possible proxy objects.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
