### PR TITLE
Catch error with dictionary validation

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Dictionary validation error causing application exit (#2101)
 
 ## [6.0.2] - 2023-10-12
 ### Fixed

--- a/packages/node-core/src/indexer/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary.service.ts
@@ -427,22 +427,27 @@ export class DictionaryService {
 
   private dictionaryValidation(metaData?: MetaData, startBlockHeight?: number): boolean {
     const validate = (): boolean => {
-      if (!metaData) {
-        return false;
-      }
-      // Some dictionaries rely on chain others rely on genesisHash
-      if (!this.validateChainMeta(metaData)) {
-        logger.error(
-          'The dictionary that you have specified does not match the chain you are indexing, it will be ignored. Please update your project manifest to reference the correct dictionary'
-        );
-        return false;
-      }
+      try {
+        if (!metaData) {
+          return false;
+        }
+        // Some dictionaries rely on chain others rely on genesisHash
+        if (!this.validateChainMeta(metaData)) {
+          logger.error(
+            'The dictionary that you have specified does not match the chain you are indexing, it will be ignored. Please update your project manifest to reference the correct dictionary'
+          );
+          return false;
+        }
 
-      if (startBlockHeight !== undefined && metaData.lastProcessedHeight < startBlockHeight) {
-        logger.warn(`Dictionary indexed block is behind current indexing block height`);
+        if (startBlockHeight !== undefined && metaData.lastProcessedHeight < startBlockHeight) {
+          logger.warn(`Dictionary indexed block is behind current indexing block height`);
+          return false;
+        }
+        return true;
+      } catch (e: any) {
+        logger.error(e, 'Unable to validate dictionary metadata');
         return false;
       }
-      return true;
     };
 
     const valid = validate();


### PR DESCRIPTION
# Description
If the dictionary returns invalid metadata then validation can throw an error (e.g genesis hash is undefined). This will now catch the error and fail validation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
