### PR TITLE
Earlier exit when failing to fetch blocks with workers

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Testing Suites should run with unfinalizedBlocks `false` (#2258)
 
 ### Changed
-- Throw error earlier when failing to fetch blocks when workers are enabled (#2256)
+- Improve error handling when fetching blocks (#2256)
 
 ## [7.2.1] - 2024-02-07
 ### Added

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Schema Migration support for Enums, Relations, Subscription (#2251)
+
 ### Fixed
 - Fixed non-atomic schema migration execution (#2244)
 - Testing Suites should run with unfinalizedBlocks `false` (#2258)
+
+### Changed
+- Throw error earlier when failing to fetch blocks when workers are enabled (#2256)
 
 ## [7.2.1] - 2024-02-07
 ### Added

--- a/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
@@ -206,7 +206,7 @@ export abstract class BlockDispatcher<B, DS>
               // Do nothing, fetching the block was flushed, this could be caused by forked blocks or dynamic datasources
               return;
             }
-            logger.warn(e, 'Failed to enqueue fetched block to process');
+            logger.error(e, 'Failed to enqueue fetched block to process');
             process.exit(1);
           });
 

--- a/packages/node-core/src/indexer/worker/worker.service.ts
+++ b/packages/node-core/src/indexer/worker/worker.service.ts
@@ -69,6 +69,7 @@ export abstract class BaseWorkerService<
         return;
       }
       logger.error(e, `Failed to fetch block ${height}`);
+      throw e;
     }
   }
 


### PR DESCRIPTION
# Description
When failing to fetch a block the error will now be thrown earlier rather than a missing block when attempting to process the block.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
