### PR TITLE
Fix incorrect DS map if start height is not updated between upgrades

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 ### Added
 - The ability to find the last indexed with a valid block hash using POI (#2176)
+
+### Fixed
+- Fix incorrect datasources map that could result in `Value at height 7408910 was undefined` (#2183)
+- Fix template assets path not been resolved correctly and lead to `Failed to parse log data` (#2182)
 
 ## [6.4.2] - 2023-11-16
 ### Fixed

--- a/packages/node-core/src/indexer/project.service.spec.ts
+++ b/packages/node-core/src/indexer/project.service.spec.ts
@@ -197,5 +197,33 @@ describe('BaseProjectService', () => {
         ])
       );
     });
+
+    it('build correct map when upgrade has the same start height as first project', () => {
+      (service as any).dynamicDsService.dynamicDatasources = [];
+      (service as any).projectUpgradeService = {
+        projects: [
+          [
+            7408909,
+            {
+              dataSources: [{startBlock: 7408909}],
+            },
+          ],
+          [
+            7880532,
+            {
+              dataSources: [{startBlock: 7408909}],
+            },
+          ],
+        ],
+      } as any;
+
+      const result = service.getDataSourcesMap();
+      expect(result.getAll()).toEqual(
+        new Map([
+          [7408909, [{startBlock: 7408909}]],
+          [7880532, [{startBlock: 7408909}]],
+        ])
+      );
+    });
   });
 });

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -282,7 +282,7 @@ export abstract class BaseProjectService<
     }
 
     //check for datasources with height after the current height
-    const dataSources = this.getDataSourcesMap().getAll();
+    const dataSources = datasourcesMap.getAll();
     return [...dataSources.entries()].some(([dsHeight, ds]) => dsHeight > height && ds.length);
   }
 
@@ -313,9 +313,12 @@ export abstract class BaseProjectService<
 
       if (i + 1 < projects.length) {
         const nextProject = projects[i + 1][1];
-        nextMinStartHeight = nextProject.dataSources
-          .filter((ds): ds is DS & {startBlock: number} => !!ds.startBlock)
-          .sort((a, b) => a.startBlock - b.startBlock)[0].startBlock;
+        nextMinStartHeight = Math.max(
+          nextProject.dataSources
+            .filter((ds): ds is DS & {startBlock: number} => !!ds.startBlock)
+            .sort((a, b) => a.startBlock - b.startBlock)[0].startBlock,
+          projects[i + 1][0]
+        );
       }
 
       const activeDataSources = new Set<DS>();

--- a/packages/types-core/CHANGELOG.md
+++ b/packages/types-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Split out `BaseAssetsDataSource` interface from `BaseCustomDataSource` (#2182)
 
 ## [0.3.0] - 2023-10-31
 ### Added


### PR DESCRIPTION
# Description
If a project was upgraded but the datasources didn't change it would use the start height of the upgraded map meaning there would be no entry for the previous project.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
