### PR TITLE
Fix issue with metadata cache setting lastProcessedHeight to undefined

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix issue with metadata cache setting lastProcessedHeight to undefined (#2200)
 
 ## [7.0.4] - 2023-12-14
 ### Changed

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.spec.ts
@@ -23,4 +23,15 @@ describe('CacheMetadata', () => {
 
     expect((cacheMetadata as any).setCache[incrementKey]).toBe(1);
   });
+
+  // This tested a very specific use case where `cacheModel.getByFields`` was called on the start block which could trigger a flush and "lastProcessedHeight" was not yet set
+  it('clears the caches properly with blockHeight', () => {
+    cacheMetadata.clear(1);
+
+    (cacheMetadata as any).getCache[incrementKey] = 100;
+
+    cacheMetadata.setIncrement(incrementKey);
+
+    expect(Object.keys((cacheMetadata as any).setCache)).not.toContain('lastProcessedHeight');
+  });
 });

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
@@ -136,7 +136,11 @@ export class CacheMetadataModel extends Cacheable implements ICachedModelControl
   clear(blockHeight?: number): void {
     const newSetCache: Partial<MetadataKeys> = {};
     this.flushableRecordCounter = 0;
-    if (blockHeight !== undefined && blockHeight !== this.setCache.lastProcessedHeight) {
+    if (
+      blockHeight !== undefined &&
+      this.setCache.lastProcessedHeight !== undefined &&
+      blockHeight !== this.setCache.lastProcessedHeight
+    ) {
       newSetCache.lastProcessedHeight = this.setCache.lastProcessedHeight;
       this.flushableRecordCounter = 1;
     }


### PR DESCRIPTION
# Description
This fixes a very specific use case where `cacheModel.getByFields` was called on the start block which could trigger a flush and "lastProcessedHeight" was not yet set, this would lead to an assertion failure.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
