### PR TITLE
Fix conn pool workers

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Base yargs config for all SDKs (#2144)
 
+### Fixed
+- Workers selecting apis for endpoints that aren't connected
+
 ## [6.3.0] - 2023-11-06
 ### Added
 - Add `dictionaryQuerySize` to nodeConfig, so the block range in dictionary can be configurable. (#2139)

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Base yargs config for all SDKs (#2144)
 
 ### Fixed
-- Workers selecting apis for endpoints that aren't connected
+- Workers selecting apis for endpoints that aren't connected (#2154)
 
 ## [6.3.0] - 2023-11-06
 ### Added

--- a/packages/node-core/src/indexer/worker/worker.connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/worker/worker.connectionPoolState.manager.ts
@@ -12,7 +12,7 @@ import {
 } from '../connectionPoolState.manager';
 
 export type HostConnectionPoolState<T> = {
-  hostGetNextConnectedEndpoint: () => Promise<string | undefined>;
+  hostGetNextConnectedEndpoint: (connectedEndpoints?: string[]) => Promise<string | undefined>;
   hostAddToConnections: (endpoint: string, primary: boolean) => Promise<void>;
   hostGetFieldFromConnectionPoolItem: <K extends keyof ConnectionPoolItem<T>>(
     endpoint: string,
@@ -68,8 +68,8 @@ export class WorkerConnectionPoolStateManager<T extends IApiConnectionSpecific>
     }
   }
 
-  async getNextConnectedEndpoint(): Promise<string | undefined> {
-    return this.host.hostGetNextConnectedEndpoint();
+  async getNextConnectedEndpoint(connectedEndpoints?: string[]): Promise<string | undefined> {
+    return this.host.hostGetNextConnectedEndpoint(connectedEndpoints);
   }
 
   async addToConnections(endpoint: string, primary = false): Promise<void> {


### PR DESCRIPTION
# Description
If a worker doesn't connect to all endpoints the connection pool state manager could still select the endpoint that isn't connected. It will now only consider the connected endpoints when selecting the next endpoint to use.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
