### PR TITLE
add query batch limit

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow restrictions on array based queries, with flag `--query-batch-limit` (#2172)
 
 ## [2.7.0] - 2023-11-15
 ### Added

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -109,6 +109,11 @@ export function getYargsOption() {
         type: 'number',
         default: 100,
       },
+      'query-batch-limit': {
+        demandOption: false,
+        describe: 'Set limit on number on the maximum batch queries',
+        type: 'number',
+      },
       'query-depth-limit': {
         demandOption: false,
         describe: 'Set limit on query depth',


### PR DESCRIPTION
# Description
To limit Array based query batching
```
[
    {"query": "{nfts (first: 1){nodes {collectionId}}}"},
    {"query": "{nfts (first: 1){nodes {collectionId}}}"}
]
```
`--query-batch-limit` can set the maximum amount of array based query that can be made


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
