### PR TITLE
Implement full text search

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for Full Text Search (#2280)
 
 ## [7.3.1] - 2024-02-29
 ### Removed

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.ts
@@ -164,6 +164,14 @@ export class SchemaMigrationService {
         for (const index of modelValue.addedIndexes) {
           migrationAction.createIndex(modelValue.model, index);
         }
+
+        if (modelValue.removedFullText) {
+          migrationAction.dropFullText(modelValue.model);
+        }
+
+        if (modelValue.addedFullText) {
+          migrationAction.createFullText(modelValue.model);
+        }
       }
 
       for (const relationModel of addedRelations) {

--- a/packages/node-core/src/db/migration-service/migration-helpers.ts
+++ b/packages/node-core/src/db/migration-service/migration-helpers.ts
@@ -40,16 +40,23 @@ export interface SchemaChangesType {
   modifiedEnums: GraphQLEnumsType[];
 }
 
+/**
+ *  Checks that 2 string arrays are the same independent of order
+ * */
+function arrayUnorderedMatch(a?: string[], b?: string[]): boolean {
+  return a?.sort().join(',') === b?.sort().join(',');
+}
+
 function indexesEqual(index1: GraphQLEntityIndex, index2: GraphQLEntityIndex): boolean {
   return (
-    index1.fields.sort().join(',') === index2.fields.sort().join(',') &&
+    arrayUnorderedMatch(index1.fields, index2.fields) &&
     index1.unique === index2.unique &&
     index1.using === index2.using
   );
 }
 
 function fullTextEqual(a?: GraphQLFullTextType, b?: GraphQLFullTextType): boolean {
-  return a?.fields.sort().join(', ') === b?.fields.sort().join(', ') && a?.language === b?.language;
+  return arrayUnorderedMatch(a?.fields, b?.fields) && a?.language === b?.language;
 }
 
 export function hasChanged(changes: SchemaChangesType): boolean {
@@ -144,8 +151,6 @@ export function compareModels(
 
       const addedFullText = !fullTextEqual(model.fullText, currentModel.fullText) ? model.fullText : undefined;
       const removedFullText = !fullTextEqual(model.fullText, currentModel.fullText) ? currentModel.fullText : undefined;
-
-      console.log('HERE', addedFullText, removedFullText);
 
       if (
         addedFields.length ||

--- a/packages/node-core/src/db/sync-helper.ts
+++ b/packages/node-core/src/db/sync-helper.ts
@@ -593,7 +593,7 @@ export const dropColumnQuery = (schema: string, columnName: string, tableName: s
   `ALTER TABLE  "${schema}"."${modelToTableName(tableName)}" DROP COLUMN IF EXISTS ${columnName};`;
 
 export const createColumnQuery = (schema: string, table: string, columnName: string, attributes: string): string =>
-  `ALTER TABLE IF EXISTS ${escapedName(schema, table)} ADD COLUMN IF NOT EXISTS "${columnName}" ${attributes};`;
+  `ALTER TABLE ${escapedName(schema, table)} ADD COLUMN IF NOT EXISTS "${columnName}" ${attributes};`;
 
 // fullTextSearch
 const TS_VECTOR_COL = '_tsv';

--- a/packages/node-core/src/db/sync-helper.ts
+++ b/packages/node-core/src/db/sync-helper.ts
@@ -68,16 +68,28 @@ export function getUniqConstraint(tableName: string, field: string): string {
   return [tableName, field, 'uindex'].map(underscored).join('_');
 }
 
-export function commentConstraintQuery(table: string, constraint: string, comment: string): string {
-  return `COMMENT ON CONSTRAINT ${constraint} ON ${table} IS E'${comment}'`;
+function escapedName(...args: string[]): string {
+  return args.map((a) => `"${a}"`).join('.');
 }
 
-export function commentTableQuery(column: string, comment: string): string {
-  return `COMMENT ON TABLE ${column} IS E'${comment}'`;
+function commentOn(type: 'CONSTRAINT' | 'TABLE' | 'COLUMN' | 'FUNCTION', entity: string, comment: string): string {
+  return `COMMENT ON ${type} ${entity} IS E'${comment}'`;
+}
+
+export function commentConstraintQuery(schema: string, table: string, constraint: string, comment: string): string {
+  return commentOn('CONSTRAINT', escapedName(schema, table), comment);
+}
+
+export function commentTableQuery(schema: string, table: string, comment: string): string {
+  return commentOn('TABLE', escapedName(schema, table), comment);
 }
 
 export function commentColumnQuery(schema: string, table: string, column: string, comment: string): string {
-  return `COMMENT ON COLUMN "${schema}".${table}.${column} IS '${comment}';`;
+  return commentOn('COLUMN', escapedName(schema, table, column), comment);
+}
+
+export function commentOnFunction(schema: string, functionName: string, comment: string): string {
+  return commentOn('FUNCTION', escapedName(schema, functionName), comment);
 }
 
 // This is used when historical is disabled so that we can perform bulk updates
@@ -195,14 +207,22 @@ END$$;
   `;
 }
 
-export function dropNotifyTrigger(schema: string, table: string): string {
-  const triggerName = hashName(schema, 'notify_trigger', table);
+function dropTrigger(schema: string, table: string, triggerName: string): string {
   return `DROP TRIGGER IF EXISTS "${triggerName}"
     ON "${schema}"."${table}";`;
 }
 
+export function dropNotifyTrigger(schema: string, table: string): string {
+  const triggerName = hashName(schema, 'notify_trigger', table);
+  return dropTrigger(schema, table, triggerName);
+}
+
+function dropFunction(schema: string, functionName: string): string {
+  return `DROP FUNCTION IF EXISTS "${schema}"."${functionName}";`;
+}
+
 export function dropNotifyFunction(schema: string): string {
-  return `DROP FUNCTION IF EXISTS "${schema}".send_notification()`;
+  return dropFunction(schema, 'send_notification');
 }
 
 // Hot schema reload, _metadata table
@@ -215,7 +235,7 @@ export function createSchemaTrigger(schema: string, metadataTableName: string): 
     ON "${schema}"."${metadataTableName}"
     FOR EACH ROW
     WHEN ( new.key = 'schemaMigrationCount')
-    EXECUTE FUNCTION "${schema}".schema_notification()`;
+    EXECUTE FUNCTION "${schema}".schema_notification();`;
 }
 
 export function createSchemaTriggerFunction(schema: string): string {
@@ -246,7 +266,7 @@ const DEFAULT_SQL_EXE_BATCH = 2000;
  * Improve SQL which could potentially increase DB IO significantly,
  * this executes it by batch size, and in ASC id order
  **/
-export const sqlIterator = (tableName: string, sql: string, batch: number = DEFAULT_SQL_EXE_BATCH) => {
+export const sqlIterator = (tableName: string, sql: string, batch: number = DEFAULT_SQL_EXE_BATCH): string => {
   return `
   DO $$
   DECLARE
@@ -367,6 +387,8 @@ export function generateCreateTableQuery(
   Object.keys(attributes).forEach((key) => {
     const attr = attributes[key];
 
+    assert(attr.field, 'Expected field to be set on attribute');
+
     if (timestampKeys.find((k) => k === attr.field)) {
       attr.type = 'timestamp with time zone';
     }
@@ -375,7 +397,7 @@ export function generateCreateTableQuery(
 
     columnDefinitions.push(columnDefinition);
     if (attr.comment) {
-      comments.push(`COMMENT ON COLUMN "${schema}"."${tableName}"."${attr.field}" IS '${attr.comment}';`);
+      comments.push(commentColumnQuery(schema, tableName, attr.field, attr.comment));
     }
     if (attr.primaryKey) {
       primaryKeyColumns.push(`"${attr.field}"`);
@@ -443,7 +465,7 @@ export function sortModels(relations: GraphQLRelationsType[], models: GraphQLMod
 export function validateNotifyTriggers(triggerName: string, triggers: NotifyTriggerPayload[]): void {
   if (triggers.length !== NotifyTriggerManipulationType.length) {
     throw new Error(
-      `Found ${triggers.length} ${triggerName} triggers, expected ${NotifyTriggerManipulationType.length} triggers `
+      `Found ${triggers.length} ${triggerName} triggers, expected ${NotifyTriggerManipulationType.length} triggers`
     );
   }
   triggers.map((t) => {
@@ -508,7 +530,7 @@ export async function getExistingEnums(schema: string, sequelize: Sequelize): Pr
 
 // enums
 export const dropEnumQuery = (enumTypeValue: string, schema: string): string =>
-  `DROP TYPE IF EXISTS "${schema}"."${enumTypeValue}"`;
+  `DROP TYPE IF EXISTS "${schema}"."${enumTypeValue}";`;
 export const commentOnEnumQuery = (type: string, comment: string): string => `COMMENT ON TYPE ${type} IS E${comment};`;
 export const createEnumQuery = (type: string, enumValues: string): string =>
   `CREATE TYPE ${type} AS ENUM (${enumValues});`;
@@ -516,6 +538,7 @@ export const createEnumQuery = (type: string, enumValues: string): string =>
 // relations
 export const dropRelationQuery = (schemaName: string, tableName: string, fkConstraint: string): string =>
   `ALTER TABLE "${schemaName}"."${tableName}" DROP CONSTRAINT IF EXISTS ${fkConstraint};`;
+
 export function generateForeignKeyQuery(attribute: ModelAttributeColumnOptions, tableName: string): string | void {
   const references = attribute?.references as ModelAttributeColumnReferencesOptions;
   if (!references) {
@@ -561,7 +584,7 @@ export const createIndexQuery = (indexOptions: IndexesOptions, tableName: string
     `CREATE ${indexOptions.unique ? 'UNIQUE ' : ''}INDEX IF NOT EXISTS "${indexOptions.name}" ` +
     `ON "${schema}"."${tableName}" ` +
     `${indexOptions.using ? `USING ${indexOptions.using} ` : ''}` +
-    `(${indexOptions.fields.join(', ')})`
+    `(${indexOptions.fields.join(', ')});`
   );
 };
 
@@ -569,5 +592,50 @@ export const createIndexQuery = (indexOptions: IndexesOptions, tableName: string
 export const dropColumnQuery = (schema: string, columnName: string, tableName: string): string =>
   `ALTER TABLE  "${schema}"."${modelToTableName(tableName)}" DROP COLUMN IF EXISTS ${columnName};`;
 
-export const createColumnQuery = (schema: string, tableName: string, columnName: string, attributes: string): string =>
-  `ALTER TABLE IF EXISTS "${schema}"."${tableName}" ADD COLUMN IF NOT EXISTS "${columnName}" ${attributes};`;
+export const createColumnQuery = (schema: string, table: string, columnName: string, attributes: string): string =>
+  `ALTER TABLE IF EXISTS ${escapedName(schema, table)} ADD COLUMN IF NOT EXISTS "${columnName}" ${attributes};`;
+
+// fullTextSearch
+const TS_VECTOR_COL = '_tsv';
+
+export const dropTsVectorColumnQuery = (schema: string, table: string): string =>
+  dropColumnQuery(schema, table, TS_VECTOR_COL);
+export const createTsVectorColumnQuery = (
+  schema: string,
+  table: string,
+  fields: string[],
+  language = 'english'
+): string => {
+  const generated = `GENERATED ALWAYS as (to_tsvector('pg_catalog.${language}', ${fields
+    .map((field) => `coalesce(${escapedName(field)}, '')`)
+    .join(` || ' ' || `)})) STORED`;
+  return createColumnQuery(schema, table, TS_VECTOR_COL, `tsvector ${generated}`);
+};
+
+export const createTsVectorCommentQuery = (schema: string, table: string): string =>
+  commentColumnQuery(schema, table, TS_VECTOR_COL, '@omit all');
+
+const tsVectorIndexName = (schema: string, table: string) => hashName(schema, 'fulltext_idx', table);
+export const dropTsVectorIndexQuery = (schema: string, table: string): string =>
+  dropIndexQuery(schema, tsVectorIndexName(schema, table));
+
+export const createTsVectorIndexQuery = (schema: string, table: string): string =>
+  createIndexQuery({using: 'gist', fields: [TS_VECTOR_COL], name: tsVectorIndexName(schema, table)}, table, schema);
+
+const searchFunctionName = (schema: string, table: string): string => hashName(schema, 'search', table);
+export const dropSearchFunctionQuery = (schema: string, table: string): string =>
+  dropFunction(schema, searchFunctionName(schema, table));
+export const createSearchFunctionQuery = (schema: string, table: string): string => {
+  const functionName = searchFunctionName(schema, table);
+  return `
+create or replace function ${escapedName(schema, functionName)}(search text)
+  returns setof ${escapedName(schema, table)} as $$
+    select *
+    from ${escapedName(schema, table)} as "table"
+    where "table"."${TS_VECTOR_COL}" @@ to_tsquery(search)
+  $$ language sql stable;
+  `;
+};
+
+export const commentSearchFunctionQuery = (schema: string, table: string): string =>
+  commentOnFunction(schema, searchFunctionName(schema, table), `@name search_${table}`);

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Fulltext search plugin to sanitise search input (#2280)
 
 ## [2.9.1] - 2024-02-29
 ### Fixed
@@ -254,7 +256,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2021-04-20
 ### Added
 - Remove `condition` in query schema, please use `filter` instead (#260)
-- `@jsonField` annotation is now supported in `graphql.schema` which allows you to store structured data JSON data in a single database field
+-  annotation is now supported in 
   - We'll automatically generate coresponding JSON interfaces when querying this data (#275)
   - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
 

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -50,6 +50,7 @@
     "graphql-query-complexity": "^0.11.0",
     "lodash": "^4.17.21",
     "pg": "^8.7.1",
+    "pg-tsquery": "^8.4.2",
     "postgraphile": "^4.13.0",
     "postgraphile-plugin-connection-filter": "^2.2.2",
     "reflect-metadata": "^0.1.13",

--- a/packages/query/src/graphql/plugins/PgSearchPlugin.ts
+++ b/packages/query/src/graphql/plugins/PgSearchPlugin.ts
@@ -1,0 +1,31 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {PgEntity, PgEntityKind, PgProc} from '@subql/x-graphile-build-pg';
+import {Plugin, Context} from 'graphile-build';
+import {Tsquery} from 'pg-tsquery';
+
+const parser = new Tsquery();
+
+function isProcedure(entity?: PgEntity): entity is PgProc {
+  return entity?.kind === PgEntityKind.PROCEDURE;
+}
+
+export const PgSearchPlugin: Plugin = (builder) => {
+  // Sanitises the search argument for fulltext search using pg-tsquery
+  builder.hook('GraphQLObjectType:fields:field', (field, build, {scope: {pgFieldIntrospection}}: Context<any>) => {
+    if (isProcedure(pgFieldIntrospection) && pgFieldIntrospection.argNames.includes('search')) {
+      return {
+        ...field,
+        resolve(source, args, ctx, info) {
+          if (args.search !== undefined) {
+            args.search = parser.parse(args.search).toString();
+          }
+          return field.resolve?.(source, args, ctx, info);
+        },
+      };
+    }
+
+    return field;
+  });
+};

--- a/packages/query/src/graphql/plugins/historical/utils.ts
+++ b/packages/query/src/graphql/plugins/historical/utils.ts
@@ -8,7 +8,7 @@ export function makeRangeQuery(tableName: SQL, blockHeight: SQL, sql: any): SQL 
 }
 
 // Used to filter out _block_range attributes
-export function hasBlockRange(entity: PgEntity): boolean {
+export function hasBlockRange(entity?: PgEntity): boolean {
   if (!entity) {
     return true;
   }

--- a/packages/query/src/graphql/plugins/index.ts
+++ b/packages/query/src/graphql/plugins/index.ts
@@ -53,6 +53,7 @@ import {PgRowByVirtualIdPlugin} from './PgRowByVirtualIdPlugin';
 import {PgDistinctPlugin} from './PgDistinctPlugin';
 import PgConnectionArgOrderBy from './PgOrderByUnique';
 import historicalPlugins from './historical';
+import {PgSearchPlugin} from './PgSearchPlugin';
 
 /* eslint-enable */
 
@@ -111,6 +112,7 @@ const plugins = [
   PgAggregationPlugin,
   PgRowByVirtualIdPlugin,
   PgDistinctPlugin,
+  PgSearchPlugin,
   makeAddInflectorsPlugin((inflectors) => {
     const {constantCase: oldConstantCase} = inflectors;
     const enumValues = new Set();

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New fullText graphql directive (#2280)
 
 ## [2.7.1] - 2024-02-29
 ### Fixed

--- a/packages/utils/src/graphql/constant.ts
+++ b/packages/utils/src/graphql/constant.ts
@@ -5,4 +5,5 @@ export enum DirectiveName {
   DerivedFrom = 'derivedFrom',
   Entity = 'entity',
   JsonField = 'jsonField',
+  FullText = 'fullText',
 }

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -367,7 +367,7 @@ describe('utils that handle schema.graphql', () => {
 
   it('can read fulltext directive', () => {
     const graphqlSchema = gql`
-      type StarterEntity @entity @fulltext(fields: ["field2", "field3"], language: "english") {
+      type StarterEntity @entity @fullText(fields: ["field2", "field3"], language: "english") {
         id: ID! #id is a required field
         field1: Int!
         field2: String #field2 is an optional field
@@ -378,12 +378,12 @@ describe('utils that handle schema.graphql', () => {
     const schema = buildSchemaFromDocumentNode(graphqlSchema);
     const entities = getAllEntitiesRelations(schema);
 
-    expect(entities.models?.[0].indexes[0].fields).toEqual(['field1', 'field2']);
+    expect(entities.models?.[0].fullText?.fields).toEqual(['field1', 'field2']);
   });
 
   it('can throw fulltext directive when field doesnt exist on entity', () => {
     const graphqlSchema = gql`
-      type StarterEntity @entity @fulltext(fields: ["field2", "not_exits"], language: "english") {
+      type StarterEntity @entity @fullText(fields: ["field2", "not_exits"], language: "english") {
         id: ID! #id is a required field
         field1: Int!
         field2: String #field2 is an optional field
@@ -399,7 +399,7 @@ describe('utils that handle schema.graphql', () => {
 
   it('can throw fulltext directive when field isnt a string', () => {
     const graphqlSchema = gql`
-      type StarterEntity @entity @fulltext(fields: ["field1"], language: "english") {
+      type StarterEntity @entity @fullText(fields: ["field1"], language: "english") {
         id: ID! #id is a required field
         field1: Int!
         field2: String #field2 is an optional field

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -378,12 +378,12 @@ describe('utils that handle schema.graphql', () => {
     const schema = buildSchemaFromDocumentNode(graphqlSchema);
     const entities = getAllEntitiesRelations(schema);
 
-    expect(entities.models?.[0].fullText?.fields).toEqual(['field1', 'field2']);
+    expect(entities.models?.[0].fullText?.fields).toEqual(['field2', 'field3']);
   });
 
   it('can throw fulltext directive when field doesnt exist on entity', () => {
     const graphqlSchema = gql`
-      type StarterEntity @entity @fullText(fields: ["field2", "not_exits"], language: "english") {
+      type StarterEntity @entity @fullText(fields: ["field2", "not_exists"], language: "english") {
         id: ID! #id is a required field
         field1: Int!
         field2: String #field2 is an optional field
@@ -392,7 +392,7 @@ describe('utils that handle schema.graphql', () => {
     `;
 
     const schema = buildSchemaFromDocumentNode(graphqlSchema);
-    expect(getAllEntitiesRelations(schema)).toThrow(
+    expect(() => getAllEntitiesRelations(schema)).toThrow(
       `Field "not_exists" in fullText directive doesn't exist on entity "StarterEntity"`
     );
   });
@@ -408,6 +408,6 @@ describe('utils that handle schema.graphql', () => {
     `;
 
     const schema = buildSchemaFromDocumentNode(graphqlSchema);
-    expect(getAllEntitiesRelations(schema)).toThrow(`fullText directive fields only supports String types`);
+    expect(() => getAllEntitiesRelations(schema)).toThrow(`fullText directive fields only supports String types`);
   });
 });

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -364,4 +364,50 @@ describe('utils that handle schema.graphql', () => {
       /Composite index on entity StarterEntity expected not more than 3 fields,/
     );
   });
+
+  it('can read fulltext directive', () => {
+    const graphqlSchema = gql`
+      type StarterEntity @entity @fulltext(fields: ["field2", "field3"], language: "english") {
+        id: ID! #id is a required field
+        field1: Int!
+        field2: String #field2 is an optional field
+        field3: String
+      }
+    `;
+
+    const schema = buildSchemaFromDocumentNode(graphqlSchema);
+    const entities = getAllEntitiesRelations(schema);
+
+    expect(entities.models?.[0].indexes[0].fields).toEqual(['field1', 'field2']);
+  });
+
+  it('can throw fulltext directive when field doesnt exist on entity', () => {
+    const graphqlSchema = gql`
+      type StarterEntity @entity @fulltext(fields: ["field2", "not_exits"], language: "english") {
+        id: ID! #id is a required field
+        field1: Int!
+        field2: String #field2 is an optional field
+        field3: String
+      }
+    `;
+
+    const schema = buildSchemaFromDocumentNode(graphqlSchema);
+    expect(getAllEntitiesRelations(schema)).toThrow(
+      `Field "not_exists" in fullText directive doesn't exist on entity "StarterEntity"`
+    );
+  });
+
+  it('can throw fulltext directive when field isnt a string', () => {
+    const graphqlSchema = gql`
+      type StarterEntity @entity @fulltext(fields: ["field1"], language: "english") {
+        id: ID! #id is a required field
+        field1: Int!
+        field2: String #field2 is an optional field
+        field3: String
+      }
+    `;
+
+    const schema = buildSchemaFromDocumentNode(graphqlSchema);
+    expect(getAllEntitiesRelations(schema)).toThrow(`fullText directive fields only supports String types`);
+  });
 });

--- a/packages/utils/src/graphql/schema/directives.ts
+++ b/packages/utils/src/graphql/schema/directives.ts
@@ -9,4 +9,5 @@ export const directives = gql`
   directive @jsonField(indexed: Boolean) on OBJECT
   directive @index(unique: Boolean) on FIELD_DEFINITION
   directive @compositeIndexes(fields: [[String]]!) on OBJECT
+  directive @fullText(fields: [String!], language: String) on OBJECT
 `;

--- a/packages/utils/src/graphql/types.ts
+++ b/packages/utils/src/graphql/types.ts
@@ -37,6 +37,8 @@ export interface GraphQLModelsType {
 
   indexes: GraphQLEntityIndex[];
 
+  fullText?: GraphQLFullTextType;
+
   description?: string;
 }
 
@@ -71,6 +73,12 @@ export interface GraphQLEntityIndex {
   unique?: boolean;
 
   using?: IndexType;
+}
+
+export interface GraphQLFullTextType {
+  fields: string[];
+
+  language?: string;
 }
 
 export interface GraphQLRelationsType {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6631,6 +6631,7 @@ __metadata:
     lodash: ^4.17.21
     nodemon: ^2.0.15
     pg: ^8.7.1
+    pg-tsquery: ^8.4.2
     postgraphile: ^4.13.0
     postgraphile-plugin-connection-filter: ^2.2.2
     reflect-metadata: ^0.1.13
@@ -18725,6 +18726,13 @@ __metadata:
   peerDependencies:
     pg: ">=6.1.0 <9"
   checksum: a9ada8a0113d9ea24e435acd627f080512c5b15248afefb0a67e4d01415c8d692b25d731cce58345b0cbef6fab334471b5cb4c5e7a07dc85ded98160aa61cbc2
+  languageName: node
+  linkType: hard
+
+"pg-tsquery@npm:^8.4.2":
+  version: 8.4.2
+  resolution: "pg-tsquery@npm:8.4.2"
+  checksum: 1ab466096775573285f16ec6b2fa93906a6203f2013bb739c6c38a7b9e858cb8f55cb0bd2c7b97167edb38bae4fda2c288822f41c6a1e6507866cc1afd52ff36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
Adds a new directive to graphql schemas that allows for full text search on entities. Full text search can be applied to `ID`, `String` and relation types. 

Internally this will create a new generated column on the table that will be a tsvector from the provided fields and language. An index will also be created on this column. Then a search function is created to perform a search which is then picked up by postgraphile to expose the search functionality.

Example schema:
```graphql
type Transfer @entity @fullText(fields: ["from", "to"], language: "english") {
  id: ID!
  amount: BigInt!
  blockNumber: Int!
  date: Date!
  from: Account!
  to: Account!
}
```

Example query:
```graphql
{
    # search transfers where toId or fromId begins with '15zf7zvduiy2eycgn6kwb'
    searchTransfers(search: "15zf7zvduiy2eycgn6kwb:*") {
        nodes {
            toId
            fromId
        }
    }
}
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/484
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
