### PR TITLE
Fix metadata increment values using actual values to increment by

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `processedBlockCount` and `schemaMigrationCount` metadata fields incrementing exponentially (#2136)
 
 ## [6.2.0] - 2023-10-31
 ### Fixed

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.spec.ts
@@ -1,0 +1,26 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {CacheMetadataModel} from './cacheMetadata';
+
+const incrementKey = 'processedBlockCount';
+
+describe('CacheMetadata', () => {
+  let cacheMetadata: CacheMetadataModel;
+
+  beforeEach(() => {
+    cacheMetadata = new CacheMetadataModel(null as any);
+  });
+
+  // Clearing the cache used to set the setCache and getCache to the same empty object
+  // The set cache has increment amounts while the get cache has the actual value
+  it('clears the caches properly', () => {
+    cacheMetadata.clear();
+
+    (cacheMetadata as any).getCache[incrementKey] = 100;
+
+    cacheMetadata.setIncrement(incrementKey);
+
+    expect((cacheMetadata as any).setCache[incrementKey]).toBe(1);
+  });
+});

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
@@ -3,6 +3,7 @@
 
 import assert from 'assert';
 import {Transaction} from '@subql/x-sequelize';
+import {getLogger} from '../..//logger';
 import {hasValue} from '../../utils';
 import {Metadata, MetadataKeys, MetadataRepo} from '../entities';
 import {Cacheable} from './cacheable';
@@ -139,7 +140,7 @@ export class CacheMetadataModel extends Cacheable implements ICachedModelControl
       newSetCache.lastProcessedHeight = this.setCache.lastProcessedHeight;
       this.flushableRecordCounter = 1;
     }
-    this.setCache = newSetCache;
-    this.getCache = newSetCache;
+    this.setCache = {...newSetCache};
+    this.getCache = {...newSetCache};
   }
 }


### PR DESCRIPTION
# Description
Fix metadata increment values using actual values to increment by. This impacted processedBlockCount and schemaMigrationsCount

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
