### PR TITLE
Fix ts manifest build failing because of missing deps

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multichain support for TypeScript manifest (#2097)
 - Support for multi endpoints CLI deployment (#2117)
 
+### Fixed
+- Building TS manifest on Windows (#2118)
+
 ## [4.0.5] - 2023-10-18
 ### Changed
 - Update error handling on deployment commands (#2108)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
     "terser-webpack-plugin": "^5.3.7",
     "ts-loader": "^9.2.6",
     "tslib": "^2.3.1",
+    "typescript": ">=5.2.2",
     "update-notifier": "5.1.0",
     "webpack": "^5.76.0",
     "webpack-merge": "^5.8.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "simple-git": "^3.16.0",
     "terser-webpack-plugin": "^5.3.7",
     "ts-loader": "^9.2.6",
+    "ts-node": "^10.9.1",
     "tslib": "^2.3.1",
     "typescript": ">=5.2.2",
     "update-notifier": "5.1.0",

--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -23,6 +23,11 @@ const requireScriptWrapper = (scriptPath: string, outputPath: string): string =>
   `const yamlOutput = yaml.dump(project);` +
   `writeFileSync('${outputPath}', '# // Auto-generated , DO NOT EDIT\\n' + yamlOutput);`;
 
+// Replaces \ in path on windows that don't work with require
+function formatPath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
 export async function buildManifestFromLocation(location: string, command: Command): Promise<string> {
   let directory: string;
   let projectManifestEntry: string;
@@ -55,6 +60,7 @@ export async function buildManifestFromLocation(location: string, command: Comma
   }
   return directory;
 }
+
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function generateManifestFromTs(projectManifestEntry: string, command: Command): Promise<string> {
   assert(existsSync(projectManifestEntry), `${projectManifestEntry} does not exist`);
@@ -64,7 +70,10 @@ export async function generateManifestFromTs(projectManifestEntry: string, comma
     const tsNodeService = tsNode.register({transpileOnly: true});
 
     // Compile the above script
-    const script = tsNodeService.compile(requireScriptWrapper(projectManifestEntry, projectYamlPath), 'inline.ts');
+    const script = tsNodeService.compile(
+      requireScriptWrapper(formatPath(projectManifestEntry), formatPath(projectYamlPath)),
+      'inline.ts'
+    );
 
     // Run compiled code
     eval(script);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6246,6 +6246,7 @@ __metadata:
     terser-webpack-plugin: ^5.3.7
     ts-loader: ^9.2.6
     tslib: ^2.3.1
+    typescript: ">=5.2.2"
     update-notifier: 5.1.0
     webpack: ^5.76.0
     webpack-merge: ^5.8.0
@@ -21684,6 +21685,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:>=5.2.2":
+  version: 5.2.2
+  resolution: "typescript@npm:5.2.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^4.9.5":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
@@ -21691,6 +21702,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@>=5.2.2#~builtin<compat/typescript>":
+  version: 5.2.2
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=493e53"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6245,6 +6245,7 @@ __metadata:
     simple-git: ^3.16.0
     terser-webpack-plugin: ^5.3.7
     ts-loader: ^9.2.6
+    ts-node: ^10.9.1
     tslib: ^2.3.1
     typescript: ">=5.2.2"
     update-notifier: 5.1.0


### PR DESCRIPTION
# Description
A lot of users have been reporting this issue:
![Screenshot 2023-10-24 at 10 56 41 AM](https://github.com/subquery/subql/assets/3432810/06f83b10-b94d-4fad-a020-0aba71f00f15)

Instead of running another command and expecting ts-node to exist we now instead add typescript as a dependency. This fixes commands run from outside of a project directory from the global install.



Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
