### PR TITLE
Dynamic ds meta optimisation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -173,7 +173,7 @@ module.exports = {
   // ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
-  testRegex: '.*\\.(spec|test)\\.ts$',
+  testRegex: '.*\\.spec\\.ts$',
 
   // This option allows the use of a custom results processor
   // testResultsProcessor: undefined,

--- a/jest.config.js
+++ b/jest.config.js
@@ -173,7 +173,7 @@ module.exports = {
   // ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
-  testRegex: '.*\\.spec\\.ts$',
+  testRegex: '.*\\.(spec|test)\\.ts$',
 
   // This option allows the use of a custom results processor
   // testResultsProcessor: undefined,

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update connection retry logic and add backoff to fetch blocks retries (#2301)
+- Optimise metadata query when dealing with a large number of dynamic datasources that regularly increase (#2302)
 
 ## [7.4.1] - 2024-03-08
 ### Fixed

--- a/packages/node-core/src/indexer/dynamic-ds.service.spec.ts
+++ b/packages/node-core/src/indexer/dynamic-ds.service.spec.ts
@@ -1,0 +1,82 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {DatasourceParams, DynamicDsService} from './dynamic-ds.service';
+import {CacheMetadataModel} from './storeCache';
+
+class TestDynamicDsService extends DynamicDsService<DatasourceParams> {
+  protected async getDatasource(params: DatasourceParams): Promise<DatasourceParams> {
+    return Promise.resolve(params);
+  }
+}
+
+const testParam1 = {templateName: 'Test', startBlock: 1};
+const testParam2 = {templateName: 'Test', startBlock: 2};
+const testParam3 = {templateName: 'Test', startBlock: 3};
+const testParam4 = {templateName: 'Test', startBlock: 4};
+
+const mockMetadata = (initData: DatasourceParams[] = []) => {
+  let datasourceParams: DatasourceParams[] = initData;
+
+  return {
+    set: (key: string, value: any) => {
+      datasourceParams = value;
+    },
+    find: (key: string) => Promise.resolve([...datasourceParams]), // Clone here to make source immutable
+    setNewDynamicDatasource: (params: DatasourceParams) => datasourceParams.push(params),
+  } as unknown as CacheMetadataModel;
+};
+
+describe('DynamicDsService', () => {
+  let service: TestDynamicDsService;
+
+  beforeEach(() => {
+    service = new TestDynamicDsService();
+  });
+
+  it('loads all datasources and params when init', async () => {
+    await service.init(mockMetadata([testParam1]));
+
+    await expect(service.getDynamicDatasources()).resolves.toEqual([testParam1]);
+
+    expect((service as any)._datasourceParams).toEqual([testParam1]);
+  });
+
+  it('keeps reference to added dynamic datasources', async () => {
+    const meta = mockMetadata([testParam1]);
+    await service.init(meta);
+
+    await service.createDynamicDatasource(testParam2);
+
+    expect((service as any)._datasourceParams).toEqual([testParam1, testParam2]);
+
+    await expect(meta.find('dynamicDatasources')).resolves.toEqual([testParam1, testParam2]);
+    await expect(service.getDynamicDatasources()).resolves.toEqual([testParam1, testParam2]);
+  });
+
+  it('resets dynamic datasources', async () => {
+    const meta = mockMetadata([testParam1, testParam2, testParam3, testParam4]);
+    await service.init(meta);
+
+    await service.resetDynamicDatasource(2);
+
+    await expect(meta.find('dynamicDatasources')).resolves.toEqual([testParam1, testParam2]);
+    await expect(service.getDynamicDatasources()).resolves.toEqual([testParam1, testParam2]);
+  });
+
+  it('getDynamicDatasources with force reloads from metadata', async () => {
+    const meta = mockMetadata([testParam1, testParam2]);
+    await service.init(meta);
+
+    meta.set('dynamicDatasources', [testParam1, testParam2, testParam3, testParam4]);
+
+    await expect(service.getDynamicDatasources()).resolves.toEqual([testParam1, testParam2]);
+    await expect(service.getDynamicDatasources(true)).resolves.toEqual([
+      testParam1,
+      testParam2,
+      testParam3,
+      testParam4,
+    ]);
+    await expect(service.getDynamicDatasources()).resolves.toEqual([testParam1, testParam2, testParam3, testParam4]);
+  });
+});

--- a/packages/node-core/src/indexer/dynamic-ds.service.ts
+++ b/packages/node-core/src/indexer/dynamic-ds.service.ts
@@ -1,14 +1,12 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {isEqual, unionWith} from 'lodash';
 import {getLogger} from '../logger';
 import {CacheMetadataModel} from './storeCache/cacheMetadata';
 
 const logger = getLogger('dynamic-ds');
 
 const METADATA_KEY = 'dynamicDatasources';
-const TEMP_DS_PREFIX = 'ds_';
 
 export interface DatasourceParams {
   templateName: string;
@@ -24,14 +22,15 @@ export interface IDynamicDsService<DS> {
 
 export abstract class DynamicDsService<DS> implements IDynamicDsService<DS> {
   private _metadata?: CacheMetadataModel;
-  private tempDsRecords: Record<string, string> = {};
-
   private _datasources?: DS[];
+  private _datasourceParams?: DatasourceParams[];
+
+  protected abstract getDatasource(params: DatasourceParams): Promise<DS>;
 
   async init(metadata: CacheMetadataModel): Promise<void> {
     this._metadata = metadata;
 
-    this._datasources = await this.loadDynamicDatasources();
+    await this.getDynamicDatasources(true);
   }
 
   get dynamicDatasources(): DS[] {
@@ -52,25 +51,26 @@ export abstract class DynamicDsService<DS> implements IDynamicDsService<DS> {
    * remove dynamic ds that is created after this height
    * @param targetHeight this height is exclusive
    */
+  // eslint-disable-next-line @typescript-eslint/require-await
   async resetDynamicDatasource(targetHeight: number): Promise<void> {
-    const dynamicDs = await this.getDynamicDatasourceParams();
-    if (dynamicDs.length !== 0) {
-      const filteredDs = dynamicDs.filter((ds) => ds.startBlock <= targetHeight);
-      const dsRecords = JSON.stringify(filteredDs);
-      this.metadata.set(METADATA_KEY, dsRecords);
+    if (this._datasourceParams && this._datasourceParams.length !== 0) {
+      const filteredDs = this._datasourceParams.filter((ds) => ds.startBlock <= targetHeight);
+      this.metadata.set(METADATA_KEY, filteredDs);
+      await this.loadDynamicDatasources(filteredDs);
     }
   }
 
   async createDynamicDatasource(params: DatasourceParams): Promise<DS> {
     try {
       const ds = await this.getDatasource(params);
-
-      await this.saveDynamicDatasourceParams(params);
+      this.metadata.setNewDynamicDatasource(params);
 
       logger.info(`Created new dynamic datasource from template: "${params.templateName}"`);
 
       if (!this._datasources) this._datasources = [];
+      if (!this._datasourceParams) this._datasourceParams = [];
       this._datasources.push(ds);
+      this._datasourceParams.push(params);
 
       return ds;
     } catch (e: any) {
@@ -79,67 +79,24 @@ export abstract class DynamicDsService<DS> implements IDynamicDsService<DS> {
     }
   }
 
+  // Not force only seems to be used for project changes
   async getDynamicDatasources(forceReload?: boolean): Promise<DS[]> {
     // Workers should not cache this result in order to keep in sync
     if (!this._datasources || forceReload) {
-      this._datasources = await this.loadDynamicDatasources();
+      const params = (await this.metadata.find(METADATA_KEY)) ?? [];
+
+      await this.loadDynamicDatasources(params);
     }
 
-    return this._datasources;
+    // loadDynamicDatasources ensures this is set
+    return this._datasources as DS[];
   }
 
-  private async loadDynamicDatasources(): Promise<DS[]> {
-    try {
-      const params = await this.getDynamicDatasourceParams();
+  private async loadDynamicDatasources(params: DatasourceParams[]): Promise<void> {
+    const dataSources = await Promise.all(params.map((params) => this.getDatasource(params)));
 
-      const dataSources = await Promise.all(params.map((params) => this.getDatasource(params)));
-
-      logger.info(`Loaded ${dataSources.length} dynamic datasources`);
-
-      return dataSources;
-    } catch (e: any) {
-      logger.error(`Unable to get dynamic datasources:\n${e.message}`);
-      process.exit(1);
-    }
+    logger.info(`Loaded ${dataSources.length} dynamic datasources`);
+    this._datasourceParams = params;
+    this._datasources = dataSources;
   }
-
-  deleteTempDsRecords(blockHeight: number): void {
-    // Main thread will not have tempDsRecords with workers
-    if (this.tempDsRecords) {
-      delete this.tempDsRecords[TEMP_DS_PREFIX + blockHeight];
-    }
-  }
-
-  private async getDynamicDatasourceParams(blockHeight?: number): Promise<DatasourceParams[]> {
-    const record = await this.metadata.find(METADATA_KEY);
-
-    let results: DatasourceParams[] = [];
-
-    const metaResults: DatasourceParams[] = JSON.parse(record ?? '[]');
-    if (metaResults.length) {
-      results = [...metaResults];
-    }
-
-    if (blockHeight !== undefined) {
-      const tempResults: DatasourceParams[] = JSON.parse(this.tempDsRecords?.[TEMP_DS_PREFIX + blockHeight] ?? '[]');
-      if (tempResults.length) {
-        results = unionWith(results, tempResults, isEqual);
-      }
-    }
-
-    return results;
-  }
-
-  private async saveDynamicDatasourceParams(dsParams: DatasourceParams): Promise<void> {
-    const existing = await this.getDynamicDatasourceParams(dsParams.startBlock);
-
-    const dsRecords = JSON.stringify([...existing, dsParams]);
-    this.metadata.set(METADATA_KEY, dsRecords);
-    this.tempDsRecords = {
-      ...this.tempDsRecords,
-      [TEMP_DS_PREFIX + dsParams.startBlock]: dsRecords,
-    };
-  }
-
-  protected abstract getDatasource(params: DatasourceParams): Promise<DS>;
 }

--- a/packages/node-core/src/indexer/entities/Metadata.entity.ts
+++ b/packages/node-core/src/indexer/entities/Metadata.entity.ts
@@ -3,6 +3,7 @@
 
 import {getMetadataTableName} from '@subql/utils';
 import {BuildOptions, DataTypes, Model, QueryTypes, Sequelize} from '@subql/x-sequelize';
+import {DatasourceParams} from '../dynamic-ds.service';
 
 export interface MetadataKeys {
   chain: string;
@@ -22,7 +23,7 @@ export interface MetadataKeys {
   lastFinalizedVerifiedHeight: number;
   indexerHealthy: boolean;
   targetHeight: number;
-  dynamicDatasources: string;
+  dynamicDatasources: DatasourceParams[];
   unfinalizedBlocks: string;
   schemaMigrationCount: number;
   deployments: string;

--- a/packages/node-core/src/indexer/fetch.service.spec.ts
+++ b/packages/node-core/src/indexer/fetch.service.spec.ts
@@ -5,15 +5,7 @@ import {EventEmitter2} from '@nestjs/event-emitter';
 import {SchedulerRegistry} from '@nestjs/schedule';
 import {BaseDataSource, BaseHandler, BaseMapping, DictionaryQueryEntry, IProjectNetworkConfig} from '@subql/types-core';
 import {range} from 'lodash';
-import {
-  BlockDispatcher,
-  delay,
-  DynamicDsService,
-  IBlockDispatcher,
-  IDictionary,
-  IProjectService,
-  NodeConfig,
-} from '../';
+import {BlockDispatcher, delay, DynamicDsService, IBlockDispatcher, IProjectService, NodeConfig} from '../';
 import {BlockHeightMap} from '../utils/blockHeightMap';
 import {DictionaryService} from './dictionary/dictionary.service';
 import {BaseFetchService} from './fetch.service';
@@ -86,11 +78,7 @@ const projectService = {
   getAllDataSources: jest.fn(() => [mockDs]),
 } as any as IProjectService<any>;
 
-const dynamicDsService = {
-  deleteTempDsRecords: (height: number) => {
-    /* Nothing */
-  },
-} as DynamicDsService<any>;
+const dynamicDsService = {} as DynamicDsService<any>;
 
 const getDictionaryService = () =>
   ({

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -353,7 +353,6 @@ export abstract class BaseFetchService<DS extends BaseDataSource, B extends IBlo
   }
 
   resetForNewDs(blockHeight: number): void {
-    this.dynamicDsService.deleteTempDsRecords(blockHeight);
     this.updateDictionary();
     this.blockDispatcher.flushQueue(blockHeight);
   }

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -22,6 +22,7 @@ import {
 import {BlockHeightMap} from '../utils/blockHeightMap';
 import {BaseDsProcessorService} from './ds-processor.service';
 import {DynamicDsService} from './dynamic-ds.service';
+import {MetadataKeys} from './entities';
 import {PoiSyncService} from './poi';
 import {PoiService} from './poi/poi.service';
 import {StoreService} from './store.service';
@@ -198,7 +199,7 @@ export abstract class BaseProjectService<
 
     this.eventEmitter.emit(IndexerEvent.NetworkMetadata, this.apiService.networkMeta);
 
-    const keys = [
+    const keys: (keyof MetadataKeys)[] = [
       'lastProcessedHeight',
       'blockOffset',
       'indexerNodeVersion',
@@ -209,7 +210,8 @@ export abstract class BaseProjectService<
       'processedBlockCount',
       'lastFinalizedVerifiedHeight',
       'schemaMigrationCount',
-    ] as const;
+      'dynamicDatasources',
+    ];
 
     const existing = await metadata.findMany(keys);
 
@@ -255,6 +257,9 @@ export abstract class BaseProjectService<
     }
     if (!existing.startHeight) {
       metadata.set('startHeight', this.getStartBlockFromDataSources());
+    }
+    if (!existing.dynamicDatasources) {
+      metadata.set('dynamicDatasources', []);
     }
   }
 

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.spec.ts
@@ -45,22 +45,22 @@ describe('CacheMetadata', () => {
       },
     } as any);
 
-    (cacheMetadata as any).appendJsonbArray('dynamicDatasources', [{foo: 'bar'}]);
+    (cacheMetadata as any).appendDynamicDatasources([{foo: 'bar'}]);
     expect(queryFn).toHaveBeenCalledWith(
       `
       UPDATE "Schema"."_metadata"
-      SET VALUE "value" = jsonb_set("value", array[(jsonb_array_length("value") + 1)::text], '{"foo":"bar"}'::jsonb}, true),
+      SET "value" = jsonb_set("value", array[(jsonb_array_length("value") + 1)::text], '{"foo":"bar"}'::jsonb, true),
         "updatedAt" = CURRENT_TIMESTAMP
       WHERE "Schema"."_metadata".key = 'dynamicDatasources';
     `,
       undefined
     );
 
-    (cacheMetadata as any).appendJsonbArray('dynamicDatasources', [{foo: 'bar'}, {baz: 'buzz'}]);
+    (cacheMetadata as any).appendDynamicDatasources([{foo: 'bar'}, {baz: 'buzz'}]);
     expect(queryFn).toHaveBeenCalledWith(
       `
       UPDATE "Schema"."_metadata"
-      SET VALUE "value" = jsonb_set(jsonb_set("value", array[(jsonb_array_length("value") + 1)::text], '{"foo":"bar"}'::jsonb}, true), array[(jsonb_array_length("value") + 1)::text], '{"baz":"buzz"}'::jsonb}, true),
+      SET "value" = jsonb_set(jsonb_set("value", array[(jsonb_array_length("value") + 1)::text], '{"foo":"bar"}'::jsonb, true), array[(jsonb_array_length("value") + 2)::text], '{"baz":"buzz"}'::jsonb, true),
         "updatedAt" = CURRENT_TIMESTAMP
       WHERE "Schema"."_metadata".key = 'dynamicDatasources';
     `,

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.test.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.test.ts
@@ -76,12 +76,12 @@ describe('cacheMetadata integration', () => {
     it('Appends dynamicDatasources correctly', async () => {
       cacheMetadataModel.setNewDynamicDatasource({templateName: 'foo', startBlock: 1});
       cacheMetadataModel.setNewDynamicDatasource({templateName: 'bar', startBlock: 2});
-      cacheMetadataModel.setNewDynamicDatasource({templateName: 'baz', startBlock: 2});
+      cacheMetadataModel.setNewDynamicDatasource({templateName: 'baz', startBlock: 3});
 
       const expected = [
         {templateName: 'foo', startBlock: 1},
         {templateName: 'bar', startBlock: 2},
-        {templateName: 'baz', startBlock: 2},
+        {templateName: 'baz', startBlock: 3},
       ];
 
       await flush();

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.test.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {QueryTypes, Sequelize} from '@subql/x-sequelize';
-import {MetadataFactory} from '../';
+import {MetadataFactory, MetadataKeys, MetadataRepo} from '../';
 import {DbOption} from '../../';
 import {CacheMetadataModel} from './cacheMetadata';
 
@@ -18,6 +18,8 @@ const option: DbOption = {
 describe('cacheMetadata integration', () => {
   let sequelize: Sequelize;
   let schema: string;
+  let metaDataRepo: MetadataRepo;
+  let cacheMetadataModel: CacheMetadataModel;
 
   beforeAll(async () => {
     sequelize = new Sequelize(
@@ -25,24 +27,33 @@ describe('cacheMetadata integration', () => {
       option
     );
     await sequelize.authenticate();
+
+    schema = '"metadata-test-1"';
+    await sequelize.createSchema(schema, {});
+    metaDataRepo = await MetadataFactory(sequelize, schema, false, '1');
+
+    await metaDataRepo.sync();
+
+    cacheMetadataModel = new CacheMetadataModel(metaDataRepo);
   });
 
-  afterEach(async () => {
-    await sequelize.dropSchema(schema, {logging: false});
-  });
+  const queryMeta = async <K extends keyof MetadataKeys>(key: K): Promise<MetadataKeys[K] | undefined> => {
+    const res = await metaDataRepo.findByPk(key);
+    return res?.toJSON()?.value as any;
+  };
+
+  const flush = async () => {
+    const tx = await sequelize.transaction();
+    await cacheMetadataModel.flush(tx);
+    await tx.commit();
+  };
+
   afterAll(async () => {
+    await sequelize.dropSchema(schema, {logging: false});
     await sequelize.close();
   });
 
   it('Ensure increment keys are created on _metadata table', async () => {
-    schema = '"metadata-test-1"';
-    await sequelize.createSchema(schema, {});
-    const metaDataRepo = await MetadataFactory(sequelize, schema, false, '1');
-
-    await metaDataRepo.sync();
-
-    const cacheMetadataModel = new CacheMetadataModel(metaDataRepo);
-
     // create key at 0
     await (cacheMetadataModel as any).incrementJsonbCount('schemaMigrationCount');
 
@@ -52,16 +63,71 @@ describe('cacheMetadata integration', () => {
     // increase by 100
     await (cacheMetadataModel as any).incrementJsonbCount('schemaMigrationCount', 100);
 
-    const v = (await sequelize.query(
-      `
-            SELECT * FROM ${schema}."_metadata"
-            WHERE key = 'schemaMigrationCount';
-        `,
-      {
-        type: QueryTypes.SELECT,
-      }
-    )) as any[];
-    expect(v.length).toBe(1);
-    expect(v[0].value).toBe(101);
+    const v = await queryMeta('schemaMigrationCount');
+    expect(v).toBe(101);
+  });
+
+  describe('dynamicDatasources', () => {
+    beforeEach(async () => {
+      // Ensure value exits so we can update it
+      await metaDataRepo.bulkCreate([{key: 'dynamicDatasources', value: []}], {updateOnDuplicate: ['key', 'value']});
+    });
+
+    it('Appends dynamicDatasources correctly', async () => {
+      cacheMetadataModel.setNewDynamicDatasource({templateName: 'foo', startBlock: 1});
+      cacheMetadataModel.setNewDynamicDatasource({templateName: 'bar', startBlock: 2});
+      cacheMetadataModel.setNewDynamicDatasource({templateName: 'baz', startBlock: 2});
+
+      const expected = [
+        {templateName: 'foo', startBlock: 1},
+        {templateName: 'bar', startBlock: 2},
+        {templateName: 'baz', startBlock: 2},
+      ];
+
+      await flush();
+
+      const v = await queryMeta('dynamicDatasources');
+      expect(v).toEqual(expected);
+
+      const cacheV = await cacheMetadataModel.find('dynamicDatasources');
+      expect(cacheV).toEqual(expected);
+    });
+
+    it('Allows overriding all dynamicDatasources', async () => {
+      cacheMetadataModel.setNewDynamicDatasource({templateName: 'foo', startBlock: 1});
+
+      cacheMetadataModel.set('dynamicDatasources', [{templateName: 'bar', startBlock: 2}]);
+
+      await flush();
+
+      const v = await queryMeta('dynamicDatasources');
+      expect(v).toEqual([{templateName: 'bar', startBlock: 2}]);
+    });
+
+    it('Caches the dynamicDatasources correctly after using set', async () => {
+      cacheMetadataModel.setNewDynamicDatasource({templateName: 'foo', startBlock: 1});
+      await flush();
+
+      const cacheV = await cacheMetadataModel.find('dynamicDatasources');
+      expect(cacheV).toEqual([{templateName: 'foo', startBlock: 1}]);
+
+      cacheMetadataModel.setNewDynamicDatasource({templateName: 'bar', startBlock: 2});
+      // await flush();
+
+      const cacheV2 = await cacheMetadataModel.find('dynamicDatasources');
+      expect(cacheV2).toEqual([
+        {templateName: 'foo', startBlock: 1},
+        {templateName: 'bar', startBlock: 2},
+      ]);
+    });
+
+    it('Uses the correct cache values when using new and set', async () => {
+      cacheMetadataModel.setNewDynamicDatasource({templateName: 'foo', startBlock: 1});
+
+      cacheMetadataModel.set('dynamicDatasources', [{templateName: 'bar', startBlock: 2}]);
+
+      const cacheV = await cacheMetadataModel.find('dynamicDatasources');
+      expect(cacheV).toEqual([{templateName: 'bar', startBlock: 2}]);
+    });
   });
 });

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
@@ -44,7 +44,7 @@ export class CacheMetadataModel extends Cacheable implements ICachedModelControl
     if (key === 'dynamicDatasources') {
       // Include any unflushed datasource updates in this
       return [
-        ...(this.getCache[key] as MetadataKeys['dynamicDatasources']),
+        ...((this.getCache[key] as MetadataKeys['dynamicDatasources']) ?? []),
         ...this.datasourceUpdates,
       ] as MetadataKeys[K];
     }

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
@@ -124,13 +124,17 @@ export class CacheMetadataModel extends Cacheable implements ICachedModelControl
 
     assert(this.model.sequelize, `Sequelize is not available on ${this.model.name}`);
 
-    const makeSet = (item: DatasourceParams, value: string): string =>
-      `jsonb_set(${value}, array[(jsonb_array_length(${value}) + 1)::text], '${JSON.stringify(item)}'::jsonb, true)`;
+    const VALUE = '"value"';
+
+    const makeSet = (item: DatasourceParams, value: string, index = 1): string =>
+      `jsonb_set(${value}, array[(jsonb_array_length(${VALUE}) + ${index})::text], '${JSON.stringify(
+        item
+      )}'::jsonb, true)`;
 
     await this.model.sequelize.query(
       `
       UPDATE ${schemaTable}
-      SET "value" = ${items.reduce((acc, item) => makeSet(item, acc), '"value"')},
+      SET ${VALUE} = ${items.reduce((acc, item, index) => makeSet(item, acc, index + 1), VALUE)},
         "updatedAt" = CURRENT_TIMESTAMP
       WHERE ${schemaTable}.key = 'dynamicDatasources';
     `,

--- a/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheMetadata.ts
@@ -42,6 +42,10 @@ export class CacheMetadataModel extends Cacheable implements ICachedModelControl
     }
 
     if (key === 'dynamicDatasources') {
+      // For migration purposes this used to be a string, we need to return that for project.service to migrate it correctly
+      if (typeof this.getCache[key] === 'string') {
+        return this.getCache[key] as MetadataKeys[K];
+      }
       // Include any unflushed datasource updates in this
       return [
         ...((this.getCache[key] as MetadataKeys['dynamicDatasources']) ?? []),

--- a/packages/node-core/src/meta/meta.service.ts
+++ b/packages/node-core/src/meta/meta.service.ts
@@ -15,7 +15,7 @@ import {
 } from '../events';
 import {StoreCacheService} from '../indexer';
 
-let UPDATE_HEIGHT_INTERVAL: number;
+const UPDATE_HEIGHT_INTERVAL = 5000;
 
 export abstract class BaseMetaService {
   private currentProcessingHeight?: number;
@@ -29,8 +29,8 @@ export abstract class BaseMetaService {
   private lastProcessedTimestamp?: number;
   private processedBlockCount?: number;
 
-  constructor(private storeCacheService: StoreCacheService, private config: NodeConfig) {
-    UPDATE_HEIGHT_INTERVAL = config.storeFlushInterval * 1000;
+  constructor(private storeCacheService: StoreCacheService, config: NodeConfig) {
+    // TODO update UPDATE_HEIGHT_INTERVAL should be configureable based on config.storeFlushInterval * 1000 but need to use SchedulerRegistry for that
   }
 
   protected abstract packageVersion: string;

--- a/packages/node/src/indexer/dynamic-ds.service.ts
+++ b/packages/node/src/indexer/dynamic-ds.service.ts
@@ -26,15 +26,15 @@ export class DynamicDsService extends BaseDynamicDsService<SubstrateProjectDs> {
   protected async getDatasource(
     params: DatasourceParams,
   ): Promise<SubstrateProjectDs> {
-    const { name, ...template } = cloneDeep(
-      this.project.templates.find((t) => t.name === params.templateName),
+    const t = this.project.templates.find(
+      (t) => t.name === params.templateName,
     );
-
-    if (!template) {
+    if (!t) {
       throw new Error(
         `Unable to find matching template in project for name: "${params.templateName}"`,
       );
     }
+    const { name, ...template } = cloneDeep(t);
 
     const dsObj = {
       ...template,


### PR DESCRIPTION
# Description
### Problem
With a large number of dynamic ds every time a new one is created it will rewrite the whole set of params to the db. This results in a slow query which has to transfer a large amount of data. 

### Solution
To have a specific query to append only new datasource parameters to the metadata.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
