### PR TITLE
bump lru-cache to 10.1.0, remove default exports

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - dictionary registry path (#2187)
 
+### Fixed
+- bump `lru-cache` to `10.1.0` and remove default exports (#2189)
+
 ## [7.0.1] - 2023-11-28
 ### Fixed
 - Fix ipfs deployment templates path failed to resolved, issue was introduced in #2182 (#2185)

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -36,7 +36,7 @@
     "cross-fetch": "^3.1.6",
     "dayjs": "^1.10.7",
     "lodash": "^4.17.21",
-    "lru-cache": "8.0.4",
+    "lru-cache": "10.1.0",
     "merkle-tools": "^1.4.1",
     "prom-client": "^14.0.1",
     "source-map": "^0.7.4",

--- a/packages/node-core/src/indexer/storeCache/types.ts
+++ b/packages/node-core/src/indexer/storeCache/types.ts
@@ -3,7 +3,7 @@
 
 import {FieldsExpression} from '@subql/types-core';
 import {Transaction} from '@subql/x-sequelize';
-import LRUCache from 'lru-cache';
+import {LRUCache} from 'lru-cache';
 import {SetValueModel} from './setValueModel';
 
 export type HistoricalModel = {__block_range: any};

--- a/packages/node/src/indexer/x-provider/cachedProvider.ts
+++ b/packages/node/src/indexer/x-provider/cachedProvider.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { ProviderInterface } from '@polkadot/rpc-provider/types';
-import LRUCache from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 
 const MAX_CACHE_SIZE = 200;
 const CACHE_TTL = 60 * 1000;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6615,7 +6615,7 @@ __metadata:
     cross-fetch: ^3.1.6
     dayjs: ^1.10.7
     lodash: ^4.17.21
-    lru-cache: 8.0.4
+    lru-cache: 10.1.0
     merkle-tools: ^1.4.1
     prom-client: ^14.0.1
     source-map: ^0.7.4
@@ -16480,17 +16480,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:10.1.0":
+  version: 10.1.0
+  resolution: "lru-cache@npm:10.1.0"
+  checksum: 58056d33e2500fbedce92f8c542e7c11b50d7d086578f14b7074d8c241422004af0718e08a6eaae8705cee09c77e39a61c1c79e9370ba689b7010c152e6a76ab
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:7.10.1 - 7.13.1":
   version: 7.13.1
   resolution: "lru-cache@npm:7.13.1"
   checksum: f53c7dd098a7afd6342b23f7182629edff206c7665de79445a7f5455440e768a4d1c6ec52e1a16175580c71535c9437dfb6f6bc22ca1a0e4a7454a97cde87329
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:8.0.4":
-  version: 8.0.4
-  resolution: "lru-cache@npm:8.0.4"
-  checksum: dee2b905a8cd688c5847faa46ba3cfeaa0766283b244bfd6177420e04e9d923fc901a9a578fc3963d70959631595240ead37abaf43e21968bb9805bbd9519856
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Due to `@subql/apollo-links` pair dependency `lru-cache` bump to `10.1.0` all default exports have been replaced with named exports. Hence, we need to update `lru-cache` exports to use named exports.