### PR TITLE
allow workers set to 0

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Now when `workers` set to 0, it will use block dispatcher instead of throw and exit 
 
 ## [4.0.0] - 2024-03-28
 ### Fixed

--- a/packages/node/src/indexer/fetch.module.ts
+++ b/packages/node/src/indexer/fetch.module.ts
@@ -68,7 +68,7 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
         unfinalizedBlocks: UnfinalizedBlocksService,
         connectionPoolState: ConnectionPoolStateManager<ApiPromiseConnection>,
       ) =>
-        nodeConfig.workers !== undefined && nodeConfig.workers !== 0
+        !!nodeConfig.workers
           ? new WorkerBlockDispatcherService(
               nodeConfig,
               eventEmitter,

--- a/packages/node/src/indexer/fetch.module.ts
+++ b/packages/node/src/indexer/fetch.module.ts
@@ -68,7 +68,7 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
         unfinalizedBlocks: UnfinalizedBlocksService,
         connectionPoolState: ConnectionPoolStateManager<ApiPromiseConnection>,
       ) =>
-        nodeConfig.workers !== undefined
+        nodeConfig.workers !== undefined && nodeConfig.workers !== 0
           ? new WorkerBlockDispatcherService(
               nodeConfig,
               eventEmitter,


### PR DESCRIPTION
# Description


We allow to set workers. to 0 now instead of throw and exit, this will use block dispatcher instead

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
