### PR TITLE
Fix services startup order, fix project upgrade block height

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed non-atomic schema migration execution (#2244)
 - Testing Suites should run with unfinalizedBlocks `false` (#2258)
 - StoreService not being fully in sync with db (#2264)
+- StoreService not being initialized early enough on startup (#2265)
 
 ### Changed
 - Improve error handling when fetching blocks (#2256)

--- a/packages/node-core/src/configure/ProjectUpgrade.service.spec.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.spec.ts
@@ -163,6 +163,34 @@ describe('Project Upgrades', () => {
       expect([...upgradeService.projects.keys()]).toEqual([20, 30, 40, 50]);
     });
 
+    // It would be a user error to do this but its still possible. In reality the last project should have no parent
+    it('can use the correct project when the parent upgrades at the start height', async () => {
+      const projects = [
+        {
+          id: '0',
+          network: {
+            chainId: '1',
+          },
+          dataSources: [{startBlock: 10}],
+        },
+        {
+          id: '1',
+          parent: {
+            block: 10,
+            reference: '0',
+          },
+          network: {
+            chainId: '1',
+          },
+          dataSources: [{startBlock: 10}],
+        },
+      ] as ISubqueryProject[];
+
+      await expect(() =>
+        ProjectUpgradeService.create(projects[1], (id) => Promise.resolve(projects[parseInt(id, 10)]))
+      ).rejects.toThrow('Project already exists at height 10');
+    });
+
     it('can load all parent projects upto and including startHeight', async () => {
       const upgradeService = await ProjectUpgradeService.create(
         demoProjects[5],

--- a/packages/node-core/src/configure/ProjectUpgrade.service.spec.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.spec.ts
@@ -4,7 +4,7 @@
 import {Sequelize} from '@subql/x-sequelize';
 import {CacheMetadataModel, ISubqueryProject, StoreCacheService, StoreService} from '../indexer';
 import {NodeConfig} from './NodeConfig';
-import {IProjectUpgradeService, ProjectUpgradeSevice, upgradableSubqueryProject} from './ProjectUpgrade.service';
+import {IProjectUpgradeService, ProjectUpgradeService, upgradableSubqueryProject} from './ProjectUpgrade.service';
 
 const templateProject = {
   network: {
@@ -114,11 +114,11 @@ const mockMetadata = () => {
 };
 
 describe('Project Upgrades', () => {
-  jest.spyOn(ProjectUpgradeSevice as any, 'rewindableCheck').mockImplementation(() => true);
+  jest.spyOn(ProjectUpgradeService as any, 'rewindableCheck').mockImplementation(() => true);
 
   describe('Loading projects', () => {
     it('can load a project with no parents', async () => {
-      const upgradeService = await ProjectUpgradeSevice.create(
+      const upgradeService = await ProjectUpgradeService.create(
         demoProjects[0],
         (id) => Promise.resolve(demoProjects[parseInt(id, 10)]),
         1
@@ -128,7 +128,7 @@ describe('Project Upgrades', () => {
     });
 
     it('can load all parent projects', async () => {
-      const upgradeService = await ProjectUpgradeSevice.create(
+      const upgradeService = await ProjectUpgradeService.create(
         demoProjects[5],
         (id) => Promise.resolve(demoProjects[parseInt(id, 10)]),
         1
@@ -138,7 +138,7 @@ describe('Project Upgrades', () => {
     });
 
     it('can load all parent projects with untilBlock field', async () => {
-      const upgradeService = await ProjectUpgradeSevice.create(
+      const upgradeService = await ProjectUpgradeService.create(
         demoProjectsUntil[1],
         (id) => Promise.resolve(demoProjectsUntil[parseInt(id, 10)]),
         1
@@ -149,12 +149,12 @@ describe('Project Upgrades', () => {
 
     it('can handle projects that somehow refer to each other', async () => {
       await expect(
-        ProjectUpgradeSevice.create(loopProjects[1], (id) => Promise.resolve(loopProjects[parseInt(id, 10)]), 1)
+        ProjectUpgradeService.create(loopProjects[1], (id) => Promise.resolve(loopProjects[parseInt(id, 10)]), 1)
       ).rejects.toThrow();
     });
 
     it('can load all parent projects upto startHeight', async () => {
-      const upgradeService = await ProjectUpgradeSevice.create(
+      const upgradeService = await ProjectUpgradeService.create(
         demoProjects[5],
         (id) => Promise.resolve(demoProjects[parseInt(id, 10)]),
         21
@@ -164,7 +164,7 @@ describe('Project Upgrades', () => {
     });
 
     it('can load all parent projects upto and including startHeight', async () => {
-      const upgradeService = await ProjectUpgradeSevice.create(
+      const upgradeService = await ProjectUpgradeService.create(
         demoProjects[5],
         (id) => Promise.resolve(demoProjects[parseInt(id, 10)]),
         20
@@ -175,7 +175,7 @@ describe('Project Upgrades', () => {
 
     it('will throw if parent projects are not at an earlier height', async () => {
       await expect(
-        ProjectUpgradeSevice.create(futureProjects[2], (id) => Promise.resolve(futureProjects[parseInt(id, 10)]), 1)
+        ProjectUpgradeService.create(futureProjects[2], (id) => Promise.resolve(futureProjects[parseInt(id, 10)]), 1)
       ).rejects.toThrow();
     });
 
@@ -184,7 +184,7 @@ describe('Project Upgrades', () => {
         dataSources: [{startBlock: 20}],
       } as ISubqueryProject;
       await expect(
-        ProjectUpgradeSevice.create(project, (id) => Promise.resolve(futureProjects[parseInt(id, 10)]), 1)
+        ProjectUpgradeService.create(project, (id) => Promise.resolve(futureProjects[parseInt(id, 10)]), 1)
       ).rejects.toThrow();
     });
 
@@ -204,7 +204,7 @@ describe('Project Upgrades', () => {
       ] as ISubqueryProject[];
 
       await expect(
-        ProjectUpgradeSevice.create(projects[1], (id) => Promise.resolve(projects[parseInt(id, 10)]), 1)
+        ProjectUpgradeService.create(projects[1], (id) => Promise.resolve(projects[parseInt(id, 10)]), 1)
       ).rejects.toThrow();
     });
 
@@ -228,16 +228,16 @@ describe('Project Upgrades', () => {
       ] as ISubqueryProject[];
 
       await expect(
-        ProjectUpgradeSevice.create(projects[1], (id) => Promise.resolve(projects[parseInt(id, 10)]), 1)
+        ProjectUpgradeService.create(projects[1], (id) => Promise.resolve(projects[parseInt(id, 10)]), 1)
       ).rejects.toThrow();
     });
   });
 
   describe('Getting projects for heights', () => {
-    let upgradeService: ProjectUpgradeSevice<ISubqueryProject>;
+    let upgradeService: ProjectUpgradeService<ISubqueryProject>;
 
     beforeAll(async () => {
-      upgradeService = await ProjectUpgradeSevice.create(
+      upgradeService = await ProjectUpgradeService.create(
         demoProjects[5],
         (id) => Promise.resolve(demoProjects[parseInt(id, 10)]),
         1
@@ -258,7 +258,7 @@ describe('Project Upgrades', () => {
   });
 
   describe('Upgradable subquery project', () => {
-    let upgradeService: ProjectUpgradeSevice<ISubqueryProject>;
+    let upgradeService: ProjectUpgradeService<ISubqueryProject>;
     let project: ISubqueryProject & IProjectUpgradeService<ISubqueryProject>;
     let storeCache: StoreCacheService;
 
@@ -267,7 +267,7 @@ describe('Project Upgrades', () => {
       // eslint-disable-next-line @typescript-eslint/dot-notation
       (storeCache as any).cachedModels['_metadata'] = mockMetadata();
 
-      upgradeService = await ProjectUpgradeSevice.create(
+      upgradeService = await ProjectUpgradeService.create(
         demoProjects[5],
         (id) => Promise.resolve(demoProjects[parseInt(id, 10)]),
         1
@@ -323,10 +323,10 @@ describe('Project Upgrades', () => {
   });
 
   describe('Upgrade metadata validation', () => {
-    let upgradeService: ProjectUpgradeSevice<ISubqueryProject>;
+    let upgradeService: ProjectUpgradeService<ISubqueryProject>;
 
     beforeEach(async () => {
-      upgradeService = await ProjectUpgradeSevice.create(
+      upgradeService = await ProjectUpgradeService.create(
         {...demoProjects[5], id: '5'},
         (id) => Promise.resolve({...demoProjects[parseInt(id, 10)], id}),
         1
@@ -369,7 +369,7 @@ describe('Project Upgrades', () => {
     });
 
     it('validates if project doesnt have upgrades', async () => {
-      const upgradeService = await ProjectUpgradeSevice.create(
+      const upgradeService = await ProjectUpgradeService.create(
         demoProjects[0],
         (id) => Promise.resolve(demoProjects[parseInt(id, 10)]),
         1

--- a/packages/node-core/src/configure/ProjectUpgrade.service.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.ts
@@ -247,7 +247,8 @@ export class ProjectUpgradeService<P extends ISubqueryProject = ISubqueryProject
 
   /**
    * Sets the current project and handles project changes
-   * Project change effects only happen after init has been called */
+   * Project change effects only happen after init has been called
+   * */
   async setCurrentHeight(height: number): Promise<void> {
     this.#currentHeight = height;
     const newProjectDetails = this._projects.getDetails(height);
@@ -344,8 +345,8 @@ export class ProjectUpgradeService<P extends ISubqueryProject = ISubqueryProject
 
     const isRewindable = this.rewindableCheck(projects);
 
-    assert(currentHeight, 'Unable to determine current height from projects');
-    return new ProjectUpgradeService(new BlockHeightMap(projects), currentHeight, isRewindable);
+    const firstProjectHeight = Math.min(...projects.keys());
+    return new ProjectUpgradeService(new BlockHeightMap(projects), firstProjectHeight, isRewindable);
   }
 
   getProject(height: number): P {

--- a/packages/node-core/src/configure/ProjectUpgrade.service.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.ts
@@ -297,6 +297,9 @@ export class ProjectUpgradeService<P extends ISubqueryProject = ISubqueryProject
     let nextProject = startProject;
 
     const addProject = (height: number, project: P) => {
+      if (projects.has(height)) {
+        throw new Error(`Project already exists at height ${height}`);
+      }
       this.validateProject(startProject, project);
       projects.set(height, project);
     };

--- a/packages/node-core/src/configure/ProjectUpgrade.service.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.ts
@@ -62,13 +62,13 @@ function getParentBlock(parent: ParentProject): number {
   return parent.untilBlock ?? parent.block;
 }
 
-const logger = getLogger('ProjectUpgradeSevice');
+const logger = getLogger('ProjectUpgradeService');
 
 /*
   We setup a proxy here so that we can have a class that matches ISubquery project but will change when we set the current height to the correct project
 */
 export function upgradableSubqueryProject<P extends ISubqueryProject>(
-  upgradeService: ProjectUpgradeSevice<P>
+  upgradeService: ProjectUpgradeService<P>
 ): P & IProjectUpgradeService<P> {
   return new Proxy<P & IProjectUpgradeService<P>>(upgradeService as any, {
     set() {
@@ -103,7 +103,7 @@ export function upgradableSubqueryProject<P extends ISubqueryProject>(
   });
 }
 
-export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject> implements IProjectUpgradeService<P> {
+export class ProjectUpgradeService<P extends ISubqueryProject = ISubqueryProject> implements IProjectUpgradeService<P> {
   #currentHeight: number;
   #currentProject: P;
 
@@ -192,6 +192,7 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
   get currentHeight(): number {
     return this.#currentHeight;
   }
+
   async rewind(
     targetBlockHeight: number,
     lastProcessedHeight: number,
@@ -244,6 +245,9 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
     }
   }
 
+  /**
+   * Sets the current project and handles project changes
+   * Project change effects only happen after init has been called */
   async setCurrentHeight(height: number): Promise<void> {
     this.#currentHeight = height;
     const newProjectDetails = this._projects.getDetails(height);
@@ -255,7 +259,7 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
     const project = this.#currentProject;
     this.#currentProject = newProject;
 
-    if (hasChanged) {
+    if (hasChanged && this.#initialized) {
       if (isMainThread) {
         try {
           await this.updateIndexedDeployments(newProject.id, startHeight);
@@ -283,7 +287,7 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
     startProject: P, // The project passed in via application start
     loadProject: (ipfsCid: string) => Promise<P>,
     startHeight?: number // How far back we need to load parent versions
-  ): Promise<ProjectUpgradeSevice<P>> {
+  ): Promise<ProjectUpgradeService<P>> {
     const projects: Map<number, P> = new Map();
 
     let currentProject = startProject;
@@ -341,7 +345,7 @@ export class ProjectUpgradeSevice<P extends ISubqueryProject = ISubqueryProject>
     const isRewindable = this.rewindableCheck(projects);
 
     assert(currentHeight, 'Unable to determine current height from projects');
-    return new ProjectUpgradeSevice(new BlockHeightMap(projects), currentHeight, isRewindable);
+    return new ProjectUpgradeService(new BlockHeightMap(projects), currentHeight, isRewindable);
   }
 
   getProject(height: number): P {

--- a/packages/node-core/src/configure/configure.module.ts
+++ b/packages/node-core/src/configure/configure.module.ts
@@ -8,7 +8,7 @@ import {ISubqueryProject} from '../indexer';
 import {getLogger, setDebugFilter} from '../logger';
 import {defaultSubqueryName, rebaseArgsWithManifest} from '../utils';
 import {IConfig, NodeConfig} from './NodeConfig';
-import {IProjectUpgradeService, ProjectUpgradeSevice, upgradableSubqueryProject} from './ProjectUpgrade.service';
+import {IProjectUpgradeService, ProjectUpgradeService, upgradableSubqueryProject} from './ProjectUpgrade.service';
 
 const logger = getLogger('configure');
 
@@ -167,7 +167,7 @@ export async function registerApp<P extends ISubqueryProject>(
     );
   };
 
-  const projectUpgradeService = await ProjectUpgradeSevice.create(project, createParentProject);
+  const projectUpgradeService = await ProjectUpgradeService.create(project, createParentProject);
 
   const upgradeableProject = upgradableSubqueryProject(projectUpgradeService);
 

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.spec.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.spec.ts
@@ -3,7 +3,7 @@
 
 import path from 'path';
 import {buildSchemaFromFile, GraphQLEnumsType} from '@subql/utils';
-import {ProjectUpgradeSevice} from '../../configure';
+import {ProjectUpgradeService} from '../../configure';
 import {compareEnums} from './migration-helpers';
 import {SchemaMigrationService} from './SchemaMigration.service';
 
@@ -54,7 +54,7 @@ describe('SchemaMigration', () => {
         [3, {schema: currentSchema}],
       ]);
 
-      const v = (ProjectUpgradeSevice as any).rewindableCheck(projects);
+      const v = (ProjectUpgradeService as any).rewindableCheck(projects);
       expect(v).toBe(false);
     });
   });

--- a/packages/node-core/src/indexer/poi/poi.service.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {Inject, Injectable, OnApplicationShutdown} from '@nestjs/common';
-import {EventEmitter2} from '@nestjs/event-emitter';
 import {Op, QueryTypes, Transaction} from '@subql/x-sequelize';
 import {NodeConfig} from '../../configure';
 import {sqlIterator} from '../../db';
@@ -10,7 +9,6 @@ import {getLogger} from '../../logger';
 import {PoiRepo} from '../entities';
 import {StoreCacheService} from '../storeCache';
 import {CachePoiModel} from '../storeCache/cachePoi';
-import {ISubqueryProject} from '../types';
 
 const logger = getLogger('PoiService');
 
@@ -24,12 +22,7 @@ export class PoiService implements OnApplicationShutdown {
   private isShutdown = false;
   private _poiRepo?: CachePoiModel;
 
-  constructor(
-    protected readonly nodeConfig: NodeConfig,
-    private storeCache: StoreCacheService,
-    private eventEmitter: EventEmitter2,
-    @Inject('ISubqueryProject') private project: ISubqueryProject
-  ) {}
+  constructor(protected readonly nodeConfig: NodeConfig, private storeCache: StoreCacheService) {}
 
   onApplicationShutdown(): void {
     this.isShutdown = true;

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -111,17 +111,11 @@ export abstract class BaseProjectService<
       await this.dynamicDsService.init(this.storeService.storeCache.metadata);
       await this.ensureMetadata();
 
-      // Get current height
-      // Set project based on current height (upgrades service)
-      // if current height not set it should use the oldest parent
-      // Init DB - This will use the schema of the current project if not already init
-      // Rewind unfinalized blocks
-      // if rewind set current project
-      // Project upgrade service find common ancestor
-      // Rewind if necessary
-      // Update start height based on current height and rewinds
-
-      /* START NEW*/
+      /**
+       * WARNING: The order of the following steps is very important.
+       *  * The right project needs to be used based on the start height which can change depending on rewinds
+       *  * The DB needs to be init for unfinalized and project upgrades to run any rewinds
+       * */
 
       this._startHeight = await this.nextProcessHeight();
 
@@ -156,33 +150,6 @@ export abstract class BaseProjectService<
       if (reindexedUpgrade !== undefined) {
         this._startHeight = reindexedUpgrade;
       }
-
-      /* END NEW */
-
-      // this._startHeight = await this.getStartHeight();
-
-      // // TODO set current project with current start height
-
-      // // These need to be init before upgrade and unfinalized services because they may cause rewinds.
-      // await this.initDbSchema();
-      // await this.initHotSchemaReload();
-
-      // if (this.nodeConfig.proofOfIndex) {
-      //   // Prepare for poi migration and creation
-      //   await this.poiService.init(this.schema);
-      //   // Sync poi from createdPoi to syncedPoi
-      //   await this.poiSyncService.init(this.schema);
-      //   void this.poiSyncService.syncPoi(undefined);
-      // }
-
-      // // Init upgrade service and run any rewinds if project ancestry changed
-      // const reindexedUpgrade = await this.initUpgradeService(this.startHeight);
-
-      // // Unfinalized is dependent on POI in some cases, it needs to be init after POI is init
-      // const reindexedUnfinalized = await this.initUnfinalizedInternal();
-
-      // // Find the new start height based on some rewinding
-      // this._startHeight = Math.min(...[this._startHeight, reindexedUpgrade, reindexedUnfinalized].filter(hasValue));
 
       // Flush any pending operations to set up DB
       await this.storeService.storeCache.flushCache(true, true);

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -265,10 +265,6 @@ export abstract class BaseProjectService<
     return this.storeService.storeCache.metadata.find('lastProcessedHeight');
   }
 
-  private async getStartHeight(): Promise<number> {
-    return (await this.nextProcessHeight()) ?? this.getStartBlockFromDataSources();
-  }
-
   private async nextProcessHeight(): Promise<number | undefined> {
     const lastProcessedHeight = await this.getLastProcessedHeight();
 

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -119,11 +119,9 @@ export abstract class BaseProjectService<
 
       this._startHeight = await this.nextProcessHeight();
 
-      // Nothing is indexed, set the first project is the right project and continue setup
+      // Nothing is indexed, the first project is the default so we can use that start height
       if (this._startHeight === undefined) {
-        const firstHeight = Math.min(...this.projectUpgradeService.projects.keys());
-        await this.projectUpgradeService.setCurrentHeight(firstHeight);
-        this._startHeight = firstHeight;
+        this._startHeight = this.projectUpgradeService.currentHeight;
       }
 
       // These need to be init before upgrade and unfinalized services because they may cause rewinds.
@@ -192,7 +190,6 @@ export abstract class BaseProjectService<
   }
 
   private async initDbSchema(): Promise<void> {
-    console.log('INIT DB', this.project.id);
     await initDbSchema(this.project, this.schema, this.storeService);
   }
 

--- a/packages/node-core/src/subcommands/reindex.service.ts
+++ b/packages/node-core/src/subcommands/reindex.service.ts
@@ -5,7 +5,7 @@ import assert from 'assert';
 import {Inject, Injectable} from '@nestjs/common';
 import {BaseDataSource} from '@subql/types-core';
 import {Sequelize} from '@subql/x-sequelize';
-import {NodeConfig, ProjectUpgradeSevice} from '../configure';
+import {NodeConfig, ProjectUpgradeService} from '../configure';
 import {CacheMetadataModel, IUnfinalizedBlocksService, StoreService, ISubqueryProject, PoiService} from '../indexer';
 import {DynamicDsService} from '../indexer/dynamic-ds.service';
 import {getLogger} from '../logger';
@@ -23,7 +23,7 @@ export class ReindexService<P extends ISubqueryProject, DS extends BaseDataSourc
     private readonly nodeConfig: NodeConfig,
     private readonly storeService: StoreService,
     private readonly poiService: PoiService,
-    @Inject('IProjectUpgradeService') private readonly projectUpgradeService: ProjectUpgradeSevice,
+    @Inject('IProjectUpgradeService') private readonly projectUpgradeService: ProjectUpgradeService,
     @Inject('ISubqueryProject') private readonly project: P,
     private readonly forceCleanService: ForceCleanService,
     @Inject('UnfinalizedBlocksService') private readonly unfinalizedBlocksService: IUnfinalizedBlocksService<B>,

--- a/packages/node-core/src/utils/blockHeightMap.ts
+++ b/packages/node-core/src/utils/blockHeightMap.ts
@@ -73,6 +73,7 @@ export class BlockHeightMap<T> {
       };
     });
   }
+
   getWithinRange(startHeight: number, endHeight: number): Map<number, T> {
     const result = new Map<number, T>();
     let previousKey = null;
@@ -94,6 +95,7 @@ export class BlockHeightMap<T> {
 
     return result;
   }
+
   map<T2>(fn: (value: T) => T2): BlockHeightMap<T2> {
     const newMap = new Map<number, T2>();
 

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -176,12 +176,7 @@ function createIndexerManager(
     project,
   );
   const cacheService = new InMemoryCacheService();
-  const poiService = new PoiService(
-    nodeConfig,
-    storeCache,
-    eventEmitter,
-    project,
-  );
+  const poiService = new PoiService(nodeConfig, storeCache);
 
   const poiSyncService = new PoiSyncService(nodeConfig, eventEmitter, project);
   const unfinalizedBlocksService = new UnfinalizedBlocksService(


### PR DESCRIPTION
# Description
Fixes the store service not yet being initialised when POI is enabled and a reindex is triggered by either a project update or a block fork is detected.

Also fixes a typo

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
