### PR TITLE
add query alias limiter

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow restrictions on alias queries, with flag `--query-alias-limit` (#2174)
 
 ## [2.7.0] - 2023-11-15
 ### Added

--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -25,6 +25,7 @@ import {getLogger, PinoConfig} from '../utils/logger';
 import {getYargsOption} from '../yargs';
 import {plugins} from './plugins';
 import {PgSubscriptionPlugin} from './plugins/PgSubscriptionPlugin';
+import {queryAliasLimit} from './plugins/QueryAliasLimitPlugin';
 import {queryComplexityPlugin} from './plugins/QueryComplexityPlugin';
 import {queryDepthLimitPlugin} from './plugins/QueryDepthLimitPlugin';
 import {ProjectService} from './project.service';
@@ -163,6 +164,7 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
         : ApolloServerPluginLandingPageDisabled(),
       queryComplexityPlugin({schema, maxComplexity: argv['query-complexity']}),
       queryDepthLimitPlugin({schema, maxDepth: argv['query-depth-limit']}),
+      queryAliasLimit({schema, limit: argv['query-alias-limit']}),
     ];
 
     if (argv['query-explain']) {

--- a/packages/query/src/graphql/plugins/QueryAliasLimitPlugin.ts
+++ b/packages/query/src/graphql/plugins/QueryAliasLimitPlugin.ts
@@ -1,0 +1,32 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import type {ApolloServerPlugin} from 'apollo-server-plugin-base';
+import {GraphQLSchema, GraphQLError, DocumentNode, visit} from 'graphql';
+
+function checkLimit(document: DocumentNode, limit: number): void {
+  let aliasCount = 0;
+  visit(document, {
+    Field(node) {
+      if (node.alias) {
+        aliasCount += 1;
+        if (aliasCount > limit) throw new GraphQLError('Alias limit exceeded');
+      }
+    },
+  });
+}
+
+export function queryAliasLimit(options: {schema: GraphQLSchema; limit?: number}): ApolloServerPlugin {
+  return {
+    requestDidStart: () => {
+      return {
+        didResolveOperation(context: {document: DocumentNode}) {
+          if (options?.limit === undefined) {
+            return;
+          }
+          checkLimit(context.document, options.limit);
+        },
+      };
+    },
+  } as unknown as ApolloServerPlugin;
+}

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -113,7 +113,11 @@ export function getYargsOption() {
         demandOption: false,
         describe: 'Set limit on query depth',
         type: 'number',
-        default: 100,
+      },
+      'query-alias-limit': {
+        demandOption: false,
+        describe: 'Set limit on query alias limi',
+        type: 'number',
       },
       'query-complexity': {
         demandOption: false,

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -116,7 +116,7 @@ export function getYargsOption() {
       },
       'query-alias-limit': {
         demandOption: false,
-        describe: 'Set limit on query alias limi',
+        describe: 'Set limit on query alias limit',
         type: 'number',
       },
       'query-complexity': {


### PR DESCRIPTION
# Description

To add a limiter on the number of alias a query can include
```
{
  queryOne: nfts(first: 1) {
      nodes {
          id
          mintedBlock
      }
  }
  queryTwo: nfts (first: 1) {
      nodes {
          id
          mintedBlock
      }
  }
}
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
