### PR TITLE
Fix connections with historical queries not taking blockheight into consideration

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -252,7 +252,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2021-04-20
 ### Added
 - Remove `condition` in query schema, please use `filter` instead (#260)
--  annotation is now supported in 
+- `@jsonField` annotation is now supported in `graphql.schema` which allows you to store structured data JSON data in a single database field
   - We'll automatically generate coresponding JSON interfaces when querying this data (#275)
   - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
 

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Relation filters not taking into account block height when historical is enabled (#2276)
 
 ## [2.9.0] - 2024-01-25
 ### Added
@@ -250,7 +252,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2021-04-20
 ### Added
 - Remove `condition` in query schema, please use `filter` instead (#260)
-- `@jsonField` annotation is now supported in `graphql.schema` which allows you to store structured data JSON data in a single database field
+-  annotation is now supported in 
   - We'll automatically generate coresponding JSON interfaces when querying this data (#275)
   - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
 

--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -122,7 +122,8 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
       subscriptions: true,
       dynamicJson: true,
       graphileBuildOptions: {
-        connectionFilterRelations: true,
+        connectionFilterRelations: false, // We use our own forked version with historical support
+
         // cockroach db does not support pgPartition
         pgUsePartitionedParent: this.dbType !== SUPPORT_DB.cockRoach,
       },

--- a/packages/query/src/graphql/plugins/historical/PgConnectionArgFilterBackwardRelationsPlugin.ts
+++ b/packages/query/src/graphql/plugins/historical/PgConnectionArgFilterBackwardRelationsPlugin.ts
@@ -1,0 +1,466 @@
+/* eslint-disable */
+
+/* INFO: This file has been modified from https://github.com/graphile-contrib/postgraphile-plugin-connection-filter to support historical queries */
+import type {Plugin} from 'graphile-build';
+import type {PgAttribute, PgClass, PgConstraint} from 'graphile-build-pg';
+import {ConnectionFilterResolver} from 'postgraphile-plugin-connection-filter/dist/PgConnectionArgFilterPlugin';
+import {makeRangeQuery, hasBlockRange} from './utils';
+
+const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
+  builder,
+  {pgSimpleCollections, pgOmitListSuffix, connectionFilterUseListInflectors}
+) => {
+  const hasConnections = pgSimpleCollections !== 'only';
+  const simpleInflectorsAreShorter = pgOmitListSuffix === true;
+  if (simpleInflectorsAreShorter && connectionFilterUseListInflectors === undefined) {
+    // TODO: in V3 consider doing this for the user automatically (doing it in V2 would be a breaking change)
+    console.warn(
+      `We recommend you set the 'connectionFilterUseListInflectors' option to 'true' since you've set the 'pgOmitListSuffix' option`
+    );
+  }
+  const useConnectionInflectors =
+    connectionFilterUseListInflectors === undefined ? hasConnections : !connectionFilterUseListInflectors;
+
+  builder.hook('inflection', (inflection) => {
+    return Object.assign(inflection, {
+      filterManyType(table: PgClass, foreignTable: PgClass): string {
+        return (this as any).upperCamelCase(
+          `${(this as any).tableType(table)}-to-many-${(this as any).tableType(foreignTable)}-filter`
+        );
+      },
+      filterBackwardSingleRelationExistsFieldName(relationFieldName: string) {
+        return `${relationFieldName}Exists`;
+      },
+      filterBackwardManyRelationExistsFieldName(relationFieldName: string) {
+        return `${relationFieldName}Exist`;
+      },
+      filterSingleRelationByKeysBackwardsFieldName(fieldName: string) {
+        return fieldName;
+      },
+      filterManyRelationByKeysFieldName(fieldName: string) {
+        return fieldName;
+      },
+    });
+  });
+
+  builder.hook('GraphQLInputObjectType:fields', (fields, build, context) => {
+    const {
+      describePgEntity,
+      extend,
+      newWithHooks,
+      inflection,
+      pgOmit: omit,
+      pgSql: sql,
+      pgIntrospectionResultsByKind: introspectionResultsByKind,
+      graphql: {GraphQLInputObjectType, GraphQLBoolean},
+      connectionFilterResolve,
+      connectionFilterRegisterResolver,
+      connectionFilterTypesByTypeName,
+      connectionFilterType,
+    } = build;
+    const {
+      fieldWithHooks,
+      scope: {pgIntrospection: table, isPgConnectionFilter},
+      Self,
+    } = context;
+
+    if (!isPgConnectionFilter || table.kind !== 'class') return fields;
+
+    connectionFilterTypesByTypeName[Self.name] = Self;
+
+    const backwardRelationSpecs = (introspectionResultsByKind.constraint as PgConstraint[])
+      .filter((con) => con.type === 'f')
+      .filter((con) => con.foreignClassId === table.id)
+      .reduce((memo: BackwardRelationSpec[], foreignConstraint) => {
+        if (omit(foreignConstraint, 'read') || omit(foreignConstraint, 'filter')) {
+          return memo;
+        }
+        const foreignTable = introspectionResultsByKind.classById[foreignConstraint.classId];
+        if (!foreignTable) {
+          throw new Error(`Could not find the foreign table (constraint: ${foreignConstraint.name})`);
+        }
+        if (omit(foreignTable, 'read') || omit(foreignTable, 'filter')) {
+          return memo;
+        }
+        const attributes = (introspectionResultsByKind.attribute as PgAttribute[])
+          .filter((attr) => attr.classId === table.id)
+          .sort((a, b) => a.num - b.num);
+        const foreignAttributes = (introspectionResultsByKind.attribute as PgAttribute[])
+          .filter((attr) => attr.classId === foreignTable.id)
+          .sort((a, b) => a.num - b.num);
+        const keyAttributes = foreignConstraint.foreignKeyAttributeNums.map(
+          (num) => attributes.filter((attr) => attr.num === num)[0]
+        );
+        const foreignKeyAttributes = foreignConstraint.keyAttributeNums.map(
+          (num) => foreignAttributes.filter((attr) => attr.num === num)[0]
+        );
+        if (keyAttributes.some((attr) => omit(attr, 'read'))) {
+          return memo;
+        }
+        if (foreignKeyAttributes.some((attr) => omit(attr, 'read'))) {
+          return memo;
+        }
+        const isForeignKeyUnique = !!(introspectionResultsByKind.constraint as PgConstraint[]).find(
+          (c) =>
+            c.classId === foreignTable.id &&
+            (c.type === 'p' || c.type === 'u') &&
+            c.keyAttributeNums.length === foreignKeyAttributes.length &&
+            c.keyAttributeNums.every((n, i) => foreignKeyAttributes[i].num === n)
+        );
+        memo.push({
+          table,
+          keyAttributes,
+          foreignTable,
+          foreignKeyAttributes,
+          foreignConstraint,
+          isOneToMany: !isForeignKeyUnique,
+        });
+        return memo;
+      }, []);
+
+    let backwardRelationSpecByFieldName: {
+      [fieldName: string]: BackwardRelationSpec;
+    } = {};
+
+    const addField = (
+      fieldName: string,
+      description: string,
+      type: any,
+      resolve: any,
+      spec: BackwardRelationSpec,
+      hint: string
+    ) => {
+      // Field
+      fields = extend(
+        fields,
+        {
+          [fieldName]: fieldWithHooks(
+            fieldName,
+            {
+              description,
+              type,
+            },
+            {
+              isPgConnectionFilterField: true,
+            }
+          ),
+        },
+        hint
+      );
+      // Relation spec for use in resolver
+      backwardRelationSpecByFieldName = extend(backwardRelationSpecByFieldName, {
+        [fieldName]: spec,
+      });
+      // Resolver
+      connectionFilterRegisterResolver(Self.name, fieldName, resolve);
+    };
+
+    const resolveSingle: ConnectionFilterResolver = ({sourceAlias, fieldName, fieldValue, queryBuilder}) => {
+      if (fieldValue == null) return null;
+
+      const {foreignTable, foreignKeyAttributes, keyAttributes} = backwardRelationSpecByFieldName[fieldName];
+
+      const foreignTableTypeName = inflection.tableType(foreignTable);
+
+      const foreignTableAlias = sql.identifier(Symbol());
+      const foreignTableFilterTypeName = inflection.filterType(foreignTableTypeName);
+      const sqlIdentifier = sql.identifier(foreignTable.namespace.name, foreignTable.name);
+
+      /******************************
+       * HISTORICAL CHANGES BEGIN
+       *******************************/
+
+      const fkMatches = foreignKeyAttributes.map((attr, i) => {
+        return sql.fragment`${foreignTableAlias}.${sql.identifier(attr.name)} = ${sourceAlias}.${sql.identifier(
+          keyAttributes[i].name
+        )}`;
+      });
+
+      if (queryBuilder.context.args?.blockHeight && hasBlockRange(table)) {
+        fkMatches.push(makeRangeQuery(foreignTableAlias, queryBuilder.context.args.blockHeight, sql));
+      }
+
+      const sqlKeysMatch = sql.query`(${sql.join(fkMatches, ') and (')})`;
+
+      /******************************
+       * HISTORICAL CHANGES END
+       *******************************/
+
+      const sqlSelectWhereKeysMatch = sql.query`select 1 from ${sqlIdentifier} as ${foreignTableAlias} where ${sqlKeysMatch}`;
+      const sqlFragment = connectionFilterResolve(
+        fieldValue,
+        foreignTableAlias,
+        foreignTableFilterTypeName,
+        queryBuilder
+      );
+      return sqlFragment == null ? null : sql.query`exists(${sqlSelectWhereKeysMatch} and (${sqlFragment}))`;
+    };
+
+    const resolveExists: ConnectionFilterResolver = ({sourceAlias, fieldName, fieldValue, queryBuilder}) => {
+      if (fieldValue == null) return null;
+
+      const {foreignTable, foreignKeyAttributes, keyAttributes} = backwardRelationSpecByFieldName[fieldName];
+
+      const foreignTableAlias = sql.identifier(Symbol());
+
+      const sqlIdentifier = sql.identifier(foreignTable.namespace.name, foreignTable.name);
+
+      /******************************
+       * HISTORICAL CHANGES BEGIN
+       *******************************/
+
+      const fkMatches = foreignKeyAttributes.map((attr, i) => {
+        return sql.fragment`${foreignTableAlias}.${sql.identifier(attr.name)} = ${sourceAlias}.${sql.identifier(
+          keyAttributes[i].name
+        )}`;
+      });
+
+      if (queryBuilder.context.args?.blockHeight && hasBlockRange(table)) {
+        fkMatches.push(makeRangeQuery(foreignTableAlias, queryBuilder.context.args.blockHeight, sql));
+      }
+
+      const sqlKeysMatch = sql.query`(${sql.join(fkMatches, ') and (')})`;
+
+      /******************************
+       * HISTORICAL CHANGES END
+       *******************************/
+
+      const sqlSelectWhereKeysMatch = sql.query`select 1 from ${sqlIdentifier} as ${foreignTableAlias} where ${sqlKeysMatch}`;
+
+      return fieldValue === true
+        ? sql.query`exists(${sqlSelectWhereKeysMatch})`
+        : sql.query`not exists(${sqlSelectWhereKeysMatch})`;
+    };
+
+    const makeResolveMany = (backwardRelationSpec: BackwardRelationSpec) => {
+      const resolveMany: ConnectionFilterResolver = ({sourceAlias, fieldName, fieldValue, queryBuilder}) => {
+        if (fieldValue == null) return null;
+
+        const {foreignTable} = backwardRelationSpecByFieldName[fieldName];
+
+        const foreignTableFilterManyTypeName = inflection.filterManyType(table, foreignTable);
+        const sqlFragment = connectionFilterResolve(
+          fieldValue,
+          sourceAlias,
+          foreignTableFilterManyTypeName,
+          queryBuilder,
+          null,
+          null,
+          null,
+          {backwardRelationSpec}
+        );
+        return sqlFragment == null ? null : sqlFragment;
+      };
+      return resolveMany;
+    };
+
+    for (const spec of backwardRelationSpecs) {
+      const {foreignTable, foreignKeyAttributes, foreignConstraint, isOneToMany} = spec;
+      const foreignTableTypeName = inflection.tableType(foreignTable);
+      const foreignTableFilterTypeName = inflection.filterType(foreignTableTypeName);
+      const ForeignTableFilterType = connectionFilterType(
+        newWithHooks,
+        foreignTableFilterTypeName,
+        foreignTable,
+        foreignTableTypeName
+      );
+      if (!ForeignTableFilterType) continue;
+
+      if (isOneToMany) {
+        if (!omit(foreignTable, 'many')) {
+          const filterManyTypeName = inflection.filterManyType(table, foreignTable);
+          if (!connectionFilterTypesByTypeName[filterManyTypeName]) {
+            connectionFilterTypesByTypeName[filterManyTypeName] = newWithHooks(
+              GraphQLInputObjectType,
+              {
+                name: filterManyTypeName,
+                description: `A filter to be used against many \`${foreignTableTypeName}\` object types. All fields are combined with a logical ‘and.’`,
+              },
+              {
+                foreignTable,
+                isPgConnectionFilterMany: true,
+              }
+            );
+          }
+          const FilterManyType = connectionFilterTypesByTypeName[filterManyTypeName];
+          const fieldName = useConnectionInflectors
+            ? inflection.manyRelationByKeys(foreignKeyAttributes, foreignTable, table, foreignConstraint)
+            : inflection.manyRelationByKeysSimple(foreignKeyAttributes, foreignTable, table, foreignConstraint);
+          const filterFieldName = inflection.filterManyRelationByKeysFieldName(fieldName);
+          addField(
+            filterFieldName,
+            `Filter by the object’s \`${fieldName}\` relation.`,
+            FilterManyType,
+            makeResolveMany(spec),
+            spec,
+            `Adding connection filter backward relation field from ${describePgEntity(table)} to ${describePgEntity(
+              foreignTable
+            )}`
+          );
+
+          const existsFieldName = inflection.filterBackwardManyRelationExistsFieldName(fieldName);
+          addField(
+            existsFieldName,
+            `Some related \`${fieldName}\` exist.`,
+            GraphQLBoolean,
+            resolveExists,
+            spec,
+            `Adding connection filter backward relation exists field from ${describePgEntity(
+              table
+            )} to ${describePgEntity(foreignTable)}`
+          );
+        }
+      } else {
+        const fieldName = inflection.singleRelationByKeysBackwards(
+          foreignKeyAttributes,
+          foreignTable,
+          table,
+          foreignConstraint
+        );
+        const filterFieldName = inflection.filterSingleRelationByKeysBackwardsFieldName(fieldName);
+        addField(
+          filterFieldName,
+          `Filter by the object’s \`${fieldName}\` relation.`,
+          ForeignTableFilterType,
+          resolveSingle,
+          spec,
+          `Adding connection filter backward relation field from ${describePgEntity(table)} to ${describePgEntity(
+            foreignTable
+          )}`
+        );
+
+        const existsFieldName = inflection.filterBackwardSingleRelationExistsFieldName(fieldName);
+        addField(
+          existsFieldName,
+          `A related \`${fieldName}\` exists.`,
+          GraphQLBoolean,
+          resolveExists,
+          spec,
+          `Adding connection filter backward relation exists field from ${describePgEntity(
+            table
+          )} to ${describePgEntity(foreignTable)}`
+        );
+      }
+    }
+
+    return fields;
+  });
+
+  builder.hook('GraphQLInputObjectType:fields', (fields, build, context) => {
+    const {
+      extend,
+      newWithHooks,
+      inflection,
+      pgSql: sql,
+      connectionFilterResolve,
+      connectionFilterRegisterResolver,
+      connectionFilterTypesByTypeName,
+      connectionFilterType,
+    } = build;
+    const {
+      fieldWithHooks,
+      scope: {foreignTable, isPgConnectionFilterMany},
+      Self,
+    } = context;
+
+    if (!isPgConnectionFilterMany || !foreignTable) return fields;
+
+    connectionFilterTypesByTypeName[Self.name] = Self;
+
+    const foreignTableTypeName = inflection.tableType(foreignTable);
+    const foreignTableFilterTypeName = inflection.filterType(foreignTableTypeName);
+    const FilterType = connectionFilterType(
+      newWithHooks,
+      foreignTableFilterTypeName,
+      foreignTable,
+      foreignTableTypeName
+    );
+
+    const manyFields = {
+      every: fieldWithHooks(
+        'every',
+        {
+          description: `Every related \`${foreignTableTypeName}\` matches the filter criteria. All fields are combined with a logical ‘and.’`,
+          type: FilterType,
+        },
+        {
+          isPgConnectionFilterManyField: true,
+        }
+      ),
+      some: fieldWithHooks(
+        'some',
+        {
+          description: `Some related \`${foreignTableTypeName}\` matches the filter criteria. All fields are combined with a logical ‘and.’`,
+          type: FilterType,
+        },
+        {
+          isPgConnectionFilterManyField: true,
+        }
+      ),
+      none: fieldWithHooks(
+        'none',
+        {
+          description: `No related \`${foreignTableTypeName}\` matches the filter criteria. All fields are combined with a logical ‘and.’`,
+          type: FilterType,
+        },
+        {
+          isPgConnectionFilterManyField: true,
+        }
+      ),
+    };
+
+    const resolve: ConnectionFilterResolver = ({sourceAlias, fieldName, fieldValue, queryBuilder, parentFieldInfo}) => {
+      if (fieldValue == null) return null;
+
+      if (!parentFieldInfo || !parentFieldInfo.backwardRelationSpec)
+        throw new Error('Did not receive backward relation spec');
+      const {keyAttributes, foreignKeyAttributes}: BackwardRelationSpec = parentFieldInfo.backwardRelationSpec;
+
+      const foreignTableAlias = sql.identifier(Symbol());
+      const sqlIdentifier = sql.identifier(foreignTable.namespace.name, foreignTable.name);
+      const sqlKeysMatch = sql.query`(${sql.join(
+        foreignKeyAttributes.map((attr, i) => {
+          return sql.fragment`${foreignTableAlias}.${sql.identifier(attr.name)} = ${sourceAlias}.${sql.identifier(
+            keyAttributes[i].name
+          )}`;
+        }),
+        ') and ('
+      )})`;
+      const sqlSelectWhereKeysMatch = sql.query`select 1 from ${sqlIdentifier} as ${foreignTableAlias} where ${sqlKeysMatch}`;
+
+      const sqlFragment = connectionFilterResolve(
+        fieldValue,
+        foreignTableAlias,
+        foreignTableFilterTypeName,
+        queryBuilder
+      );
+      if (sqlFragment == null) {
+        return null;
+      } else if (fieldName === 'every') {
+        return sql.query`not exists(${sqlSelectWhereKeysMatch} and not (${sqlFragment}))`;
+      } else if (fieldName === 'some') {
+        return sql.query`exists(${sqlSelectWhereKeysMatch} and (${sqlFragment}))`;
+      } else if (fieldName === 'none') {
+        return sql.query`not exists(${sqlSelectWhereKeysMatch} and (${sqlFragment}))`;
+      }
+      throw new Error(`Unknown field name: ${fieldName}`);
+    };
+
+    for (const fieldName of Object.keys(manyFields)) {
+      connectionFilterRegisterResolver(Self.name, fieldName, resolve);
+    }
+
+    return extend(fields, manyFields);
+  });
+};
+
+export interface BackwardRelationSpec {
+  table: PgClass;
+  keyAttributes: PgAttribute[];
+  foreignTable: PgClass;
+  foreignKeyAttributes: PgAttribute[];
+  foreignConstraint: PgConstraint;
+  isOneToMany: boolean;
+}
+
+export default PgConnectionArgFilterBackwardRelationsPlugin;

--- a/packages/query/src/graphql/plugins/historical/PgConnectionArgFilterForwardRelationsPlugin.ts
+++ b/packages/query/src/graphql/plugins/historical/PgConnectionArgFilterForwardRelationsPlugin.ts
@@ -1,0 +1,265 @@
+/* eslint-disable */
+
+/* INFO: This file has been modified from https://github.com/graphile-contrib/postgraphile-plugin-connection-filter to support historical queries */
+
+import type {Plugin} from 'graphile-build';
+import type {PgAttribute, PgClass, PgConstraint} from 'graphile-build-pg';
+import {ConnectionFilterResolver} from 'postgraphile-plugin-connection-filter/dist/PgConnectionArgFilterPlugin';
+import {makeRangeQuery, hasBlockRange} from './utils';
+
+const PgConnectionArgFilterForwardRelationsPlugin: Plugin = (builder) => {
+  builder.hook('inflection', (inflection) => ({
+    ...inflection,
+    filterForwardRelationExistsFieldName(relationFieldName: string) {
+      return `${relationFieldName}Exists`;
+    },
+    filterSingleRelationFieldName(fieldName: string) {
+      return fieldName;
+    },
+  }));
+
+  builder.hook('GraphQLInputObjectType:fields', (fields, build, context) => {
+    const {
+      describePgEntity,
+      extend,
+      newWithHooks,
+      inflection,
+      graphql: {GraphQLBoolean},
+      pgOmit: omit,
+      pgSql: sql,
+      pgIntrospectionResultsByKind: introspectionResultsByKind,
+      connectionFilterResolve,
+      connectionFilterRegisterResolver,
+      connectionFilterTypesByTypeName,
+      connectionFilterType,
+    } = build;
+    const {
+      fieldWithHooks,
+      scope: {pgIntrospection: table, isPgConnectionFilter},
+      Self,
+    } = context;
+
+    if (!isPgConnectionFilter || table.kind !== 'class') return fields;
+
+    connectionFilterTypesByTypeName[Self.name] = Self;
+
+    const forwardRelationSpecs = (introspectionResultsByKind.constraint as PgConstraint[])
+      .filter((con) => con.type === 'f')
+      .filter((con) => con.classId === table.id)
+      .reduce((memo: ForwardRelationSpec[], constraint) => {
+        if (omit(constraint, 'read') || omit(constraint, 'filter')) {
+          return memo;
+        }
+        const foreignTable = constraint.foreignClassId
+          ? introspectionResultsByKind.classById[constraint.foreignClassId]
+          : null;
+        if (!foreignTable) {
+          throw new Error(`Could not find the foreign table (constraint: ${constraint.name})`);
+        }
+        if (omit(foreignTable, 'read') || omit(foreignTable, 'filter')) {
+          return memo;
+        }
+        const attributes = (introspectionResultsByKind.attribute as PgAttribute[])
+          .filter((attr) => attr.classId === table.id)
+          .sort((a, b) => a.num - b.num);
+        const foreignAttributes = (introspectionResultsByKind.attribute as PgAttribute[])
+          .filter((attr) => attr.classId === foreignTable.id)
+          .sort((a, b) => a.num - b.num);
+        const keyAttributes = constraint.keyAttributeNums.map(
+          (num) => attributes.filter((attr) => attr.num === num)[0]
+        );
+        const foreignKeyAttributes = constraint.foreignKeyAttributeNums.map(
+          (num) => foreignAttributes.filter((attr) => attr.num === num)[0]
+        );
+        if (keyAttributes.some((attr) => omit(attr, 'read'))) {
+          return memo;
+        }
+        if (foreignKeyAttributes.some((attr) => omit(attr, 'read'))) {
+          return memo;
+        }
+        memo.push({
+          table,
+          keyAttributes,
+          foreignTable,
+          foreignKeyAttributes,
+          constraint,
+        });
+        return memo;
+      }, []);
+
+    let forwardRelationSpecByFieldName: {
+      [fieldName: string]: ForwardRelationSpec;
+    } = {};
+
+    const addField = (
+      fieldName: string,
+      description: string,
+      type: any,
+      resolve: any,
+      spec: ForwardRelationSpec,
+      hint: string
+    ) => {
+      // Field
+      fields = extend(
+        fields,
+        {
+          [fieldName]: fieldWithHooks(
+            fieldName,
+            {
+              description,
+              type,
+            },
+            {
+              isPgConnectionFilterField: true,
+            }
+          ),
+        },
+        hint
+      );
+      // Spec for use in resolver
+      forwardRelationSpecByFieldName = extend(forwardRelationSpecByFieldName, {
+        [fieldName]: spec,
+      });
+      // Resolver
+      connectionFilterRegisterResolver(Self.name, fieldName, resolve);
+    };
+
+    const resolve: ConnectionFilterResolver = ({sourceAlias, fieldName, fieldValue, queryBuilder}) => {
+      if (fieldValue == null) return null;
+
+      const {foreignTable, foreignKeyAttributes, keyAttributes} = forwardRelationSpecByFieldName[fieldName];
+
+      const foreignTableAlias = sql.identifier(Symbol());
+
+      const sqlIdentifier = sql.identifier(foreignTable.namespace.name, foreignTable.name);
+
+      /******************************
+       * HISTORICAL CHANGES BEGIN
+       *******************************/
+
+      const keyMatches = keyAttributes.map((key, i) => {
+        return sql.fragment`${sourceAlias}.${sql.identifier(key.name)} = ${foreignTableAlias}.${sql.identifier(
+          foreignKeyAttributes[i].name
+        )}`;
+      });
+
+      if (queryBuilder.context.args?.blockHeight && hasBlockRange(table)) {
+        keyMatches.push(makeRangeQuery(foreignTableAlias, queryBuilder.context.args.blockHeight, sql));
+      }
+
+      const sqlKeysMatch = sql.query`(${sql.join(keyMatches, ') and (')})`;
+
+      /******************************
+       * HISTORICAL CHANGES END
+       *******************************/
+
+      const foreignTableTypeName = inflection.tableType(foreignTable);
+      const foreignTableFilterTypeName = inflection.filterType(foreignTableTypeName);
+
+      const sqlFragment = connectionFilterResolve(
+        fieldValue,
+        foreignTableAlias,
+        foreignTableFilterTypeName,
+        queryBuilder
+      );
+
+      return sqlFragment == null
+        ? null
+        : sql.query`\
+      exists(
+        select 1 from ${sqlIdentifier} as ${foreignTableAlias}
+        where ${sqlKeysMatch} and
+          (${sqlFragment})
+      )`;
+    };
+
+    const resolveExists: ConnectionFilterResolver = ({sourceAlias, fieldName, fieldValue, queryBuilder}) => {
+      if (fieldValue == null) return null;
+
+      const {foreignTable, foreignKeyAttributes, keyAttributes} = forwardRelationSpecByFieldName[fieldName];
+
+      const foreignTableAlias = sql.identifier(Symbol());
+
+      const sqlIdentifier = sql.identifier(foreignTable.namespace.name, foreignTable.name);
+
+      /******************************
+       * HISTORICAL CHANGES BEGIN
+       *******************************/
+
+      const keyMatches = keyAttributes.map((key, i) => {
+        return sql.fragment`${sourceAlias}.${sql.identifier(key.name)} = ${foreignTableAlias}.${sql.identifier(
+          foreignKeyAttributes[i].name
+        )}`;
+      });
+
+      if (queryBuilder.context.args?.blockHeight && hasBlockRange(table)) {
+        keyMatches.push(makeRangeQuery(foreignTableAlias, queryBuilder.context.args.blockHeight, sql));
+      }
+
+      const sqlKeysMatch = sql.query`(${sql.join(keyMatches, ') and (')})`;
+
+      /******************************
+       * HISTORICAL CHANGES END
+       *******************************/
+
+      const sqlSelectWhereKeysMatch = sql.query`select 1 from ${sqlIdentifier} as ${foreignTableAlias} where ${sqlKeysMatch}`;
+
+      return fieldValue === true
+        ? sql.query`exists(${sqlSelectWhereKeysMatch})`
+        : sql.query`not exists(${sqlSelectWhereKeysMatch})`;
+    };
+
+    for (const spec of forwardRelationSpecs) {
+      const {constraint, foreignTable, keyAttributes} = spec;
+      const fieldName = inflection.singleRelationByKeys(keyAttributes, foreignTable, table, constraint);
+      const filterFieldName = inflection.filterSingleRelationFieldName(fieldName);
+      const foreignTableTypeName = inflection.tableType(foreignTable);
+      const foreignTableFilterTypeName = inflection.filterType(foreignTableTypeName);
+      const ForeignTableFilterType = connectionFilterType(
+        newWithHooks,
+        foreignTableFilterTypeName,
+        foreignTable,
+        foreignTableTypeName
+      );
+      if (!ForeignTableFilterType) continue;
+
+      addField(
+        filterFieldName,
+        `Filter by the object’s \`${fieldName}\` relation.`,
+        ForeignTableFilterType,
+        resolve,
+        spec,
+        `Adding connection filter forward relation field from ${describePgEntity(table)} to ${describePgEntity(
+          foreignTable
+        )}`
+      );
+
+      const keyIsNullable = !keyAttributes.every((attr) => attr.isNotNull);
+      if (keyIsNullable) {
+        const existsFieldName = inflection.filterForwardRelationExistsFieldName(fieldName);
+        addField(
+          existsFieldName,
+          `A related \`${fieldName}\` exists.`,
+          GraphQLBoolean,
+          resolveExists,
+          spec,
+          `Adding connection filter forward relation exists field from ${describePgEntity(table)} to ${describePgEntity(
+            foreignTable
+          )}`
+        );
+      }
+    }
+
+    return fields;
+  });
+};
+
+export interface ForwardRelationSpec {
+  table: PgClass;
+  keyAttributes: PgAttribute[];
+  foreignTable: PgClass;
+  foreignKeyAttributes: PgAttribute[];
+  constraint: PgConstraint;
+}
+
+export default PgConnectionArgFilterForwardRelationsPlugin;

--- a/packages/query/src/graphql/plugins/historical/index.ts
+++ b/packages/query/src/graphql/plugins/historical/index.ts
@@ -1,0 +1,14 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {PgBlockHeightPlugin} from './PgBlockHeightPlugin';
+import PgConnectionArgFilterBackwardRelationsPlugin from './PgConnectionArgFilterBackwardRelationsPlugin';
+import PgConnectionArgFilterForwardRelationsPlugin from './PgConnectionArgFilterForwardRelationsPlugin';
+
+const historicalPlugins = [
+  PgBlockHeightPlugin, // This must be before the other plugins to ensure the context is set
+  PgConnectionArgFilterBackwardRelationsPlugin,
+  PgConnectionArgFilterForwardRelationsPlugin,
+];
+
+export default historicalPlugins;

--- a/packages/query/src/graphql/plugins/historical/utils.ts
+++ b/packages/query/src/graphql/plugins/historical/utils.ts
@@ -1,0 +1,26 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {PgEntity, PgEntityKind, SQL} from '@subql/x-graphile-build-pg';
+
+export function makeRangeQuery(tableName: SQL, blockHeight: SQL, sql: any): SQL {
+  return sql.fragment`${tableName}._block_range @> ${blockHeight}`;
+}
+
+// Used to filter out _block_range attributes
+export function hasBlockRange(entity: PgEntity): boolean {
+  if (!entity) {
+    return true;
+  }
+
+  switch (entity.kind) {
+    case PgEntityKind.CLASS: {
+      return entity.attributes.some(({name}) => name === '_block_range');
+    }
+    case PgEntityKind.CONSTRAINT: {
+      return hasBlockRange(entity.class); // DOESNT WORK && notBlockRange(pgFieldIntrospection.foreignClass)
+    }
+    default:
+      return true;
+  }
+}

--- a/packages/query/src/graphql/plugins/index.ts
+++ b/packages/query/src/graphql/plugins/index.ts
@@ -49,11 +49,10 @@ import {GetMetadataPlugin} from './GetMetadataPlugin';
 import {smartTagsPlugin} from './smartTagsPlugin';
 import {makeAddInflectorsPlugin} from 'graphile-utils';
 import PgAggregationPlugin from './PgAggregationPlugin';
-import {PgBlockHeightPlugin} from './PgBlockHeightPlugin';
 import {PgRowByVirtualIdPlugin} from './PgRowByVirtualIdPlugin';
 import {PgDistinctPlugin} from './PgDistinctPlugin';
-import {makeAddPgTableOrderByPlugin, orderByAscDesc} from 'postgraphile';
 import PgConnectionArgOrderBy from './PgOrderByUnique';
+import historicalPlugins from './historical';
 
 /* eslint-enable */
 
@@ -102,6 +101,7 @@ export const pgDefaultPlugins = [
 const plugins = [
   ...defaultPlugins,
   ...pgDefaultPlugins,
+  ...historicalPlugins,
   PgConnectionArgOrderBy,
   PgSimplifyInflectorPlugin,
   PgManyToManyPlugin,
@@ -109,7 +109,6 @@ const plugins = [
   smartTagsPlugin,
   GetMetadataPlugin,
   PgAggregationPlugin,
-  PgBlockHeightPlugin,
   PgRowByVirtualIdPlugin,
   PgDistinctPlugin,
   makeAddInflectorsPlugin((inflectors) => {


### PR DESCRIPTION
# Description
This fixes an issue where any filtering on relations would not consider the block height when historical indexing is enabled. This was an issue in 2 plugins from [postgraphile-plugin-connection-filter](https://github.com/graphile-contrib/postgraphile-plugin-connection-filter). As a result the problematic plugins have been forked and modified within the query service to consider the historical block height. 

There are also some changes to the historical plugin to improve types and code reuse


Fixes https://github.com/subquery/subql/issues/2222

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
