### PR TITLE
Fix getByFields not flushing all data

### DIFF
--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -79,7 +79,7 @@ export class StoreCacheService extends BaseCacheService {
       this._historical,
       this.config,
       this.getNextStoreOperationIndex.bind(this),
-      () => this.flushCache(true),
+      () => this.flushCache(true, true),
       this._useCockroachDb
     );
     if (this.config.csvOutDir) {


### PR DESCRIPTION
# Description
When `store.getByFields` was called it would flush data up to the current block. This meant if data was updated and then `store.getByFields` was called it would miss any of the updated data. 

We now make sure everything gets flushed so `store.getByFields` returns the right data.

Fixes https://github.com/subquery/subql/issues/2323

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
