### PR TITLE
config dictionary query size

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `dictionaryQuerySize` to nodeConfig, so the block range in dictionary can be configurable. (#2139)
 ### Fixed
 - `processedBlockCount` and `schemaMigrationCount` metadata fields incrementing exponentially (#2136)
 

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -33,6 +33,7 @@ export interface IConfig {
   readonly proofOfIndex: boolean;
   readonly ipfs?: string;
   readonly dictionaryTimeout: number;
+  readonly dictionaryQuerySize: number;
   readonly workers?: number;
   readonly profiler?: boolean;
   readonly unsafe?: boolean;
@@ -68,6 +69,7 @@ const DEFAULT_CONFIG = {
   timestampField: true,
   proofOfIndex: false,
   dictionaryTimeout: 30,
+  dictionaryQuerySize: 10000,
   profiler: false,
   subscription: false,
   disableHistorical: false,
@@ -211,6 +213,10 @@ export class NodeConfig<C extends IConfig = IConfig> implements IConfig {
 
   get dictionaryTimeout(): number {
     return this._config.dictionaryTimeout;
+  }
+
+  get dictionaryQuerySize(): number {
+    return this._config.dictionaryQuerySize;
   }
 
   get ipfs(): string | undefined {

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -271,7 +271,6 @@ export abstract class BaseFetchService<
         /* queryEndBlock needs to be limited by the latest height or the maximum value of endBlock in datasources.
          * Dictionaries could be in the future depending on if they index unfinalized blocks or the node is using an RPC endpoint that is behind.
          */
-        this.nodeConfig.dictionaryTimeout;
         const queryEndBlock = Math.min(
           startBlockHeight + this.nodeConfig.dictionaryQuerySize,
           this.latestFinalizedHeight

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -17,7 +17,6 @@ import {DynamicDsService} from './dynamic-ds.service';
 import {IProjectService} from './types';
 
 const logger = getLogger('FetchService');
-const DICTIONARY_MAX_QUERY_SIZE = 10000;
 const CHECK_MEMORY_INTERVAL = 60000;
 
 export abstract class BaseFetchService<
@@ -272,7 +271,11 @@ export abstract class BaseFetchService<
         /* queryEndBlock needs to be limited by the latest height or the maximum value of endBlock in datasources.
          * Dictionaries could be in the future depending on if they index unfinalized blocks or the node is using an RPC endpoint that is behind.
          */
-        const queryEndBlock = Math.min(startBlockHeight + DICTIONARY_MAX_QUERY_SIZE, this.latestFinalizedHeight);
+        this.nodeConfig.dictionaryTimeout;
+        const queryEndBlock = Math.min(
+          startBlockHeight + this.nodeConfig.dictionaryQuerySize,
+          this.latestFinalizedHeight
+        );
         try {
           const dictionary = await this.dictionaryService.scopedDictionaryEntries(
             startBlockHeight,

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- With `dictionary-query-size` now dictionary can config the query block range(#2139)
 
 ## [3.2.0] - 2023-10-31
 ### Fixed

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -85,6 +85,12 @@ export const yargsOptions = yargs(hideBin(process.argv))
             describe: 'Max timeout for dictionary query',
             type: 'number',
           },
+          'dictionary-query-size': {
+            demandOption: false,
+            describe:
+              'Dictionary query max block size, this specify the block height range of the dictionary query',
+            type: 'number',
+          },
           'disable-historical': {
             demandOption: false,
             describe: 'Disable storing historical state entities',


### PR DESCRIPTION
# Description

allow dictionary query range configurable

`--dictionary-query-size=20000 --debug="dictionary"`

```
<dictionary> DEBUG query: query($events_0_0:String!,$events_0_1:String!,$events_1_0:String!,$events_1_1:String!,$events_2_0:String!,$events_2_1:String!,$events_3_0:String!,$events_3_1:String!,$events_4_0:String!,$events_4_1:String!){_metadata {lastProcessedHeight genesisHash }  events (filter:{or:[{and:[{module:{equalTo:$events_0_0}},{event:{equalTo:$events_0_1}}]},{and:[{module:{equalTo:$events_1_0}},{event:{equalTo:$events_1_1}}]},{and:[{module:{equalTo:$events_2_0}},{event:{equalTo:$events_2_1}}]},{and:[{module:{equalTo:$events_3_0}},{event:{equalTo:$events_3_1}}]},{and:[{module:{equalTo:$events_4_0}},{event:{equalTo:$events_4_1}}]}],blockHeight:{greaterThanOrEqualTo:"331122",lessThan:"351122"}},orderBy:BLOCK_HEIGHT_ASC,first:100,distinct:[BLOCK_HEIGHT]){nodes {blockHeight }  } }

```

Query end block range + 20000
 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
