### PR TITLE
Fix issues when flushing the auto queue

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Auto queue flush getting the queue into a bad state (#2103)
 
 ## [6.0.2] - 2023-10-12
 ### Fixed

--- a/packages/node-core/src/utils/autoQueue.spec.ts
+++ b/packages/node-core/src/utils/autoQueue.spec.ts
@@ -29,6 +29,7 @@ describe('AutoQueue', () => {
   it('doesnt resolve tasks if flush is called', async () => {
     const autoQueue = new AutoQueue<number>(10, 2);
     const results: number[] = [];
+    let abortedCount = 0;
 
     const tasks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((v) => async () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -37,9 +38,14 @@ describe('AutoQueue', () => {
     });
 
     tasks.map((t) => {
-      void autoQueue.put(t).then((r) => {
-        results.push(r);
-      });
+      void autoQueue
+        .put(t)
+        .then((r) => {
+          results.push(r);
+        })
+        .catch((e) => {
+          abortedCount++;
+        });
     });
 
     // Wait for some tasks to complete
@@ -53,6 +59,8 @@ describe('AutoQueue', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     expect(results).toEqual([1, 2]);
+    // Match concurrency
+    expect(abortedCount).toEqual(2);
   });
 
   it('has a cap on the number of out of order tasks', async () => {
@@ -75,7 +83,7 @@ describe('AutoQueue', () => {
           results.push(r);
         })
       )
-    ).rejects.toEqual(new Error('timeout'));
+    ).rejects.toEqual(new Error('Auto queue process task timeout in 0.2 seconds. Please increase --timeout'));
   });
 
   it('can adjust the parallelism while running', async () => {
@@ -141,5 +149,48 @@ describe('AutoQueue', () => {
 
     // Assertions done, complete the task
     resolveFn();
+  });
+
+  it('resumes after flushing', async () => {
+    const autoQueue = new AutoQueue<number>(10, 2, 1);
+
+    const results: number[] = [];
+
+    const tasks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((v) => async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      return v;
+    });
+
+    tasks.map((t) => {
+      void autoQueue
+        .put(t)
+        .then((r) => {
+          results.push(r);
+        })
+        .catch((e) => {
+          // We expect some to throw as they get flushed
+        });
+    });
+
+    // Wait for some tasks to complete
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    autoQueue.flush();
+
+    const tasks2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((v) => async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return v;
+    });
+
+    await Promise.all(
+      tasks2.map((t) => {
+        return autoQueue.put(t).then((r) => {
+          results.push(r + 10);
+        });
+      })
+    );
+
+    expect(results).toEqual([1, 2, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
   });
 });


### PR DESCRIPTION
# Description
When flushing the auto queue any pending tasks would be added to out of order tasks, we now add a check to see if a flush has happened

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
