### PR TITLE
Fix RPC validation happening after network meta is set

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `WorkerUnfinalizedBlocksService` class from node that is now chain agnostic (#2346)
 
+### Fixed
+- Issue with using metadata if incorrect network endpoint was provided (#2350)
+
+### Changed
+- Simplify ApiService and remove need for getChainId function (#2450)
+
 ## [8.0.1] - 2024-04-05
 ### Fixed
 - Fix modulo filter not applying correctly with multiple dataSources (#2331)

--- a/packages/node-core/src/api.connection.error.ts
+++ b/packages/node-core/src/api.connection.error.ts
@@ -43,3 +43,13 @@ export class LargeResponseError extends ApiConnectionError {
     super('RpcInternalError', newMessage, ApiErrorType.Default);
   }
 }
+
+export class MetadataMismatchError extends Error {
+  constructor(metadata: string, expected: string, actual: string) {
+    super(
+      `Value of ${metadata} does not match across all endpoints\n
+       Expected: ${expected}
+       Actual: ${actual}`
+    );
+  }
+}

--- a/packages/node-core/src/api.service.spec.ts
+++ b/packages/node-core/src/api.service.spec.ts
@@ -1,0 +1,75 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {EventEmitter2} from '@nestjs/event-emitter';
+import {delay} from '@subql/common';
+import {ProjectNetworkConfig} from '@subql/types-core';
+import {ApiService, IApiConnectionSpecific} from './api.service';
+import {NodeConfig} from './configure';
+import {ConnectionPoolService, ConnectionPoolStateManager} from './indexer';
+
+class TestApiService extends ApiService {
+  retryConnection(
+    createConnection: (endpoint: string) => Promise<IApiConnectionSpecific>,
+    network: ProjectNetworkConfig & {chainId: string},
+    index: number,
+    endpoint: string,
+    postConnectedHook?: ((connection: IApiConnectionSpecific, endpoint: string, index: number) => void) | undefined
+  ): void {
+    /* No Op to avoid creating intervals/timeouts in tests*/
+  }
+}
+
+describe('ApiService', () => {
+  let apiService: TestApiService;
+
+  beforeEach(() => {
+    const stateManager = new ConnectionPoolStateManager();
+    const poolService = new ConnectionPoolService(new NodeConfig({} as any), stateManager);
+
+    apiService = new TestApiService(poolService, new EventEmitter2());
+  });
+
+  it('should throw creating connections if all endpoints are invalid', async () => {
+    await expect(
+      apiService.createConnections(
+        {chainId: 'test', endpoint: ['fail', 'fail']} as any,
+        (endpoint) => Promise.resolve({networkMeta: {chain: endpoint}} as any) // Fail meta validation
+      )
+    ).rejects.toThrow();
+  });
+
+  it('should succeed creating connections if one endpoint is invalid', async () => {
+    await expect(
+      apiService.createConnections(
+        {chainId: 'test', endpoint: ['test', 'fail']} as any,
+        (endpoint) => Promise.resolve({networkMeta: {chain: endpoint}} as any) // Fail meta validation
+      )
+    ).resolves.not.toThrow();
+  });
+
+  it(`doesn't set network meta if a connection fails validation`, async () => {
+    await expect(
+      apiService.createConnections({chainId: 'test', endpoint: ['fail']} as any, (endpoint) =>
+        Promise.resolve({networkMeta: {chain: endpoint}} as any)
+      )
+    ).rejects.toThrow();
+
+    expect((apiService as any)._networkMeta).toBeUndefined();
+  });
+
+  it('should retry connections if they fail with something other than metadata', async () => {
+    const retrySpy = jest.spyOn(apiService, 'retryConnection');
+
+    await apiService.createConnections({chainId: 'test', endpoint: ['test', 'fail']} as any, (endpoint) =>
+      endpoint === 'test'
+        ? Promise.resolve({networkMeta: {chain: endpoint}} as any) // At least one endpoint needs to succeed
+        : Promise.reject(new Error('Test'))
+    );
+
+    // Add delay so non blocking promise is resolve in create connections
+    await delay(0.001);
+
+    expect(retrySpy).toHaveBeenCalled();
+  });
+});

--- a/packages/node-core/src/utils/promise.ts
+++ b/packages/node-core/src/utils/promise.ts
@@ -57,29 +57,3 @@ async function backoffRetryInternal<T>(fn: () => Promise<T>, maxAttempts: number
 export async function backoffRetry<T>(fn: () => Promise<T>, attempts = 5): Promise<T> {
   return backoffRetryInternal(fn, attempts);
 }
-
-/* eslint-disable @typescript-eslint/no-misused-promises */
-export async function raceFulfilled<T = any>(promises: Promise<T>[]): Promise<{result: T; fulfilledIndex: number}> {
-  //eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    let hasFulfilled = false;
-
-    promises.forEach(async (promise, index) => {
-      try {
-        const result = await promise;
-        if (!hasFulfilled) {
-          hasFulfilled = true;
-          resolve({result, fulfilledIndex: index});
-        }
-      } catch (error) {
-        // Ignore rejections
-      }
-    });
-
-    // Check if all promises were rejected
-    const results = await Promise.allSettled(promises);
-    if (!hasFulfilled && results.every((result) => result.status === 'rejected')) {
-      reject(new Error('All promises were rejected'));
-    }
-  });
-}

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unused `@subql/testing` dependency (#2346)
 - `WorkerUnfinalizedBlocksService` and use version from node-core (#2346)
 
+### Changed
+- Update ApiService to match changes with `@subql/node-core` (#2350)
+
 ## [4.0.1] - 2024-04-05
 ### Fixed
 - Fix modulo block didn't apply correctly with multiple dataSources (#2331)

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -43,10 +43,8 @@ export class ApiPromiseConnection
 {
   readonly networkMeta: NetworkMetadataPayload;
 
-  constructor(
+  private constructor(
     public unsafeApi: ApiPromise,
-    private apiOptions: ApiOptions,
-    private endpoint: string,
     private fetchBlocksBatches: GetFetchFunc,
   ) {
     this.networkMeta = {
@@ -84,12 +82,7 @@ export class ApiPromiseConnection
       ...args.chainTypes,
     };
     const api = await ApiPromise.create(apiOption);
-    return new ApiPromiseConnection(
-      api,
-      apiOption,
-      endpoint,
-      fetchBlocksBatches,
-    );
+    return new ApiPromiseConnection(api, fetchBlocksBatches);
   }
 
   safeApi(height: number): ApiAt {

--- a/packages/node/src/indexer/dictionary/substrateDictionary.service.ts
+++ b/packages/node/src/indexer/dictionary/substrateDictionary.service.ts
@@ -78,9 +78,8 @@ export class SubstrateDictionaryService extends DictionaryService<
     nodeConfig: NodeConfig,
     eventEmitter: EventEmitter2,
     protected dsProcessorService: DsProcessorService,
-    chainId?: string,
   ) {
-    super(chainId ?? project.network.chainId, nodeConfig, eventEmitter);
+    super(project.network.chainId, nodeConfig, eventEmitter);
   }
 
   private getV1Dictionary(): SubstrateDictionaryV1 | undefined {

--- a/packages/node/src/indexer/x-provider/x-provider.spec.ts
+++ b/packages/node/src/indexer/x-provider/x-provider.spec.ts
@@ -3,8 +3,8 @@
 
 import { WsProvider } from '@polkadot/rpc-provider';
 import { delay } from '@subql/common';
-import { createCachedProvider } from './x-provider/cachedProvider';
-import { HttpProvider } from './x-provider/http';
+import { createCachedProvider } from './cachedProvider';
+import { HttpProvider } from './http';
 
 const TEST_BLOCKHASH =
   '0x3b712c10ba98c5421a468d1411c94479381be307b7ecb5b2602cf0d395eb4292';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6399,7 +6399,6 @@ __metadata:
     "@subql/common": "workspace:*"
     "@subql/common-substrate": "workspace:*"
     "@subql/node-core": "workspace:*"
-    "@subql/testing": "workspace:*"
     "@subql/types": "workspace:*"
     "@subql/utils": "workspace:*"
     "@types/express": ^4.17.13


### PR DESCRIPTION
# Description
If multiple endpoints are provided and one of them was for the wrong network, if that endpoint connected first it would set invalid network metadata. This PR validates the metadata before setting it.

Other changes:
* No longer retries connections for endpoints that fail network validation.
* Remove `raceFulfilled` and use `Promise.any` which has the same functionality
* Move polkadot provider tests to relevant location
* Simplify logic to get chainId for connection

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (`@subql/node-core` only) 

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
