### PR TITLE
Update table creation on schema migration

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Historical queries not using the correct block height (#2243)
 
+### Fixed
+- Fixed non-autonomous schema migration execution (#2244)
+
 ## [7.2.0] - 2024-01-30
 ### Changed
 - Update `@subql/apollo-links` and add specific logger for it

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -41,6 +41,7 @@
     "prom-client": "^14.0.1",
     "source-map": "^0.7.4",
     "tar": "^6.1.11",
+    "toposort-class": "^1.0.1",
     "vm2": "^3.9.19",
     "yargs": "^16.2.0"
   },

--- a/packages/node-core/src/configure/migration-service/migration.ts
+++ b/packages/node-core/src/configure/migration-service/migration.ts
@@ -125,9 +125,9 @@ export class Migration {
       addHistoricalIdIndex(model, indexes);
     }
 
-    const sequelizeModel = this.storeService.defineModel(model, attributes, indexes, this.schemaName);
-
     updateIndexesName(model.name, indexes, existedIndexes);
+
+    const sequelizeModel = this.storeService.defineModel(model, attributes, indexes, this.schemaName);
 
     this.rawQueries.push(generateCreateTableStatement(sequelizeModel, this.schemaName));
 

--- a/packages/node-core/src/configure/migration-service/migration.ts
+++ b/packages/node-core/src/configure/migration-service/migration.ts
@@ -144,8 +144,7 @@ export class Migration {
 
     updateIndexesName(model.name, indexes, existedIndexes);
 
-    this.addModel(sequelizeModel);
-    this.rawQueries.push(generateCreateTableStatement(sequelizeModel, this.schemaName, this.historical));
+    this.rawQueries.push(generateCreateTableStatement(sequelizeModel, this.schemaName));
 
     if (sequelizeModel.options.indexes) {
       this.rawQueries.push(
@@ -153,6 +152,7 @@ export class Migration {
       );
     }
 
+    this.addModel(sequelizeModel);
   }
 
   dropTable(model: GraphQLModelsType): void {
@@ -172,7 +172,7 @@ export class Migration {
     const dbTableName = modelToTableName(model.name);
     const dbColumnName = formatColumnName(field.name);
 
-    const formattedAttributes = formatAttributes(columnOptions, this.schemaName, dbTableName);
+    const formattedAttributes = formatAttributes(columnOptions, this.schemaName);
     this.rawQueries.push(
       `ALTER TABLE "${this.schemaName}"."${dbTableName}" ADD COLUMN "${dbColumnName}" ${formattedAttributes};`
     );

--- a/packages/node-core/src/configure/migration-service/migration.ts
+++ b/packages/node-core/src/configure/migration-service/migration.ts
@@ -97,21 +97,6 @@ export class Migration {
     return {attributes, indexes};
   }
 
-  private defineSequelizeModel(
-    model: GraphQLModelsType,
-    attributes: ModelAttributes<any>,
-    indexes: IndexesOptions[]
-  ): ModelStatic<any> {
-    return this.sequelize.define(model.name, attributes, {
-      underscored: true,
-      comment: model.description,
-      freezeTableName: false,
-      createdAt: this.config.timestampField,
-      updatedAt: this.config.timestampField,
-      schema: this.schemaName,
-      indexes,
-    });
-  }
   private addModel(sequelizeModel: ModelStatic<any>): void {
     const modelName = sequelizeModel.name;
 
@@ -140,7 +125,7 @@ export class Migration {
       addHistoricalIdIndex(model, indexes);
     }
 
-    const sequelizeModel = this.defineSequelizeModel(model, attributes, indexes);
+    const sequelizeModel = this.storeService.defineModel(model, attributes, indexes, this.schemaName);
 
     updateIndexesName(model.name, indexes, existedIndexes);
 

--- a/packages/node-core/src/configure/migration-service/migration.ts
+++ b/packages/node-core/src/configure/migration-service/migration.ts
@@ -172,7 +172,7 @@ export class Migration {
     const dbTableName = modelToTableName(model.name);
     const dbColumnName = formatColumnName(field.name);
 
-    const formattedAttributes = formatAttributes(columnOptions, this.schemaName);
+    const formattedAttributes = formatAttributes(columnOptions, this.schemaName, false);
     this.rawQueries.push(
       `ALTER TABLE "${this.schemaName}"."${dbTableName}" ADD COLUMN "${dbColumnName}" ${formattedAttributes};`
     );

--- a/packages/node-core/src/utils/sequelizeUtil.ts
+++ b/packages/node-core/src/utils/sequelizeUtil.ts
@@ -1,9 +1,18 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import assert from 'assert';
 import NodeUtil from 'node:util';
-import {BigInt, Boolean, DateObj, Float, ID, Int, Json, SequelizeTypes, String} from '@subql/utils';
-import {DataType, DataTypes, IndexesOptions, ModelAttributeColumnOptions, TableName, Utils} from '@subql/x-sequelize';
+import {BigInt, Boolean, DateObj, Int, Json, SequelizeTypes, String} from '@subql/utils';
+import {
+  DataType,
+  DataTypes,
+  IndexesOptions,
+  ModelAttributeColumnOptions,
+  TableName,
+  Utils,
+  TableNameWithSchema,
+} from '@subql/x-sequelize';
 import {underscored} from './sync-helper';
 
 // This method is simplified from https://github.com/sequelize/sequelize/blob/066421c00aad61694dcdbb624d4b73dbac7c7b42/packages/core/src/model-definition.ts#L245
@@ -43,15 +52,15 @@ ${NodeUtil.inspect(index)}`);
   return underscored(out);
 }
 
-export function formatReferences(
-  columnOptions: ModelAttributeColumnOptions,
-  schema: string,
-  tableName: string
-): string {
+export function formatReferences(columnOptions: ModelAttributeColumnOptions, schema: string): string {
   if (!columnOptions.references) {
     return '';
   }
-  let referenceStatement = `REFERENCES "${schema}"."${tableName}" ("${(columnOptions?.references as any).key}")`;
+  assert(typeof columnOptions.references !== 'string', 'reference is type string');
+  assert(typeof columnOptions.references.model !== 'string', 'reference.model is type string');
+  let referenceStatement = `REFERENCES "${schema}"."${
+    (columnOptions.references.model as TableNameWithSchema).tableName
+  }" ("${columnOptions.references.key}")`;
   if (columnOptions.onDelete) {
     referenceStatement += ` ON DELETE ${columnOptions.onDelete}`;
   }
@@ -61,32 +70,27 @@ export function formatReferences(
   return referenceStatement;
 }
 
-export function formatAttributes(
-  columnOptions: ModelAttributeColumnOptions,
-  schema: string,
-  tableName: string
-): string {
+export function formatAttributes(columnOptions: ModelAttributeColumnOptions, schema: string): string {
   const type = formatDataType(columnOptions.type);
   const allowNull = columnOptions.allowNull === false ? 'NOT NULL' : '';
-  const primaryKey = columnOptions.primaryKey ? 'PRIMARY KEY' : '';
   const unique = columnOptions.unique ? 'UNIQUE' : '';
   const autoIncrement = columnOptions.autoIncrement ? 'AUTO_INCREMENT' : ''; //  PostgreSQL
 
-  const references = formatReferences(columnOptions, schema, tableName);
+  const references = formatReferences(columnOptions, schema);
 
-  return `${type} ${allowNull} ${primaryKey} ${unique} ${autoIncrement} ${references}`.trim();
+  return `${type} ${allowNull} ${unique} ${autoIncrement} ${references}`.trim();
 }
 
 const sequelizeToPostgresTypeMap = {
   [DataTypes.STRING.name]: (dataType: DataType) => String.sequelizeType,
   [DataTypes.INTEGER.name]: () => Int.sequelizeType,
   [DataTypes.BIGINT.name]: () => BigInt.sequelizeType,
-  [DataTypes.UUID.name]: () => ID.sequelizeType,
+  [DataTypes.UUID.name]: () => DataTypes.UUID,
   [DataTypes.BOOLEAN.name]: () => Boolean.sequelizeType,
-  [DataTypes.FLOAT.name]: () => Float.sequelizeType,
+  [DataTypes.FLOAT.name]: () => 'double precision', // to maintain compatibility we will use float8
   [DataTypes.DATE.name]: () => DateObj.sequelizeType,
   [DataTypes.JSONB.name]: () => Json.sequelizeType,
-  RANGE: () => 'int8range', // Custom handler for int8range
+  [DataTypes.RANGE.name]: () => 'int8range',
 };
 
 export function formatDataType(dataType: DataType): SequelizeTypes {

--- a/packages/node-core/src/utils/sequelizeUtil.ts
+++ b/packages/node-core/src/utils/sequelizeUtil.ts
@@ -70,7 +70,11 @@ export function formatReferences(columnOptions: ModelAttributeColumnOptions, sch
   return referenceStatement;
 }
 
-export function formatAttributes(columnOptions: ModelAttributeColumnOptions, schema: string): string {
+export function formatAttributes(
+  columnOptions: ModelAttributeColumnOptions,
+  schema: string,
+  withoutForeignKey: boolean
+): string {
   const type = formatDataType(columnOptions.type);
   const allowNull = columnOptions.allowNull === false ? 'NOT NULL' : '';
   const unique = columnOptions.unique ? 'UNIQUE' : '';
@@ -78,7 +82,7 @@ export function formatAttributes(columnOptions: ModelAttributeColumnOptions, sch
 
   const references = formatReferences(columnOptions, schema);
 
-  return `${type} ${allowNull} ${unique} ${autoIncrement} ${references}`.trim();
+  return `${type} ${allowNull} ${unique} ${autoIncrement} ${withoutForeignKey ? '' : references}`.trim();
 }
 
 const sequelizeToPostgresTypeMap = {

--- a/packages/node-core/src/utils/sync-helper.spec.ts
+++ b/packages/node-core/src/utils/sync-helper.spec.ts
@@ -115,16 +115,16 @@ describe('sync-helper', () => {
   } as unknown as ModelStatic<Model<any, any>>;
 
   it('Generate SQL statement for table creation with historical', () => {
-    const statement = generateCreateTableStatement(mockModel, 'test', true);
+    const statement = generateCreateTableStatement(mockModel, 'test');
     const expectedStatement = `
     CREATE TABLE IF NOT EXISTS "test"."test-table" (
       "id" text NOT NULL,
       "amount" numeric NOT NULL,
       "date" timestamp NOT NULL,
       "from_id" text NOT NULL,
-      "_id" text NOT NULL PRIMARY KEY,
+      "_id" uuid NOT NULL,
       "_block_range" int8range NOT NULL,
-      "last_transfer_block" integer
+      "last_transfer_block" integer, PRIMARY KEY ("_id")
     );
   
 COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and must look like this';
@@ -159,7 +159,7 @@ COMMENT ON COLUMN "test"."test-table"."last_transfer_block" IS 'The most recent 
         },
       };
     }) as any;
-    const statement = generateCreateTableStatement(mockModel, 'test', false);
+    const statement = generateCreateTableStatement(mockModel, 'test');
 
     // Correcting the expected statement to reflect proper SQL syntax
     const expectedStatement = `
@@ -194,7 +194,7 @@ COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and m
       onUpdate: 'CASCADE',
     } as ModelAttributeColumnOptions;
 
-    const statement = formatReferences(attribute, 'test', 'test-table');
+    const statement = formatReferences(attribute, 'test');
     expect(statement).toMatch(`REFERENCES "test"."test-table" ("id") ON DELETE NO ACTION ON UPDATE CASCADE`);
   });
 });

--- a/packages/node-core/src/utils/sync-helper.spec.ts
+++ b/packages/node-core/src/utils/sync-helper.spec.ts
@@ -1,0 +1,193 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {Model, ModelAttributeColumnOptions, ModelStatic} from '@subql/x-sequelize';
+import {formatReferences} from './sequelizeUtil';
+import {generateCreateIndexStatement, generateCreateTableStatement} from './sync-helper';
+
+describe('sync-helper', () => {
+  const mockModel = {
+    schema: {
+      name: 'test',
+    },
+    tableName: 'test-table',
+    options: {
+      indexes: [
+        {
+          fields: ['from_id', '_block_range'],
+          unique: false,
+          using: 'gist',
+          name: '0xf48017d5c5d3d768',
+          type: '',
+          parser: null,
+        },
+        {
+          fields: ['id'],
+          unique: false,
+          name: '0xb91efc8ed4021e6e',
+          type: '',
+          parser: null,
+        },
+      ],
+    },
+    getAttributes: () => {
+      return {
+        // ID
+        id: {
+          type: 'text',
+          comment: 'id field is always required and must look like this',
+          allowNull: false,
+          primaryKey: false,
+          fieldName: 'id',
+          _modelAttribute: true,
+          field: 'id',
+        },
+        // BIGINT
+        amount: {
+          type: 'numeric',
+          comment: 'Amount that is transferred',
+          allowNull: false,
+          primaryKey: false,
+          fieldName: 'amount',
+          _modelAttribute: true,
+          field: 'amount',
+        },
+        // TIMESTAMP
+        date: {
+          type: 'timestamp',
+          comment: 'The date of the transfer',
+          allowNull: false,
+          primaryKey: false,
+          fieldName: 'date',
+          _modelAttribute: true,
+          field: 'date',
+        },
+        // RELATION with HISTORICAL
+        fromId: {
+          type: 'text',
+          comment: 'The account that transfers are made from',
+          allowNull: false,
+          primaryKey: false,
+          fieldName: 'fromId',
+          _modelAttribute: true,
+          field: 'from_id',
+        },
+        // UUID
+        __id: {
+          type: {
+            key: 'UUID',
+          },
+          defaultValue: {},
+          allowNull: false,
+          primaryKey: true,
+          fieldName: '__id',
+          _modelAttribute: true,
+          field: '_id',
+        },
+        // HISTORICAL RANGE
+        __block_range: {
+          type: {
+            key: 'RANGE',
+            _subtype: 'BIGINT',
+            options: {
+              subtype: {
+                options: {},
+              },
+            },
+          },
+          allowNull: false,
+          fieldName: '__block_range',
+          _modelAttribute: true,
+          field: '_block_range',
+        },
+        // NULLABLE
+        lastTransferBlock: {
+          type: 'integer',
+          comment: 'The most recent block on which we see a transfer involving this account',
+          allowNull: true,
+          primaryKey: false,
+          fieldName: 'lastTransferBlock',
+          _modelAttribute: true,
+          field: 'last_transfer_block',
+        },
+      };
+    },
+  } as unknown as ModelStatic<Model<any, any>>;
+
+  it('Generate SQL statement for table creation with historical', () => {
+    const statement = generateCreateTableStatement(mockModel, 'test', true);
+    const expectedStatement = `CREATE TABLE IF NOT EXISTS "test"."test-table" (
+      "id" text NOT NULL,
+      "amount" numeric NOT NULL,
+      "date" timestamp NOT NULL,
+      "from_id" text NOT NULL,
+      "_id" text NOT NULL PRIMARY KEY,
+      "_block_range" int8range NOT NULL,
+      "last_transfer_block" integer, PRIMARY KEY ("_id")
+    );`.trim();
+    expect(statement.trim()).toMatch(expectedStatement);
+  });
+  it('Generate SQL statement for Indexes', () => {
+    const statement = generateCreateIndexStatement(
+      mockModel.options.indexes as any,
+      mockModel.schema.name,
+      mockModel.tableName
+    );
+    expect(statement).toStrictEqual([
+      `CREATE  INDEX "0xf48017d5c5d3d768" ON "test"."${mockModel.tableName}" USING gist ("from_id", "_block_range");`,
+      `CREATE  INDEX "0xb91efc8ed4021e6e" ON "test"."${mockModel.tableName}"  ("id");`,
+    ]);
+  });
+  it('Generate table statement no historical, no multi primary keys', () => {
+    mockModel.getAttributes = jest.fn(() => {
+      return {
+        id: {
+          type: 'text',
+          comment: 'id field is always required and must look like this',
+          allowNull: false,
+          primaryKey: true,
+          fieldName: 'id',
+          _modelAttribute: true,
+          field: 'id',
+        },
+      };
+    }) as any;
+    const statement = generateCreateTableStatement(mockModel, 'test', false);
+
+    // Correcting the expected statement to reflect proper SQL syntax
+    const expectedStatement = `
+        CREATE TABLE IF NOT EXISTS "test"."test-table" (
+      "id" text NOT NULL PRIMARY KEY
+    );
+  
+COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and must look like this';`.trim();
+
+    expect(statement.trim()).toBe(expectedStatement);
+  });
+  it('Reference statement', () => {
+    const attribute = {
+      type: 'text',
+      comment: 'The account that transfers are made from',
+      allowNull: false,
+      primaryKey: false,
+      fieldName: 'fromId',
+      _modelAttribute: true,
+      field: 'from_id',
+      references: {
+        model: {
+          tableName: 'accounts',
+          table: 'accounts',
+          name: 'Account',
+          schema: 't-sync-4',
+          delimiter: '.',
+        },
+        key: 'id',
+      },
+      onDelete: 'NO ACTION',
+      onUpdate: 'CASCADE',
+    } as ModelAttributeColumnOptions;
+
+    const statement = formatReferences(attribute, 'test', 'test-table');
+    expect(statement).toMatch(`REFERENCES "test"."test-table" ("id") ON DELETE NO ACTION ON UPDATE CASCADE`);
+  });
+});

--- a/packages/node-core/src/utils/sync-helper.spec.ts
+++ b/packages/node-core/src/utils/sync-helper.spec.ts
@@ -116,16 +116,23 @@ describe('sync-helper', () => {
 
   it('Generate SQL statement for table creation with historical', () => {
     const statement = generateCreateTableStatement(mockModel, 'test', true);
-    const expectedStatement = `CREATE TABLE IF NOT EXISTS "test"."test-table" (
+    const expectedStatement = `
+    CREATE TABLE IF NOT EXISTS "test"."test-table" (
       "id" text NOT NULL,
       "amount" numeric NOT NULL,
       "date" timestamp NOT NULL,
       "from_id" text NOT NULL,
       "_id" text NOT NULL PRIMARY KEY,
       "_block_range" int8range NOT NULL,
-      "last_transfer_block" integer, PRIMARY KEY ("_id")
-    );`.trim();
-    expect(statement.trim()).toMatch(expectedStatement);
+      "last_transfer_block" integer
+    );
+  
+COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and must look like this';
+COMMENT ON COLUMN "test"."test-table"."amount" IS 'Amount that is transferred';
+COMMENT ON COLUMN "test"."test-table"."date" IS 'The date of the transfer';
+COMMENT ON COLUMN "test"."test-table"."from_id" IS 'The account that transfers are made from';
+COMMENT ON COLUMN "test"."test-table"."last_transfer_block" IS 'The most recent block on which we see a transfer involving this account';`.trim();
+    expect(statement.trim()).toBe(expectedStatement);
   });
   it('Generate SQL statement for Indexes', () => {
     const statement = generateCreateIndexStatement(

--- a/packages/node-core/src/utils/sync-helper.spec.ts
+++ b/packages/node-core/src/utils/sync-helper.spec.ts
@@ -121,23 +121,16 @@ describe('sync-helper', () => {
 
   it('Generate SQL statement for table creation with historical', () => {
     const statement = generateCreateTableStatement(mockModel, 'test');
-    const expectedStatement = `
-    CREATE TABLE IF NOT EXISTS "test"."test-table" (
-      "id" text NOT NULL,
-      "amount" numeric NOT NULL,
-      "date" timestamp NOT NULL,
-      "from_id" text NOT NULL,
-      "_id" uuid NOT NULL,
-      "_block_range" int8range NOT NULL,
-      "last_transfer_block" integer, PRIMARY KEY ("_id")
-    );
-  
-COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and must look like this';
-COMMENT ON COLUMN "test"."test-table"."amount" IS 'Amount that is transferred';
-COMMENT ON COLUMN "test"."test-table"."date" IS 'The date of the transfer';
-COMMENT ON COLUMN "test"."test-table"."from_id" IS 'The account that transfers are made from';
-COMMENT ON COLUMN "test"."test-table"."last_transfer_block" IS 'The most recent block on which we see a transfer involving this account';`.trim();
-    expect(statement.trim()).toBe(expectedStatement);
+    const expectedStatement = [
+      'CREATE TABLE IF NOT EXISTS "test"."test-table" ("id" text NOT NULL,\n      "amount" numeric NOT NULL,\n      "date" timestamp NOT NULL,\n      "from_id" text NOT NULL,\n      "_id" UUID NOT NULL,\n      "_block_range" int8range NOT NULL,\n      "last_transfer_block" integer, PRIMARY KEY ("_id"));',
+
+      `COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and must look like this';`,
+      `COMMENT ON COLUMN "test"."test-table"."amount" IS 'Amount that is transferred';`,
+      `COMMENT ON COLUMN "test"."test-table"."date" IS 'The date of the transfer';`,
+      `COMMENT ON COLUMN "test"."test-table"."from_id" IS 'The account that transfers are made from';`,
+      `COMMENT ON COLUMN "test"."test-table"."last_transfer_block" IS 'The most recent block on which we see a transfer involving this account';`,
+    ];
+    expect(statement).toStrictEqual(expectedStatement);
   });
   it('Generate SQL statement for Indexes', () => {
     const statement = generateCreateIndexStatement(
@@ -167,14 +160,17 @@ COMMENT ON COLUMN "test"."test-table"."last_transfer_block" IS 'The most recent 
     const statement = generateCreateTableStatement(mockModel, 'test');
 
     // Correcting the expected statement to reflect proper SQL syntax
-    const expectedStatement = `
-        CREATE TABLE IF NOT EXISTS "test"."test-table" (
-      "id" text NOT NULL PRIMARY KEY
-    );
-  
-COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and must look like this';`.trim();
+    //     const expectedStatement = `
+    //         CREATE TABLE IF NOT EXISTS "test"."test-table" (
+    //       "id" text NOT NULL PRIMARY KEY
+    //     );
+    //
+    // COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and must look like this';`.trim();
 
-    expect(statement.trim()).toBe(expectedStatement);
+    expect(statement).toStrictEqual([
+      `CREATE TABLE IF NOT EXISTS "test"."test-table" ("id" text NOT NULL, PRIMARY KEY ("id"));`,
+      `COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and must look like this';`,
+    ]);
   });
   it('Reference statement', () => {
     const attribute = {
@@ -228,7 +224,7 @@ COMMENT ON COLUMN "test"."test-table"."id" IS 'id field is always required and m
     expect(v[0]).toBe(
       `ALTER TABLE "test"."test-table"
       ADD FOREIGN KEY (transfer_id_id) 
-      REFERENCES "test"."transfers" (id) ON DELETE NO ACTION ON UPDATE CASCADE;`
+      REFERENCES "test"."transfers" ("id") ON DELETE NO ACTION ON UPDATE CASCADE;`
     );
   });
   it('sortModel with toposort on cyclic schema', () => {

--- a/packages/node/src/indexer/store.service.test.ts
+++ b/packages/node/src/indexer/store.service.test.ts
@@ -1,0 +1,246 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import { promisify } from 'util';
+import { DynamicModule, INestApplication } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ScheduleModule } from '@nestjs/schedule';
+import { Test } from '@nestjs/testing';
+import { DbModule, DbOption, NodeConfig, registerApp } from '@subql/node-core';
+import { QueryTypes, Sequelize } from '@subql/x-sequelize';
+import rimraf from 'rimraf';
+import { ConfigureModule } from '../configure/configure.module';
+import { SubqueryProject } from '../configure/SubqueryProject';
+import { FetchModule } from '../indexer/fetch.module';
+import { MetaModule } from '../meta/meta.module';
+import { ApiService } from './api.service';
+import { ProjectService } from './project.service';
+
+const mockInstance = async (
+  cid: string,
+  schemaName: string,
+  disableHistorical: boolean,
+) => {
+  const argv: Record<string, any> = {
+    _: [],
+    disableHistorical,
+    subquery: `ipfs://${cid}`,
+    dbSchema: schemaName,
+    ipfs: 'https://unauthipfs.subquery.network/ipfs/api/v0',
+    networkEndpoint: 'wss://rpc.polkadot.io/public-ws',
+  };
+  return registerApp<SubqueryProject>(
+    argv,
+    SubqueryProject.create.bind(SubqueryProject),
+    jest.fn(),
+    '',
+  );
+};
+
+async function mockRegister(
+  cid: string,
+  schemaName: string,
+  disableHistorical: boolean,
+): Promise<DynamicModule> {
+  const { nodeConfig, project } = await mockInstance(
+    cid,
+    schemaName,
+    disableHistorical,
+  );
+
+  return {
+    module: ConfigureModule,
+    providers: [
+      {
+        provide: NodeConfig,
+        useValue: nodeConfig,
+      },
+      {
+        provide: 'ISubqueryProject',
+        useValue: project,
+      },
+      {
+        provide: 'IProjectUpgradeService',
+        useValue: project,
+      },
+      {
+        provide: 'Null',
+        useValue: null,
+      },
+    ],
+    exports: [NodeConfig, 'ISubqueryProject', 'IProjectUpgradeService', 'Null'],
+  };
+}
+
+async function prepareApp(
+  schemaName: string,
+  cid: string,
+  disableHistorical = false,
+) {
+  const m = await Test.createTestingModule({
+    imports: [
+      DbModule.forRoot(),
+      EventEmitterModule.forRoot(),
+      mockRegister(cid, schemaName, disableHistorical),
+      ScheduleModule.forRoot(),
+      FetchModule,
+      MetaModule,
+    ],
+    controllers: [],
+  }).compile();
+
+  const app = m.createNestApplication();
+  await app.init();
+  return app;
+}
+
+const option: DbOption = {
+  host: process.env.DB_HOST ?? '127.0.0.1',
+  port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 5432,
+  username: process.env.DB_USER ?? 'postgres',
+  password: process.env.DB_PASS ?? 'postgres',
+  database: process.env.DB_DATABASE ?? 'postgres',
+  timezone: 'utc',
+};
+
+jest.setTimeout(900000);
+describe('Store service integration test', () => {
+  let app: INestApplication;
+  let projectService: ProjectService;
+  let sequelize: Sequelize;
+  let tempDir: string;
+  let schemaName: string;
+
+  beforeAll(async () => {
+    sequelize = new Sequelize(
+      `postgresql://${option.username}:${option.password}@${option.host}:${option.port}/${option.database}`,
+      option,
+    );
+    await sequelize.authenticate();
+  });
+  afterEach(async () => {
+    // await sequelize.dropSchema(schemaName, { logging: false });
+    await app?.close();
+  });
+
+  afterAll(async () => {
+    await promisify(rimraf)(tempDir);
+  });
+
+  it('Correct db sync on historical project', async () => {
+    // on uniswap complex schema
+    const cid = 'QmNUNBiVC1BDDNbXCbTxzPexodbSmTqZUaohbeBae6b6r8';
+    schemaName = 'sync-schema-1';
+
+    app = await prepareApp(schemaName, cid, false);
+
+    projectService = app.get('IProjectService');
+    const apiService = app.get(ApiService);
+
+    await apiService.init();
+    await projectService.init(1);
+
+    tempDir = (projectService as any).project.root;
+
+    const [result] = await sequelize.query(`
+       SELECT 
+          table_name
+        FROM 
+          information_schema.tables
+        WHERE 
+          table_schema = '${schemaName}'; 
+        `);
+    const expectedTables = result.map(
+      (t: { table_name: string }) => t.table_name,
+    );
+    expect(expectedTables.sort()).toStrictEqual(
+      [
+        'factories',
+        'bundles',
+        'tokens',
+        '_metadata',
+        'white_list_pools',
+        'pools',
+        'ticks',
+        'positions',
+        'position_snapshots',
+        'transactions',
+        'mints',
+        'burns',
+        'swaps',
+        'collects',
+        'flashes',
+        'uniswap_day_data',
+        'pool_day_data',
+        'pool_hour_data',
+        'tick_hour_data',
+        'tick_day_data',
+        'token_day_data',
+        'token_hour_data',
+      ].sort(),
+    );
+
+    const columnResult = await sequelize.query(
+      `
+        SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = '${schemaName}' 
+AND table_name = 'positions';
+`,
+      {
+        type: QueryTypes.SELECT,
+      },
+    );
+    expect(
+      columnResult.find((c: any) => c.column_name === 'created_at'),
+    ).toStrictEqual({
+      column_name: 'created_at',
+      data_type: 'timestamp with time zone',
+      is_nullable: 'NO',
+    });
+    expect(
+      columnResult.find((c: any) => c.column_name === 'token0_id'),
+    ).toStrictEqual({
+      column_name: 'token0_id',
+      data_type: 'text',
+      is_nullable: 'NO',
+    });
+
+    expect(
+      columnResult.find((c: any) => c.column_name === '_block_range'),
+    ).toStrictEqual({
+      column_name: '_block_range',
+      data_type: 'int8range',
+      is_nullable: 'NO',
+    });
+
+    expect(
+      columnResult.find((c: any) => c.column_name === 'withdrawn_token0'),
+    ).toStrictEqual({
+      column_name: 'withdrawn_token0',
+      data_type: 'double precision',
+      is_nullable: 'NO',
+    });
+    expect(
+      columnResult.find((c: any) => c.column_name === 'withdrawn_token0'),
+    ).toStrictEqual({
+      column_name: '_id',
+      data_type: 'uuid',
+      is_nullable: 'NO',
+    });
+  });
+  it('Correct db sync on non-historical', async () => {
+    const cid = 'QmNUNBiVC1BDDNbXCbTxzPexodbSmTqZUaohbeBae6b6r8';
+    schemaName = 'sync-schema-2';
+
+    app = await prepareApp(schemaName, cid, true);
+
+    projectService = app.get('IProjectService');
+    const apiService = app.get(ApiService);
+
+    await apiService.init();
+    await projectService.init(1);
+
+    tempDir = (projectService as any).project.root;
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6431,6 +6431,7 @@ __metadata:
     prom-client: ^14.0.1
     source-map: ^0.7.4
     tar: ^6.1.11
+    toposort-class: ^1.0.1
     vm2: ^3.9.19
     yargs: ^16.2.0
   languageName: unknown


### PR DESCRIPTION
# Description
Schema migraiton should be an autonomous action that should be in one transaction
Hence, we can not use sequelize.sync(), as if migration were to fail, table creation would still be executed 

Tests on
- Cyclic schema
- Historical (complex schema, multiple relationals)
- Non-historical (complex schema, multiple relationals)
- QueryGenerators

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
