### PR TITLE
Fix any fields being converted to timestamps, remove `timestamps-field` flag

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Graphql comments not being escaped (#2299)
+- Fields called `createdAt` or `updatedAt` having their type converted to timestamps (#2310)
 
 ### Changed
 - Update connection retry logic and add backoff to fetch blocks retries (#2301)
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - `@subql/apollo-links` for resolving dictionary endpoints and matching `dictionary-resolver` flag (#2305)
+- Unused `timestamps-field` flag (#2310)
 
 ## [7.4.1] - 2024-03-08
 ### Fixed

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -29,7 +29,6 @@ export interface IConfig {
   readonly logLevel: LevelWithSilent;
   readonly queryLimit: number;
   readonly indexCountLimit: number;
-  readonly timestampField: boolean;
   readonly proofOfIndex: boolean;
   readonly ipfs?: string;
   readonly dictionaryTimeout: number;
@@ -67,7 +66,6 @@ const DEFAULT_CONFIG = {
   debug: undefined,
   queryLimit: 100,
   indexCountLimit: 10,
-  timestampField: true,
   proofOfIndex: false,
   dictionaryTimeout: 30,
   dictionaryQuerySize: 10000,
@@ -211,10 +209,6 @@ export class NodeConfig<C extends IConfig = IConfig> implements IConfig {
 
   get indexCountLimit(): number {
     return this._config.indexCountLimit;
-  }
-
-  get timestampField(): boolean {
-    return this._config.timestampField;
   }
 
   get proofOfIndex(): boolean {

--- a/packages/node-core/src/db/sync-helper.ts
+++ b/packages/node-core/src/db/sync-helper.ts
@@ -54,8 +54,6 @@ export interface NotifyTriggerPayload {
 
 const NotifyTriggerManipulationType = [`INSERT`, `DELETE`, `UPDATE`];
 
-const timestampKeys = ['created_at', 'updated_at'];
-
 const byTagOrder = (a: [keyof SmartTags, any], b: [keyof SmartTags, any]) => {
   return tagOrder[a[0]] - tagOrder[b[0]];
 };
@@ -407,10 +405,6 @@ export function generateCreateTableQuery(
     const attr = attributes[key];
 
     assert(attr.field, 'Expected field to be set on attribute');
-
-    if (timestampKeys.find((k) => k === attr.field)) {
-      attr.type = 'timestamp with time zone';
-    }
 
     const columnDefinition = `"${attr.field}" ${formatAttributes(attr, schema, withoutForeignKey)}`;
 

--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -225,8 +225,6 @@ export class StoreService {
       underscored: true,
       comment: model.description,
       freezeTableName: false,
-      createdAt: this.config.timestampField,
-      updatedAt: this.config.timestampField,
       schema,
       indexes,
     });

--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -225,6 +225,7 @@ export class StoreService {
       underscored: true,
       comment: model.description,
       freezeTableName: false,
+      timestamps: false,
       schema,
       indexes,
     });

--- a/packages/node-core/src/yargs.ts
+++ b/packages/node-core/src/yargs.ts
@@ -305,13 +305,6 @@ export function yargsBuilder<
           describe: 'Local path or IPFS cid of the subquery project',
           type: 'string',
         },
-        // this need to be in default option, it impacts on outcome of index/reindex/regen
-        'timestamp-field': {
-          demandOption: false,
-          describe: 'Enable/disable created_at and updated_at in schema',
-          type: 'boolean',
-          default: false,
-        },
       })
   );
 }


### PR DESCRIPTION
# Description
Fixes 2 issues:
1. If you had a field called `createdAt` or `updatedAt` it would convert the type to a timestamp which would break projects using any other types
2. Removes the `timestamps-field` flag that had no effect and was unused.  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
