### PR TITLE
End exit

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - When using store get methods the `save` function would be missing
+- Not indexing cleanly when all datasources have reached their end block
 
 ### Fixed
 - Workers selecting apis for endpoints that aren't connected (#2154)

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -271,7 +271,7 @@ export abstract class BaseProjectService<API extends IApi, DS extends BaseDataSo
   hasDataSourcesAfterHeight(height: number): boolean {
     const datasourcesMap = this.getDataSourcesMap();
     //check if there are datasoures for current height
-    if (datasourcesMap.get(height).length) {
+    if (datasourcesMap.get(height + 1).length) {
       return true;
     }
 


### PR DESCRIPTION
# Description
If all datasources end via the endBlock field, then the app would exit with an error rather than cleanly. This fixes that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
