### PR TITLE
Fix worker store array

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add `dictionaryQuerySize` to nodeConfig, so the block range in dictionary can be configurable. (#2139)
+
 ### Fixed
 - Fix `multi-chain` should disable historical by default, rather than exit
 - Fix reindex targetHeight issue introduced in #2131 (#2138)
 - `processedBlockCount` and `schemaMigrationCount` metadata fields incrementing exponentially (#2136)
+- Fix regression introduced in [#2110](https://github.com/subquery/subql/pull/2110) that broke `unwrapProxy` if the input is an array
 
 ## [6.2.0] - 2023-10-31
 ### Fixed

--- a/packages/node-core/src/indexer/worker/utils.ts
+++ b/packages/node-core/src/indexer/worker/utils.ts
@@ -10,6 +10,11 @@ import {instanceToPlain} from 'class-transformer';
  * NOTE do not use this on return types, if used on an entity it would strip all functions and have a plain object
  * */
 function unwrapProxy<T = any>(input: T): T {
+  // Arrays are not proxy objects but their contents might be. This applies to bulkCreate and bulkUpdate
+  if (Array.isArray(input) && input.length && util.types.isProxy(input[0])) {
+    return instanceToPlain(input) as T;
+  }
+
   if (!util.types.isProxy(input)) {
     return input;
   }


### PR DESCRIPTION
# Description

Fix regression introduced in [#2110](https://github.com/subquery/subql/pull/2110) that broke `unwrapProxy` if the input is an array

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
