### PR TITLE
Remove entryScript from datasources

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Memory leak with workers and large number of (dynamic) datasources (#2292)
 
 ## [7.4.0] - 2024-03-05
 ### Fixed

--- a/packages/node-core/src/indexer/dictionary.service.test.ts
+++ b/packages/node-core/src/indexer/dictionary.service.test.ts
@@ -17,7 +17,6 @@ const mockDS = [
     kind: SubstrateDatasourceKind.Runtime,
     startBlock: 100,
     mapping: {
-      entryScript: '',
       handlers: [
         {
           handler: 'handleTest',
@@ -36,7 +35,6 @@ const mockDS = [
     kind: SubstrateDatasourceKind.Runtime,
     startBlock: 500,
     mapping: {
-      entryScript: '',
       handlers: [
         {
           handler: 'handleTest',
@@ -56,7 +54,6 @@ const mockDS = [
     kind: SubstrateDatasourceKind.Runtime,
     startBlock: 1000,
     mapping: {
-      entryScript: '',
       handlers: [
         {
           handler: 'handleTest',

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -110,9 +110,8 @@ export async function getEnumDeprecated(sequelize: Sequelize, enumTypeNameDeprec
 }
 
 type IsCustomDs<DS, CDS> = (x: DS | CDS) => x is CDS;
-export type SubqlProjectDs<DS extends BaseDataSource> = DS & {
-  mapping: DS['mapping'] & {entryScript: string};
-};
+// TODO remove this type, it would result in a breaking change though
+export type SubqlProjectDs<DS extends BaseDataSource> = DS;
 
 export function getModulos<DS extends BaseDataSource, CDS extends DS & BaseCustomDataSource>(
   dataSources: DS[],
@@ -165,12 +164,12 @@ export async function updateDataSourcesV1_0_0<DS extends BaseDataSource, CDS ext
         }
         return {
           ...dataSource,
-          mapping: {...dataSource.mapping, entryScript, file},
+          mapping: {...dataSource.mapping, file},
         };
       } else {
         return {
           ...dataSource,
-          mapping: {...dataSource.mapping, entryScript, file},
+          mapping: {...dataSource.mapping, file},
         };
       }
     })

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -111,6 +111,9 @@ export async function getEnumDeprecated(sequelize: Sequelize, enumTypeNameDeprec
 
 type IsCustomDs<DS, CDS> = (x: DS | CDS) => x is CDS;
 // TODO remove this type, it would result in a breaking change though
+/**
+ * @deprecated Please unwrap the datasource from this type
+ * */
 export type SubqlProjectDs<DS extends BaseDataSource> = DS;
 
 export function getModulos<DS extends BaseDataSource, CDS extends DS & BaseCustomDataSource>(
@@ -141,7 +144,7 @@ export async function updateDataSourcesV1_0_0<DS extends BaseDataSource, CDS ext
   reader: Reader,
   root: string,
   isCustomDs: IsCustomDs<DS, CDS>
-): Promise<SubqlProjectDs<DS | CDS>[]> {
+): Promise<(DS | CDS)[]> {
   // force convert to updated ds
   return Promise.all(
     _dataSources.map(async (dataSource) => {
@@ -309,7 +312,7 @@ export async function loadProjectTemplates<T extends BaseDataSource & TemplateBa
   root: string,
   reader: Reader,
   isCustomDs: IsCustomDs<BaseDataSource, BaseCustomDataSource>
-): Promise<SubqlProjectDs<T>[]> {
+): Promise<T[]> {
   if (!templates || !templates.length) {
     return [];
   }
@@ -317,7 +320,7 @@ export async function loadProjectTemplates<T extends BaseDataSource & TemplateBa
   return dsTemplates.map((ds, index) => ({
     ...ds,
     name: templates[index].name,
-  })) as SubqlProjectDs<T>[]; // How to get rid of cast here?
+  })) as T[]; // How to get rid of cast here?
 }
 
 export function getStartHeight(dataSources: BaseDataSource[]): number {

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove usage of deprecated type
 
 ## [3.9.0] - 2024-03-05
 ### Changed

--- a/packages/node/src/configure/SubqueryProject.spec.ts
+++ b/packages/node/src/configure/SubqueryProject.spec.ts
@@ -16,23 +16,12 @@ import {
   SubstrateCustomDataSourceImpl,
   isCustomDs,
 } from '@subql/common-substrate';
-import {
-  loadDataSourceScript,
-  saveFile,
-  SubqlProjectDs,
-  updateDataSourcesEntry,
-  updateDataSourcesV1_0_0,
-  updateProcessor,
-} from '@subql/node-core';
+import { updateDataSourcesV1_0_0 } from '@subql/node-core';
 import {
   SubstrateCustomDatasource,
   SubstrateRuntimeDatasource,
 } from '@subql/types';
-import {
-  BaseCustomDataSource,
-  BaseDataSource,
-  Reader,
-} from '@subql/types-core';
+import { Reader } from '@subql/types-core';
 import { SubqueryProject } from './SubqueryProject';
 
 // eslint-disable-next-line jest/no-export

--- a/packages/node/src/configure/SubqueryProject.ts
+++ b/packages/node/src/configure/SubqueryProject.ts
@@ -16,7 +16,6 @@ import {
 import {
   insertBlockFiltersCronSchedules,
   loadProjectTemplates,
-  SubqlProjectDs,
   updateDataSourcesV1_0_0,
   ISubqueryProject,
 } from '@subql/node-core';
@@ -35,10 +34,10 @@ import { getChainTypes } from '../utils/project';
 
 const { version: packageVersion } = require('../../package.json');
 
-export type SubstrateProjectDs = SubqlProjectDs<SubstrateDatasource>;
+export type SubstrateProjectDs = SubstrateDatasource;
 export type SubqlProjectDsTemplate =
-  | SubqlProjectDs<RuntimeDatasourceTemplate>
-  | SubqlProjectDs<CustomDatasourceTemplate>;
+  | RuntimeDatasourceTemplate
+  | CustomDatasourceTemplate;
 
 export type SubqlProjectBlockFilter = SubstrateBlockFilter & {
   cronSchedule?: {

--- a/packages/node/src/indexer/ds-processor.service.spec.ts
+++ b/packages/node/src/indexer/ds-processor.service.spec.ts
@@ -25,7 +25,6 @@ function getTestProject(
         processor: { file: 'test/jsonfy.js' },
         startBlock: 1,
         mapping: {
-          entryScript: '',
           handlers: [{ handler: 'testSandbox', kind: 'substrate/JsonfyEvent' }],
         },
       },

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -75,7 +75,6 @@ function testSubqueryProject_1(): SubqueryProject {
         startBlock: 1,
         mapping: {
           file: '',
-          entryScript: '',
           handlers: [
             { handler: 'testSandbox', kind: SubstrateHandlerKind.Event },
           ],
@@ -85,7 +84,6 @@ function testSubqueryProject_1(): SubqueryProject {
         kind: SubstrateDatasourceKind.Runtime,
         startBlock: 1,
         mapping: {
-          entryScript: '',
           file: '',
           handlers: [
             { handler: 'testSandbox', kind: SubstrateHandlerKind.Event },
@@ -114,7 +112,6 @@ function testSubqueryProject_2(): SubqueryProject {
         startBlock: 1,
         mapping: {
           file: '',
-          entryScript: `console.log('test handler runtime0')`,
           handlers: [
             { handler: 'testSandbox', kind: SubstrateHandlerKind.Event },
           ],

--- a/packages/node/src/subcommands/testing.service.ts
+++ b/packages/node/src/subcommands/testing.service.ts
@@ -9,7 +9,6 @@ import {
   TestingService as BaseTestingService,
   NestLogger,
   TestRunner,
-  SubqlProjectDs,
 } from '@subql/node-core';
 import { SubstrateDatasource } from '@subql/types';
 import { SubqueryProject } from '../configure/SubqueryProject';
@@ -24,7 +23,7 @@ export class TestingService extends BaseTestingService<
   ApiPromise,
   ApiAt,
   BlockContent | LightBlockContent,
-  SubqlProjectDs<SubstrateDatasource>
+  SubstrateDatasource
 > {
   constructor(
     nodeConfig: NodeConfig,
@@ -36,12 +35,7 @@ export class TestingService extends BaseTestingService<
   async getTestRunner(): Promise<
     [
       close: () => Promise<void>,
-      runner: TestRunner<
-        ApiPromise,
-        ApiAt,
-        BlockContent,
-        SubqlProjectDs<SubstrateDatasource>
-      >,
+      runner: TestRunner<ApiPromise, ApiAt, BlockContent, SubstrateDatasource>,
     ]
   > {
     const testContext = await NestFactory.createApplicationContext(


### PR DESCRIPTION
# Description
Fixes a memory leak with workers caused by all datasources having the utf8 string of the js code. This was exacerbated when having a large number of datasources/dynamic datasources.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
