### PR TITLE
Handle TaskFlushedErrors, add the ability to name auto queues

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Not handling TaskFlushedErrors in block dispatchers (#2120)
 
 ## [6.1.0] - 2023-10-20
 ### Added


### PR DESCRIPTION
# Description
Handle TaskFlushedErrors by swallowing them, they are expected when a new dynamic ds is created or a fork is detected.

Also added names to the queues to more easily debug and determine what queue an error is coming from

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
