### PR TITLE
Fix poi migration init check

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed poi migration init check, and improve logging 
+
 ## [6.0.4] - 2023-10-18
 ### Fixed
 - Store bulk methods failing with workers (#2107)

--- a/packages/node-core/src/indexer/poi/poi.service.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.ts
@@ -53,7 +53,7 @@ export class PoiService implements OnApplicationShutdown {
     }
     const latestSyncedPoiHeight = await this.storeCache.metadata.find('latestSyncedPoiHeight');
     const poiDataExist = await this._poiRepo?.model.findOne();
-    if (latestSyncedPoiHeight === undefined && poiDataExist !== undefined && poiDataExist !== null) {
+    if (latestSyncedPoiHeight === undefined && !!poiDataExist) {
       await this.migratePoi(schema);
     }
   }

--- a/packages/node-core/src/indexer/poi/poi.service.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.ts
@@ -48,8 +48,12 @@ export class PoiService implements OnApplicationShutdown {
    */
   async init(schema: string): Promise<void> {
     this._poiRepo = this.storeCache.poi ?? undefined;
+    if (!this._poiRepo) {
+      return;
+    }
     const latestSyncedPoiHeight = await this.storeCache.metadata.find('latestSyncedPoiHeight');
-    if (latestSyncedPoiHeight === undefined) {
+    const poiDataExist = await this._poiRepo?.model.findOne();
+    if (latestSyncedPoiHeight === undefined && poiDataExist !== undefined && poiDataExist !== null) {
       await this.migratePoi(schema);
     }
   }

--- a/packages/node-core/src/indexer/poi/poi.service.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.ts
@@ -52,8 +52,7 @@ export class PoiService implements OnApplicationShutdown {
       return;
     }
     const latestSyncedPoiHeight = await this.storeCache.metadata.find('latestSyncedPoiHeight');
-    const poiDataExist = await this._poiRepo?.model.findOne();
-    if (latestSyncedPoiHeight === undefined && !!poiDataExist) {
+    if (latestSyncedPoiHeight === undefined) {
       await this.migratePoi(schema);
     }
   }
@@ -65,14 +64,13 @@ export class PoiService implements OnApplicationShutdown {
    */
   private async migratePoi(schema: string): Promise<void> {
     try {
-      logger.info('Migrating POI table, this may take some time');
       // Remove and Change column from sequelize not work, it only applies to public schema
       // https://github.com/sequelize/sequelize/issues/13365
       // await this.poiRepo?.model.sequelize?.getQueryInterface().changeColumn(tableName,'mmrRoot',{})
       const tableName = this.poiRepo.model.getTableName().toString();
       const checkAttributesQuery = `SELECT
-        (NOT EXISTS (SELECT 1 FROM ${tableName} WHERE "operationHashRoot" IS NOT NULL)) AS operationHashRoot_nullable,
-        (NOT EXISTS (SELECT 1 FROM ${tableName} WHERE "chainBlockHash" IS NOT NULL)) AS chainBlockHash_nullable,
+        (NOT EXISTS (SELECT 1 FROM ${tableName} WHERE "operationHashRoot" IS NOT NULL)) AS operationhashroot_nullable,
+        (NOT EXISTS (SELECT 1 FROM ${tableName} WHERE "chainBlockHash" IS NOT NULL)) AS chainblockhash_nullable,
         (NOT EXISTS (SELECT 1 FROM ${tableName} WHERE "hash" IS NOT NULL)) AS hash_nullable,
         (NOT EXISTS (SELECT 1 FROM ${tableName} WHERE "parentHash" IS NOT NULL)) AS parent_nullable,
         (EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = '_poi' AND column_name = 'mmrRoot' AND table_schema = '${schema}' )) AS mmr_exists;`;
@@ -91,10 +89,10 @@ export class PoiService implements OnApplicationShutdown {
           queries.push(`ALTER TABLE ${tableName} DROP COLUMN "mmrRoot";`);
           queries.push(`DROP TABLE IF EXISTS "${schema}"."_mmr";`);
         }
-        if (!checkResult.chainBlockHash_nullable) {
+        if (!checkResult.operationhashroot_nullable) {
           queries.push(`ALTER TABLE ${tableName} ALTER COLUMN "operationHashRoot" DROP NOT NULL;`);
         }
-        if (!checkResult.chainBlockHash_nullable) {
+        if (!checkResult.chainblockhash_nullable) {
           queries.push(`ALTER TABLE ${tableName} ALTER COLUMN "chainBlockHash" DROP NOT NULL;`);
           // keep existing chainBlockHash
           queries.push(
@@ -128,6 +126,7 @@ export class PoiService implements OnApplicationShutdown {
       }
 
       if (queries.length) {
+        logger.info('Migrating POI table, this may take some time');
         const tx = await this.poiRepo.model.sequelize?.transaction();
         if (!tx) {
           throw new Error(`Create transaction for poi migration got undefined!`);
@@ -146,10 +145,10 @@ export class PoiService implements OnApplicationShutdown {
           logger.info(`If file based mmr were used previously, it can be clean up mannually`);
         }
       }
+      logger.info('Migrating POI completed.');
     } catch (e) {
       throw new Error(`Failed to migrate poi table. {e}`);
     }
-    logger.info('Migrating POI completed.');
   }
 
   async rewind(targetBlockHeight: number, transaction: Transaction): Promise<void> {

--- a/packages/node-core/src/indexer/poi/poi.service.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.ts
@@ -140,12 +140,11 @@ export class PoiService implements OnApplicationShutdown {
           }
         }
         await tx.commit();
-        logger.info(`Successful migrate Poi`);
+        logger.info('Migrating POI completed.');
         if (checkResult?.mmr_exists) {
           logger.info(`If file based mmr were used previously, it can be clean up mannually`);
         }
       }
-      logger.info('Migrating POI completed.');
     } catch (e) {
       throw new Error(`Failed to migrate poi table. {e}`);
     }


### PR DESCRIPTION
# Description

Poi migration got triggered for new project. This is due to migration check query returned result does not support camel case, and this lead condition been true and migration sql got executed. 

![image](https://github.com/subquery/subql/assets/10431657/be678911-f2a2-43a0-835f-80d3e0085497)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
