### PR TITLE
error handle on generate command

### DIFF
--- a/packages/cli/src/commands/codegen/generate.ts
+++ b/packages/cli/src/commands/codegen/generate.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import {EventFragment, FunctionFragment} from '@ethersproject/abi/src.ts/fragments';
 import {Command, Flags} from '@oclif/core';
-import {getProjectRootAndManifest} from '@subql/common';
+import {DEFAULT_TS_MANIFEST, getProjectRootAndManifest} from '@subql/common';
 import {SubqlRuntimeDatasource as EthereumDs} from '@subql/types-ethereum';
 import {parseContractPath} from 'typechain';
 import {
@@ -49,6 +49,9 @@ export default class Generate extends Command {
     const {abiPath, address, events, file, functions, startBlock} = flags;
 
     const projectPath = path.resolve(file ?? process.cwd());
+    if (fs.existsSync(path.join(projectPath, DEFAULT_TS_MANIFEST))) {
+      throw new Error('generate does not yet support ts manifest');
+    }
     const {manifests, root} = getProjectRootAndManifest(projectPath);
 
     const abiName = parseContractPath(abiPath).name;


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

`codegen:generate` is not yet supported by ts-manifest, should throw appropriate error accordingly

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
