### PR TITLE
fix executable path in docker

### DIFF
--- a/packages/node/Dockerfile
+++ b/packages/node/Dockerfile
@@ -34,5 +34,5 @@ RUN apk add --no-cache tini curl git && \
 USER 1000
 
 # Set Entry point and command
-ENTRYPOINT ["/sbin/tini", "--", "bin/run"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/run"]
 CMD ["-f","/app"]

--- a/packages/query/Dockerfile
+++ b/packages/query/Dockerfile
@@ -34,5 +34,5 @@ RUN apk add --no-cache tini curl git && \
 USER 1000
 
 # Set Entry point and command
-ENTRYPOINT ["/sbin/tini", "--", "bin/run"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/run"]
 CMD ["-f","/app"]


### PR DESCRIPTION
# Description
Currently if I build on top of the subql docker image, and change working directory like the following
```
FROM subquerynetwork/subql-node-substrate:v3.10.1 as subql-node
VOLUME ["/app"]
WORKDIR /app/packages/evm-subql
```
when running the new image, it will throw `[FATAL tini (12)] exec bin/run failed: No such file or directory`.

Using absolute path fixes it, and should make the image more robust

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
