### PR TITLE
Drop down axios version to commonjs version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
     "@subql/common": "workspace:*",
     "@subql/common-algorand": "^3.0.0",
     "@subql/common-concordium": "^3.1.3",
-    "@subql/common-cosmos": "^3.0.1",
+    "@subql/common-cosmos": "^3.2.1",
     "@subql/common-ethereum": "^3.0.2",
     "@subql/common-flare": "^3.0.1",
     "@subql/common-near": "^3.0.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,7 +15,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@subql/types-core": "workspace:*",
-    "axios": "^1.6.0",
+    "axios": "^0.27.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "fs-extra": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6320,7 +6320,7 @@ __metadata:
     "@subql/common": "workspace:*"
     "@subql/common-algorand": ^3.0.0
     "@subql/common-concordium": ^3.1.3
-    "@subql/common-cosmos": ^3.0.1
+    "@subql/common-cosmos": ^3.2.1
     "@subql/common-ethereum": ^3.0.2
     "@subql/common-flare": ^3.0.1
     "@subql/common-near": ^3.0.0
@@ -6404,9 +6404,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/common-cosmos@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@subql/common-cosmos@npm:3.0.1"
+"@subql/common-cosmos@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@subql/common-cosmos@npm:3.2.1"
   dependencies:
     "@cosmology/telescope": ^0.104.0
     "@cosmwasm/ts-codegen": ^0.35.3
@@ -6417,8 +6417,8 @@ __metadata:
     "@protobufs/google": ^0.0.10
     "@protobufs/ibc": ^0.1.0
     "@protobufs/tendermint": ^0.0.10
-    "@subql/common": ^3.1.0
-    "@subql/types-cosmos": 3.0.1
+    "@subql/common": ^3.3.0
+    "@subql/types-cosmos": 3.2.1
     fs-extra: ^11.1.1
     js-yaml: ^4.1.0
     reflect-metadata: ^0.1.13
@@ -6426,7 +6426,7 @@ __metadata:
     class-transformer: "*"
     class-validator: "*"
     ejs: "*"
-  checksum: 01f03a112a37dbc6274886894adc413f87c2e4fe325881f5fc205ddd5f31eb6696a048a29c69c0ffe32bb3a47145a3582ded63f236ea6e6a0be5b89eb3379090
+  checksum: 9773055e03303dbf52f8c55f3b7021f44650288c194cf6d6b42d864b8670526304b7ecd0c2119d255339c00e230b40e7dde100813525c9f19425800b97da8a87
   languageName: node
   linkType: hard
 
@@ -6533,7 +6533,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/common@npm:^3.1.0, @subql/common@npm:^3.1.1":
+"@subql/common@npm:^3.1.1, @subql/common@npm:^3.3.0":
   version: 3.3.0
   resolution: "@subql/common@npm:3.3.0"
   dependencies:
@@ -6582,7 +6582,7 @@ __metadata:
     "@types/semver": ^7.3.9
     "@types/tar": ^6.1.1
     "@types/update-notifier": ^6
-    axios: ^1.6.0
+    axios: ^0.27.2
     class-transformer: ^0.5.1
     class-validator: ^0.14.0
     fs-extra: ^10.1.0
@@ -6743,7 +6743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/types-core@npm:0.1.1, @subql/types-core@npm:^0.1.0, @subql/types-core@npm:^0.1.1":
+"@subql/types-core@npm:0.1.1, @subql/types-core@npm:^0.1.1":
   version: 0.1.1
   resolution: "@subql/types-core@npm:0.1.1"
   dependencies:
@@ -6761,7 +6761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/types-core@npm:0.3.0":
+"@subql/types-core@npm:0.3.0, @subql/types-core@npm:^0.3.0":
   version: 0.3.0
   resolution: "@subql/types-core@npm:0.3.0"
   dependencies:
@@ -6778,15 +6778,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@subql/types-cosmos@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@subql/types-cosmos@npm:3.0.1"
+"@subql/types-cosmos@npm:3.2.1":
+  version: 3.2.1
+  resolution: "@subql/types-cosmos@npm:3.2.1"
   dependencies:
     "@cosmjs/cosmwasm-stargate": ^0.30.1
     "@cosmjs/proto-signing": ^0.30.1
     "@cosmjs/stargate": ^0.30.1
-    "@subql/types-core": ^0.1.0
-  checksum: 5c6f232c6c1e53e1189df9226a90a5035465ac8d5bfb154acd638e432ee8af6d8940d9b552404bf41573d908240e511919e21fe96fc53c71aa7ba37d612ac9cb
+    "@subql/types-core": ^0.3.0
+  checksum: 802a4f41066c0fde6991c2e19967fb01e1a854f5eb7079a455227a321e7cf02e1e91e7f8ec2f90b5e424f10888b4ad273453cc3986327816cc5c0904b6be2de5
   languageName: node
   linkType: hard
 
@@ -9201,17 +9201,6 @@ __metadata:
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
   checksum: 7fb6a4313bae7f45e89d62c70a800913c303df653f19eafec88e56cea2e3821066b8409bc68be1930ecca80e861c52aa787659df0ffec6ad4d451c7816b9386b
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.6.0":
-  version: 1.6.1
-  resolution: "axios@npm:1.6.1"
-  dependencies:
-    follow-redirects: ^1.15.0
-    form-data: ^4.0.0
-    proxy-from-env: ^1.1.0
-  checksum: 573f03f59b7487d54551b16f5e155d1d130ad4864ed32d1da93d522b78a57123b34e3bde37f822a65ee297e79f1db840f9ad6514addff50d3cbf5caeed39e8dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
Axios versions >1 use ESM rather than common js. We don't support ESM at this stage. Downgrading version fixes issues with other SDKs that don't have other versions of Axios

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
