### PR TITLE
Update parent project to use `untilBlock` as and alias for `block`

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Update `ParentProject` to use `untilBlock` as and alias for `block` (#2235)
 
 ## [3.3.1] - 2023-12-14
 ### Fixed

--- a/packages/common/src/project/versioned/v1_0_0/models.ts
+++ b/packages/common/src/project/versioned/v1_0_0/models.ts
@@ -25,6 +25,7 @@ import {
   IsArray,
   IsNotEmpty,
   Allow,
+  ValidateIf,
 } from 'class-validator';
 import {SemverVersionValidator} from '../../utils';
 import {FileType} from '../base';
@@ -78,7 +79,11 @@ export class BlockFilterImpl implements BlockFilter {
 
 export class ParentProjectModel implements ParentProject {
   @IsNumber()
+  @ValidateIf((obj, value) => value != null || obj.unitlBlock === null || obj.untilBlock === undefined)
   block: number;
+  @IsNumber()
+  @ValidateIf((obj, value) => value != null || obj.block === null || obj.block === undefined)
+  untilBlock: number;
   @IsString()
   reference: string;
 }

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Update `ParentProject` to use `untilBlock` as and alias for `block` (#2235)
 
 ## [7.2.0] - 2024-01-30
 ### Changed

--- a/packages/node-core/src/configure/ProjectUpgrade.service.spec.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.spec.ts
@@ -54,6 +54,19 @@ const demoProjects = [
   },
 ] as ISubqueryProject[];
 
+const demoProjectsUntil = [
+  {
+    ...templateProject,
+  },
+  {
+    parent: {
+      untilBlock: 10,
+      reference: '0',
+    },
+    ...templateProject,
+  },
+] as ISubqueryProject[];
+
 const loopProjects = [
   {
     parent: {
@@ -122,6 +135,16 @@ describe('Project Upgrades', () => {
       );
 
       expect([...upgradeService.projects.keys()]).toEqual([1, 10, 20, 30, 40, 50]);
+    });
+
+    it('can load all parent projects with untilBlock field', async () => {
+      const upgradeService = await ProjectUpgradeSevice.create(
+        demoProjectsUntil[1],
+        (id) => Promise.resolve(demoProjectsUntil[parseInt(id, 10)]),
+        1
+      );
+
+      expect([...upgradeService.projects.keys()]).toEqual([1, 10]);
     });
 
     it('can handle projects that somehow refer to each other', async () => {

--- a/packages/types-core/CHANGELOG.md
+++ b/packages/types-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Update `ParentProject` to use `untilBlock` as and alias for `block` (#2235)
 
 ## [0.4.0] - 2023-11-27
 ### Changed

--- a/packages/types-core/src/project/versioned/v1_0_0/types.ts
+++ b/packages/types-core/src/project/versioned/v1_0_0/types.ts
@@ -123,10 +123,18 @@ export interface NodeOptions {
 export interface ParentProject {
   /**
    * The block height at which to switch from the parent project to this project.
+   * @deprecated Please use `untilBlock` instead
    * @type {number}
    * @description The block height to switch from the parent project to this project.
    */
   block: number;
+
+  /**
+   * The block height at which to switch from the parent project to this project.
+   * @type {number}
+   * @description The block height to switch from the parent project to this project.
+   */
+  untilBlock: number;
 
   /**
    * The IPFS CID (Content Identifier) referencing the parent project.


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update https://github.com/subquery/documentation/pull/472

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/472
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
