### PR TITLE
Update docker images to use non-root user

### DIFF
--- a/packages/node/Dockerfile
+++ b/packages/node/Dockerfile
@@ -30,6 +30,9 @@ RUN apk add --no-cache tini curl git && \
     yarn cache clean && \
     rm -rf /root/.npm /root/.cache
 
+# Make the user not ROOT
+USER 1000
+
 # Set Entry point and command
 ENTRYPOINT ["/sbin/tini", "--", "bin/run"]
 CMD ["-f","/app"]

--- a/packages/query/Dockerfile
+++ b/packages/query/Dockerfile
@@ -30,6 +30,9 @@ RUN apk add --no-cache tini curl git && \
     yarn cache clean && \
     rm -rf /root/.npm /root/.cache
 
+# Make the user not ROOT
+USER 1000
+
 # Set Entry point and command
 ENTRYPOINT ["/sbin/tini", "--", "bin/run"]
 CMD ["-f","/app"]


### PR DESCRIPTION
# Description
By default docker images will use the root user. For increased security we now set the user to uid 1000
