### PR TITLE
further fix for ipfs assets

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed resolved asset file with incorrect format and content in #2185
+
 ## [7.0.2] - 2023-11-29
 ### Changed
 - dictionary registry path (#2187)

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -142,11 +142,12 @@ export async function updateDataSourcesV1_0_0<DS extends BaseDataSource, CDS ext
       dataSource.startBlock = dataSource.startBlock ?? 1;
       const entryScript = await loadDataSourceScript(reader, dataSource.mapping.file);
       if (isAssetsDs(dataSource)) {
-        for (const [, asset] of Object.entries(dataSource.assets)) {
+        for (const [, asset] of dataSource.assets.entries()) {
+          // Only need to resolve path for local file
           if (reader instanceof LocalReader) {
             asset.file = path.resolve(root, asset.file);
           } else {
-            asset.file = await saveFile(reader, root, asset.file, '');
+            asset.file = await fetchAndSaveFile(reader, root, asset.file, '');
           }
         }
       }

--- a/packages/node/src/configure/SubqueryProject.spec.ts
+++ b/packages/node/src/configure/SubqueryProject.spec.ts
@@ -179,9 +179,9 @@ describe('load asset with updateDataSourcesV1_0_0', () => {
   const customDsImpl: SubstrateCustomDataSourceImpl[] = [
     {
       kind: 'substrate/FrontierEvm',
-      assets: new Map().set('erc20', {
+      assets: new Map([['erc20', {
         file: 'ipfs://QmYoHL3BvEW6nH1zYZqnziUHjajadu5ErJHavHS2zXkZhv',
-      }),
+      ]]),
       mapping: {
         file: 'ipfs://QmP4Hrfydh4zswkZYeTnnZQFhTGo3LkCfHz4jdkbP8ZA8P',
         handlers: [

--- a/packages/node/src/configure/SubqueryProject.spec.ts
+++ b/packages/node/src/configure/SubqueryProject.spec.ts
@@ -145,9 +145,11 @@ describe('SubqueryProject', () => {
       },
     );
     expect(project.templates[0].name).toBeDefined();
-    // Expect file path to be ipfs too
-    expect((project.templates[0] as any).assets.get('erc20').file).toBe(
-      'ipfs://QmYoHL3BvEW6nH1zYZqnziUHjajadu5ErJHavHS2zXkZhv',
+    // Expect asset to be fetched
+    const regexPattern = /^\/var\/folders\/\d+\/\w+\/T\/\w+\/\w+$/;
+
+    expect((project.templates[0] as any).assets.get('erc20').file).toMatch(
+      regexPattern,
     );
   }, 50000);
 });


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
This fix should save the asset file to local, and return in correct format

Previous fix to `updateDataSourcesV1_0_0` stores an empty js file in local, and this could lead to phrase abi failed error again. 

And previous test didn't detect this bug due to `Object.entries(dataSource.assets)` alway return an empty array, so not thing is updated in the dataSource for substrate, but actually iterate in other network package(due to another bug, they are object https://github.com/subquery/subql-ethereum/pull/223). 


![image](https://github.com/subquery/subql/assets/10431657/8183903f-7d7d-4085-be67-3c497c059705)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
