### PR TITLE
fix find index entity name failed

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
+- Fix unable to find index in `modelIndexedFields` due to a special case entity name (2327)
 - Fix multi-chain has `block-range` issue due to migartion handle historical status incorrectly
 
 ## [Unreleased]

--- a/packages/node-core/src/indexer/store.service.spec.ts
+++ b/packages/node-core/src/indexer/store.service.spec.ts
@@ -30,4 +30,23 @@ describe('Store Service', () => {
       allowNull: false,
     });
   });
+
+  it('could find indexed field', () => {
+    storeService = new StoreService(null as any, null as any, null as any, null as any);
+    (storeService as any).__modelIndexedFields = [
+      {
+        entityName: 'MinerIP', // no need camel case
+        fieldName: 'net_uid',
+        isUnique: false,
+        type: 'btree',
+      },
+      {
+        entityName: 'MinerColdkey',
+        fieldName: 'net_uid',
+        isUnique: false,
+        type: 'btree',
+      },
+    ];
+    expect(() => storeService.isIndexed('MinerIP', 'netUid')).toBeTruthy();
+  });
 });

--- a/packages/node-core/src/indexer/store.service.spec.ts
+++ b/packages/node-core/src/indexer/store.service.spec.ts
@@ -35,7 +35,7 @@ describe('Store Service', () => {
     storeService = new StoreService(null as any, null as any, null as any, null as any);
     (storeService as any).__modelIndexedFields = [
       {
-        entityName: 'MinerIP', // no need camel case
+        entityName: 'MinerIP', // This is a special case that upperFirst and camelCase will fail
         fieldName: 'net_uid',
         isUnique: false,
         type: 'btree',

--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -403,7 +403,8 @@ group by
     return (
       this.modelIndexedFields.findIndex(
         (indexField) =>
-          upperFirst(camelCase(indexField.entityName)) === entity && camelCase(indexField.fieldName) === field
+          (upperFirst(camelCase(indexField.entityName)) === entity || indexField.entityName === entity) &&
+          camelCase(indexField.fieldName) === field
       ) > -1
     );
   }

--- a/packages/node-core/src/indexer/store.service.ts
+++ b/packages/node-core/src/indexer/store.service.ts
@@ -404,6 +404,8 @@ group by
       this.modelIndexedFields.findIndex(
         (indexField) =>
           (upperFirst(camelCase(indexField.entityName)) === entity || indexField.entityName === entity) &&
+          // We add this because in some case upperFirst and camelCase will not match with entity name,
+          // see test entity name like `MinerIP`
           camelCase(indexField.fieldName) === field
       ) > -1
     );

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix unable to find index in `modelIndexedFields` due to a special case entity name (2327)
 ### Changed
 - Updated with node-core to support both versions of dictionaries. Now also support multiple dictionary endpoints, indexer will fetch and switch dictionaries base on available blocks (#2257)
 


### PR DESCRIPTION
# Description
```
Failed to getByField Entity MinerIP with field netUid: AssertionError [ERR_ASSERTION]: to query by field netUid, an index must be created on model MinerIP
```
Entity name in indexedField is now identical as actual entity name, this fix correct that
![Pasted Graphic 1](https://github.com/subquery/subql/assets/10431657/f8174264-2e60-4524-8287-22b1b0890446)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
