### PR TITLE
fix migration poi sql script

### DIFF
--- a/packages/node-core/src/indexer/poi/poi.service.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.ts
@@ -98,7 +98,7 @@ export class PoiService implements OnApplicationShutdown {
         }
         if (!checkResult.hash_nullable) {
           queries.push(`ALTER TABLE ${tableName} ALTER COLUMN "hash" DROP NOT NULL;`);
-          queries.push(sqlIterator(tableName, `UPDATE ${tableName} SET hash = NULL;`));
+          queries.push(sqlIterator(tableName, `UPDATE ${tableName} SET hash = NULL`));
           queries.push(
             sqlIterator(
               tableName,


### PR DESCRIPTION
Fix error "<PoiService> ERROR Migration poi failed with query:" when migrate indexer from v2.x.x to v3.x.x
