### PR TITLE
Further reindex improvement

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Fix reindex targetHeight issue introduced in #2131 (#2138)
 - `processedBlockCount` and `schemaMigrationCount` metadata fields incrementing exponentially (#2136)
 
 ## [6.2.0] - 2023-10-31

--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -895,65 +895,49 @@ async function batchDeleteAndThenUpdate(
   targetBlockHeight: number,
   batchSize = 10000
 ): Promise<void> {
-  let offset = 0;
-  let completed = false;
-  // eslint-disable-next-line no-constant-condition
-  while (!completed) {
+  let destroyCompleted = false;
+  let updateCompleted = false;
+  while (!destroyCompleted || !updateCompleted) {
     try {
-      const [recordsToUpdate, recordsToDelete] = await Promise.all([
-        model.findAll({
-          transaction,
-          limit: batchSize,
-          attributes: {include: ['_id']},
-          offset, // We need to apply offset, because after update the records, the record could still with in range, avoid endless query here.
-          where: {
-            __block_range: {
-              [Op.contains]: targetBlockHeight,
-            },
-          },
-        }),
-        model.findAll({
-          transaction,
-          limit: batchSize,
-          attributes: {include: ['_id']},
-          where: sequelize.where(sequelize.fn('lower', sequelize.col('_block_range')), Op.gt, targetBlockHeight),
-        }),
-      ]);
-      if (recordsToDelete.length === 0 && recordsToUpdate.length === 0) {
-        break;
-        completed = true;
-      }
-      logger.debug(
-        `Found ${model.name} recordsToDelete ${recordsToDelete.length},recordsToUpdate ${recordsToUpdate.length}`
-      );
-      if (recordsToDelete.length) {
-        await model.destroy({
-          transaction,
-          hooks: false,
-          where: {
-            _id: {
-              [Op.in]: recordsToDelete.map((record) => record.dataValues._id),
-            },
-          },
-        });
-      }
-      if (recordsToUpdate.length) {
-        await model.update(
-          {
-            __block_range: sequelize.fn('int8range', sequelize.fn('lower', sequelize.col('_block_range')), null),
-          },
-          {
-            transaction,
-            hooks: false,
-            where: {
-              _id: {
-                [Op.in]: recordsToUpdate.map((record) => record.dataValues._id),
+      const [numDestroyRows, [numUpdatedRows]] = await Promise.all([
+        destroyCompleted
+          ? 0
+          : model.destroy({
+              transaction,
+              hooks: false,
+              limit: batchSize,
+              where: sequelize.where(sequelize.fn('lower', sequelize.col('_block_range')), Op.gt, targetBlockHeight),
+            }),
+        updateCompleted
+          ? [0]
+          : model.update(
+              {
+                __block_range: sequelize.fn('int8range', sequelize.fn('lower', sequelize.col('_block_range')), null),
               },
-            },
-          }
-        );
+              {
+                transaction,
+                limit: batchSize,
+                hooks: false,
+                where: {
+                  [Op.and]: [
+                    {
+                      __block_range: {
+                        [Op.contains]: targetBlockHeight,
+                      },
+                    },
+                    sequelize.where(sequelize.fn('upper', sequelize.col('_block_range')), Op.not, null),
+                  ],
+                },
+              }
+            ),
+      ]);
+      logger.info(`${model.name} deleted ${numDestroyRows} records, updated ${numUpdatedRows} records`);
+      if (numDestroyRows === 0) {
+        destroyCompleted = true;
       }
-      offset += batchSize;
+      if (numUpdatedRows === 0) {
+        updateCompleted = true;
+      }
     } catch (e) {
       throw new Error(`Reindex update model ${model.name} failed, please try to reindex again: ${e}`);
     }

--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -931,7 +931,7 @@ async function batchDeleteAndThenUpdate(
               }
             ),
       ]);
-      logger.info(`${model.name} deleted ${numDestroyRows} records, updated ${numUpdatedRows} records`);
+      logger.debug(`${model.name} deleted ${numDestroyRows} records, updated ${numUpdatedRows} records`);
       if (numDestroyRows === 0) {
         destroyCompleted = true;
       }


### PR DESCRIPTION
# Description

Reindex during indexing (not cli )is broken due to findAll logic has triggered a hook, and it is point to current index height.
The issue was introduced in #2131

![image](https://github.com/subquery/subql/assets/10431657/cd4b7979-df33-42a9-bfdb-abca741a2e87)


Current fix roll back to previous implementation, remove/up with a limit and also make sure modified records not be called again. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
