### PR TITLE
Fix subscription drop queries

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `scale-batch-size` flag as it had no use (#2275)
 
+### Fixed
+- Drop subscription triggers and notifiy_functions (#2277)
+
 ## [7.3.0] - 2024-02-23
 ### Added
 - Schema Migration support for Enums, Relations, Subscription (#2251)

--- a/packages/node-core/src/db/migration-service/migration.ts
+++ b/packages/node-core/src/db/migration-service/migration.ts
@@ -202,11 +202,16 @@ export class Migration {
     } else {
       //TODO: DROP TRIGGER IF EXIST is not valid syntax for cockroach, better check trigger exist at first.
       if (this.dbType !== SUPPORT_DB.cockRoach) {
-        this.extraQueries.push(syncHelper.dropNotifyTrigger(this.schemaName, sequelizeModel.tableName));
+        // trigger drop should be prioritized
+        this.extraQueries.unshift(syncHelper.dropNotifyTrigger(this.schemaName, sequelizeModel.tableName));
       }
     }
 
-    if (!this.useSubscription && this.dbType !== SUPPORT_DB.cockRoach) {
+    if (
+      !this.extraQueries.includes(syncHelper.dropNotifyFunction(this.schemaName)) &&
+      !this.useSubscription &&
+      this.dbType !== SUPPORT_DB.cockRoach
+    ) {
       this.extraQueries.push(syncHelper.dropNotifyFunction(this.schemaName));
     }
 

--- a/packages/node-core/src/db/migration-service/migration.ts
+++ b/packages/node-core/src/db/migration-service/migration.ts
@@ -20,7 +20,7 @@ import {
   Transaction,
   Utils,
 } from '@subql/x-sequelize';
-import {isEqual} from 'lodash';
+import {isEqual, uniq} from 'lodash';
 import {NodeConfig} from '../../configure/NodeConfig';
 import {StoreService} from '../../indexer';
 import {getLogger} from '../../logger';
@@ -113,7 +113,7 @@ export class Migration {
         await this.sequelize.query(query, {transaction: effectiveTransaction});
       }
 
-      for (const query of this.extraQueries) {
+      for (const query of uniq(this.extraQueries)) {
         await this.sequelize.query(query, {transaction: effectiveTransaction});
       }
 
@@ -207,11 +207,7 @@ export class Migration {
       }
     }
 
-    if (
-      !this.extraQueries.includes(syncHelper.dropNotifyFunction(this.schemaName)) &&
-      !this.useSubscription &&
-      this.dbType !== SUPPORT_DB.cockRoach
-    ) {
+    if (!this.useSubscription && this.dbType !== SUPPORT_DB.cockRoach) {
       this.extraQueries.push(syncHelper.dropNotifyFunction(this.schemaName));
     }
 

--- a/packages/node/src/indexer/store.service.test.ts
+++ b/packages/node/src/indexer/store.service.test.ts
@@ -298,7 +298,6 @@ ORDER BY t.typname, e.enumsortorder;`,
   it('Able to drop notification triggers and functions', async () => {
     // if subscription is no longer enabled should be able to drop all prior triggers and functions related to subscription
     const cid = 'Qma3HraGKnH5Gte2WVs4sAAY6z5nBSqVuVq7Ef3eVQQPvz';
-
     schemaName = 'sync-schema-5';
 
     // simulate start with subscription then without subscription

--- a/packages/node/src/indexer/store.service.test.ts
+++ b/packages/node/src/indexer/store.service.test.ts
@@ -296,10 +296,12 @@ ORDER BY t.typname, e.enumsortorder;`,
     );
   });
   it('Able to drop notification triggers and functions', async () => {
+    // if subscription is no longer enabled should be able to drop all prior triggers and functions related to subscription
     const cid = 'Qma3HraGKnH5Gte2WVs4sAAY6z5nBSqVuVq7Ef3eVQQPvz';
 
     schemaName = 'sync-schema-5';
 
+    // simulate start with subscription then without subscription
     const initQueries = [
       `CREATE SCHEMA IF NOT EXISTS "${schemaName}";`,
       ` CREATE TABLE IF NOT EXISTS "${schemaName}"."transfers" ("id" text NOT NULL,

--- a/packages/node/src/indexer/store.service.test.ts
+++ b/packages/node/src/indexer/store.service.test.ts
@@ -3,7 +3,13 @@
 
 import { promisify } from 'util';
 import { INestApplication } from '@nestjs/common';
-import { DbOption } from '@subql/node-core';
+import {
+  createNotifyTrigger,
+  createSendNotificationTriggerFunction,
+  DbOption,
+  getFunctions,
+  getTriggers,
+} from '@subql/node-core';
 import { QueryTypes, Sequelize } from '@subql/x-sequelize';
 import rimraf from 'rimraf';
 import { prepareApp } from '../utils/test.utils';
@@ -288,5 +294,57 @@ ORDER BY t.typname, e.enumsortorder;`,
     expect(result.map((r: { enum_type: string }) => r.enum_type)).toStrictEqual(
       ['65c7fd4e5d', '65c7fd4e5d', '65c7fd4e5d'],
     );
+  });
+  it('Able to drop notification triggers and functions', async () => {
+    const cid = 'Qma3HraGKnH5Gte2WVs4sAAY6z5nBSqVuVq7Ef3eVQQPvz';
+
+    schemaName = 'sync-schema-5';
+
+    const initQueries = [
+      `CREATE SCHEMA IF NOT EXISTS "${schemaName}";`,
+      ` CREATE TABLE IF NOT EXISTS "${schemaName}"."transfers" ("id" text NOT NULL,
+            "amount" numeric NOT NULL,
+            "block_number" integer NOT NULL,
+            "date" timestamp NOT NULL,
+            "from_id" text NOT NULL,
+            "to_id" text NOT NULL,
+            "_id" UUID NOT NULL,
+            "_block_range" int8range NOT NULL, PRIMARY KEY ("_id"));`,
+      `CREATE TABLE IF NOT EXISTS "${schemaName}"."accounts" ("id" text NOT NULL,
+          "public_key" text NOT NULL,
+          "first_transfer_block" integer,
+          "last_transfer_block" integer,
+          "_id" UUID NOT NULL,
+          "_block_range" int8range NOT NULL, PRIMARY KEY ("_id"));`,
+      createSendNotificationTriggerFunction(schemaName),
+      createNotifyTrigger(schemaName, 'transfers'),
+      createNotifyTrigger(schemaName, 'accounts'),
+    ];
+    for (const q of initQueries) {
+      await sequelize.query(q);
+    }
+
+    app = await prepareApp(schemaName, cid, false, false);
+
+    projectService = app.get('IProjectService');
+    const apiService = app.get(ApiService);
+
+    await apiService.init();
+    await projectService.init(1);
+
+    tempDir = (projectService as any).project.root;
+
+    const accountTrigger = await getTriggers(sequelize, '0xe2ae28f317df40c5');
+    const transferTrigger = await getTriggers(sequelize, '0x2416ab4b88a0cdac');
+
+    const functions = await getFunctions(
+      sequelize,
+      schemaName,
+      'send_notification',
+    );
+
+    expect(accountTrigger.length).toBe(0);
+    expect(transferTrigger.length).toBe(0);
+    expect(functions.length).toBe(0);
   });
 });


### PR DESCRIPTION
# Description
if `subscription` was enabled and then disabled, on restart the node would fail to drop the exisitng triggers due to ordering issues on the SQL. 

Fix order, and remove duplicated drop notification queries

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
