### PR TITLE
Only check relevant datasources when deciding whether to use modulos or not

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Improve modulo filter performance when there are other data sources (#2152)
 
 ## [7.0.8] - 2024-01-10
 ### Fixed

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -317,6 +317,7 @@ export abstract class BaseFetchService<
 
       const endHeight = this.nextEndBlockHeight(startBlockHeight, scaledBatchSize);
 
+      // Find current datasources to check if they are only modulo filters, this also limits the range to the current DS set.
       const details = this.projectService.getDataSourcesMap().getDetails(startBlockHeight);
       assert(details, `Datasources not found for height ${startBlockHeight}`);
       const {endHeight: rangeEndHeight, value: relevantDS} = details;

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -267,7 +267,6 @@ export abstract class BaseProjectService<
     }
   }
 
-  // This is used everywhere but within indexing blocks, see comment on getDataSources for more info
   getAllDataSources(): DS[] {
     assert(isMainThread, 'This method is only avaiable on the main thread');
     const dataSources = this.project.dataSources;
@@ -288,7 +287,6 @@ export abstract class BaseProjectService<
     return [...dataSources.entries()].some(([dsHeight, ds]) => dsHeight > height && ds.length);
   }
 
-  // This gets used when indexing blocks, it needs to be async to ensure dynamicDs is updated within workers
   async getDataSources(blockHeight?: number): Promise<DS[]> {
     const dataSources = this.project.dataSources;
     const dynamicDs = await this.dynamicDsService.getDynamicDatasources();

--- a/packages/node-core/src/indexer/types.ts
+++ b/packages/node-core/src/indexer/types.ts
@@ -44,7 +44,14 @@ export interface IProjectService<DS> {
   blockOffset: number | undefined;
   startHeight: number;
   reindex(lastCorrectHeight: number): Promise<void>;
+  /**
+   * This is used everywhere but within indexing blocks, see comment on getDataSources for more info
+   * */
   getAllDataSources(): DS[];
+  /**
+   * This gets used when indexing blocks, it needs to be async to ensure dynamicDs is updated within workers
+   *
+   * */
   getDataSources(blockHeight?: number): Promise<DS[]>;
   getStartBlockFromDataSources(): number;
   getDataSourcesMap(): BlockHeightMap<DS[]>;


### PR DESCRIPTION
# Description
This is a performance improvement that improves checks on other data sources if there is a modulo filter. Previously it would fetch all blocks if there were any other data sources even with a different block range. This will now consider only active datasources

Fixes https://github.com/subquery/subql/issues/2152

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
