### PR TITLE
Fix store methods failing with workers when arrays are used

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Store bulk methods failing with workers (#2107)
 
 ## [6.0.3] - 2023-10-17
 ### Fixed

--- a/packages/node-core/src/indexer/worker/worker.store.service.ts
+++ b/packages/node-core/src/indexer/worker/worker.store.service.ts
@@ -11,6 +11,11 @@ import {instanceToPlain} from 'class-transformer';
  * NOTE do not use this on return types, if used on an entity it would strip all functions and have a plain object
  * */
 function unwrapProxy<T = any>(input: T): T {
+  // Arrays are not proxy objects but their contents might be. This applies to bulkCreate and bulkUpdate
+  if (Array.isArray(input) && input.length && util.types.isProxy(input[0])) {
+    return instanceToPlain(input) as T;
+  }
+
   if (!util.types.isProxy(input)) {
     return input;
   }


### PR DESCRIPTION
# Description
Fix store methods failing with workers when arrays are used. Specifically with bulk store methods

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
