### PR TITLE
Fix output flag not working with publish command

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Publish command output flag not working (#2270)
 
 ## [4.2.7] - 2024-02-23
 ### Changed

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -28,10 +28,17 @@ export default class Build extends Command {
       assert(existsSync(location), 'Argument `location` is not a valid directory or file');
       const directory = lstatSync(location).isDirectory() ? location : path.dirname(location);
 
-      const tsManifest = getTsManifest(location, this);
+      const tsManifest = getTsManifest(location);
 
       if (tsManifest) {
-        await buildManifestFromLocation(tsManifest, this);
+        await buildManifestFromLocation(
+          tsManifest,
+          flags.silent
+            ? () => {
+                /* No-op */
+              }
+            : this.log.bind(this)
+        );
       }
 
       // Get the output location from the project package.json main field
@@ -70,7 +77,7 @@ export default class Build extends Command {
         }
       }
       await runWebpack(buildEntries, directory, outputDir, isDev, true);
-      if (!flags.slient) {
+      if (!flags.silent) {
         this.log('Building and packing code ...');
         this.log('Done!');
       }

--- a/packages/cli/src/commands/codegen/index.ts
+++ b/packages/cli/src/commands/codegen/index.ts
@@ -32,10 +32,10 @@ export default class Codegen extends Command {
       or multichain ts manifest
       or multichain yaml manifest containing single chain ts project paths
     */
-    const tsManifest = getTsManifest(projectPath, this);
+    const tsManifest = getTsManifest(projectPath);
 
     if (tsManifest) {
-      await buildManifestFromLocation(tsManifest, this);
+      await buildManifestFromLocation(tsManifest, this.log.bind(this));
     }
 
     const {manifests, root} = getProjectRootAndManifest(projectPath);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -68,14 +68,26 @@ export default class Publish extends Command {
 
     const directoryCid = Array.from(fileToCidMap).find(([file]) => file === '');
 
-    if (directoryCid) {
-      this.log(`SubQuery Multichain Project uploaded to IPFS: ${directoryCid[1]}`);
-    }
-
-    fileToCidMap.forEach((cid, file) => {
-      if (file !== '') {
-        this.log(`${directoryCid ? '- This includes' : 'SubQuery Project'} ${file} uploaded to IPFS: ${cid}`);
+    if (!flags.output) {
+      if (directoryCid) {
+        this.log(`SubQuery Multichain Project uploaded to IPFS: ${directoryCid[1]}`);
       }
-    });
+
+      fileToCidMap.forEach((cid, file) => {
+        if (file !== '') {
+          this.log(`${directoryCid ? '- This includes' : 'SubQuery Project'} ${file} uploaded to IPFS: ${cid}`);
+        }
+      });
+    } else {
+      if (directoryCid) {
+        this.log(directoryCid[1]);
+      } else {
+        fileToCidMap.forEach((cid, file) => {
+          if (file !== '') {
+            this.log(cid);
+          }
+        });
+      }
+    }
   }
 }

--- a/packages/cli/src/utils/build.spec.ts
+++ b/packages/cli/src/utils/build.spec.ts
@@ -3,7 +3,6 @@
 
 import {existsSync, readFileSync, writeFileSync} from 'fs';
 import path from 'path';
-import {Command} from '@oclif/core';
 import {MultichainProjectManifest} from '@subql/types-core';
 import * as yaml from 'js-yaml';
 import rimraf from 'rimraf';
@@ -21,9 +20,7 @@ describe('Manifest generation', () => {
 
   it('should build ts manifest from multichain file', async () => {
     const projectPath = path.join(__dirname, '../../test/tsManifestTest/subquery-multichain.ts');
-    await expect(
-      buildManifestFromLocation(projectPath, {log: console.log} as unknown as Command)
-    ).resolves.toBeDefined();
+    await expect(buildManifestFromLocation(projectPath, console.log.bind(console))).resolves.toBeDefined();
     expect(existsSync(path.join(projectPath, '../project1.yaml'))).toBe(true);
     expect(existsSync(path.join(projectPath, '../project2.yaml'))).toBe(true);
     expect(existsSync(path.join(projectPath, '../subquery-multichain.yaml'))).toBe(true);
@@ -37,14 +34,12 @@ describe('Manifest generation', () => {
 
   it('throws error on unknown file in multichain manifest', async () => {
     const projectPath = path.join(__dirname, '../../test/tsManifestTest/subquery-multichain2.ts');
-    await expect(buildManifestFromLocation(projectPath, {log: console.log} as unknown as Command)).rejects.toThrow();
+    await expect(buildManifestFromLocation(projectPath, console.log.bind(console))).rejects.toThrow();
   }, 50000);
 
   it('allows both ts and yaml file in multichain manifest', async () => {
     const projectPath = path.join(__dirname, '../../test/tsManifestTest/subquery-multichain3.ts');
-    await expect(
-      buildManifestFromLocation(projectPath, {log: console.log} as unknown as Command)
-    ).resolves.toBeDefined();
+    await expect(buildManifestFromLocation(projectPath, console.log.bind(console))).resolves.toBeDefined();
     expect(existsSync(path.join(projectPath, '../project1.yaml'))).toBe(true);
     expect(existsSync(path.join(projectPath, '../project3.yaml'))).toBe(true);
     expect(existsSync(path.join(projectPath, '../subquery-multichain3.yaml'))).toBe(true);
@@ -58,9 +53,7 @@ describe('Manifest generation', () => {
 
   it('should build ts manifest from yaml multichain file', async () => {
     const projectPath = path.join(__dirname, '../../test/tsManifestTest/subquery-multichain4.yaml');
-    await expect(
-      buildManifestFromLocation(projectPath, {log: console.log} as unknown as Command)
-    ).resolves.toBeDefined();
+    await expect(buildManifestFromLocation(projectPath, console.log.bind(console))).resolves.toBeDefined();
     expect(existsSync(path.join(projectPath, '../project1.yaml'))).toBe(true);
     expect(existsSync(path.join(projectPath, '../project2.yaml'))).toBe(true);
 


### PR DESCRIPTION
# Description
If the flag is enabled it will now only output the CID, if multichain this will be the multichain directory

Fixes #2248

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
