### PR TITLE
use dictionary registry if dictionary is not provided

### DIFF
--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -25,6 +25,7 @@ export interface IConfig {
   readonly primaryNetworkEndpoint?: string;
   readonly networkDictionary?: string;
   readonly dictionaryResolver?: string | false;
+  readonly dictionaryRegistry: string;
   readonly outputFmt?: 'json';
   readonly logLevel: LevelWithSilent;
   readonly queryLimit: number;
@@ -169,6 +170,14 @@ export class NodeConfig<C extends IConfig = IConfig> implements IConfig {
       return false;
     }
     return this._config.dictionaryResolver ?? 'https://kepler-auth.subquery.network';
+  }
+
+  get dictionaryRegistry(): string {
+    if (this._config.dictionaryRegistry) {
+      return this._config.dictionaryRegistry;
+    }
+
+    return 'https://github.com/subquery/templates/raw/main/dictionary.json';
   }
 
   get timeout(): number {

--- a/packages/node-core/src/indexer/dictionary.service.test.ts
+++ b/packages/node-core/src/indexer/dictionary.service.test.ts
@@ -3,6 +3,7 @@
 
 import assert from 'assert';
 import {EventEmitter2} from '@nestjs/event-emitter';
+import {NETWORK_FAMILY} from '@subql/common';
 import {SubstrateDatasourceKind, SubstrateHandlerKind} from '@subql/types';
 import {DictionaryQueryEntry} from '@subql/types-core';
 import {range} from 'lodash';
@@ -354,4 +355,14 @@ describe('DictionaryService', () => {
   });
 
   // TODO write a test that queries over 2 block ranges in case DS has been removed
+
+  it('can use the dictionary registry to resolve a url', async () => {
+    const dictUrl: string = await (DictionaryService as any).resolveDictionary(
+      NETWORK_FAMILY.ethereum,
+      1,
+      'https://github.com/subquery/templates/raw/main/dictionary.json'
+    );
+
+    expect(dictUrl).toEqual('https://dict-tyk.subquery.network/query/eth-mainnet');
+  });
 });

--- a/packages/node/src/configure/SubqueryProject.ts
+++ b/packages/node/src/configure/SubqueryProject.ts
@@ -28,11 +28,14 @@ import {
 } from '@subql/types';
 import { ParentProject, Reader, RunnerSpecs } from '@subql/types-core';
 import { buildSchemaFromString } from '@subql/utils';
+import axios from 'axios';
 import Cron from 'cron-converter';
 import { GraphQLSchema } from 'graphql';
 import { getChainTypes } from '../utils/project';
 
 const { version: packageVersion } = require('../../package.json');
+const DICTIONARY_REGISTRY =
+  'https://raw.githubusercontent.com/subquery/templates/main/dist/dictionary.json';
 
 export type SubstrateProjectDs = SubqlProjectDs<SubstrateDatasource>;
 export type SubqlProjectDsTemplate =
@@ -151,6 +154,22 @@ async function loadProjectFromManifestBase(
       `Network endpoint must be provided for network. chainId="${network.chainId}"`,
     ),
   );
+
+  if (!projectManifest.network.dictionary) {
+    try {
+      const response = await axios.get(DICTIONARY_REGISTRY);
+      const dictionaryJson = response.data;
+
+      const dictionaries =
+        dictionaryJson.polkadot[projectManifest.network.chainId];
+
+      if (Array.isArray(dictionaries) && dictionaries.length > 0) {
+        projectManifest.network.dictionary = dictionaries[0];
+      }
+    } catch (error) {
+      console.error('An error occurred while fetching the dictionary:', error);
+    }
+  }
 
   let schemaString: string;
   try {

--- a/packages/node/src/configure/SubqueryProject.ts
+++ b/packages/node/src/configure/SubqueryProject.ts
@@ -28,14 +28,12 @@ import {
 } from '@subql/types';
 import { ParentProject, Reader, RunnerSpecs } from '@subql/types-core';
 import { buildSchemaFromString } from '@subql/utils';
-import axios from 'axios';
+
 import Cron from 'cron-converter';
 import { GraphQLSchema } from 'graphql';
 import { getChainTypes } from '../utils/project';
 
 const { version: packageVersion } = require('../../package.json');
-const DICTIONARY_REGISTRY =
-  'https://raw.githubusercontent.com/subquery/templates/main/dist/dictionary.json';
 
 export type SubstrateProjectDs = SubqlProjectDs<SubstrateDatasource>;
 export type SubqlProjectDsTemplate =
@@ -154,22 +152,6 @@ async function loadProjectFromManifestBase(
       `Network endpoint must be provided for network. chainId="${network.chainId}"`,
     ),
   );
-
-  if (!projectManifest.network.dictionary) {
-    try {
-      const response = await axios.get(DICTIONARY_REGISTRY);
-      const dictionaryJson = response.data;
-
-      const dictionaries =
-        dictionaryJson.polkadot[projectManifest.network.chainId];
-
-      if (Array.isArray(dictionaries) && dictionaries.length > 0) {
-        projectManifest.network.dictionary = dictionaries[0];
-      }
-    } catch (error) {
-      console.error('An error occurred while fetching the dictionary:', error);
-    }
-  }
 
   let schemaString: string;
   try {

--- a/packages/node/src/indexer/dictionary.service.test.ts
+++ b/packages/node/src/indexer/dictionary.service.test.ts
@@ -31,7 +31,7 @@ const nodeConfig = new NodeConfig({
 describe('DictionaryService', () => {
   it('should return all specVersion', async () => {
     const project = testSubqueryProject();
-    const dictionaryService = new DictionaryService(
+    const dictionaryService = await DictionaryService.create(
       project,
       nodeConfig,
       new EventEmitter2(),
@@ -44,7 +44,7 @@ describe('DictionaryService', () => {
 
   it('not use dictionary if endpoint genesisHash is not match with metadata', async () => {
     const project = testSubqueryProject();
-    const dictionaryService = new DictionaryService(
+    const dictionaryService = await DictionaryService.create(
       project,
       nodeConfig,
       new EventEmitter2(),

--- a/packages/node/src/indexer/fetch.module.ts
+++ b/packages/node/src/indexer/fetch.module.ts
@@ -124,7 +124,22 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
     ConnectionPoolService,
     IndexingBenchmarkService,
     PoiBenchmarkService,
-    DictionaryService,
+    {
+      provide: DictionaryService,
+      useFactory: async (
+        project: SubqueryProject,
+        nodeConfig: NodeConfig,
+        eventEmitter: EventEmitter2,
+      ) => {
+        const dictionaryService = await DictionaryService.create(
+          project,
+          nodeConfig,
+          eventEmitter,
+        );
+        return dictionaryService;
+      },
+      inject: ['ISubqueryProject', NodeConfig, EventEmitter2],
+    },
     SandboxService,
     DsProcessorService,
     DynamicDsService,

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -91,6 +91,12 @@ export const yargsOptions = yargs(hideBin(process.argv))
               'Dictionary query max block size, this specify the block height range of the dictionary query',
             type: 'number',
           },
+          'dictionary-registry': {
+            demandOption: false,
+            describe:
+              'Url to a dictionary registry used to resolve dictionary if one is not provided',
+            type: 'string',
+          },
           'disable-historical': {
             demandOption: false,
             describe: 'Disable storing historical state entities',


### PR DESCRIPTION
# Description
Use dictionary registry if dictionary endpoint is not provided in the manifest

Fixes #2119 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
