### PR TITLE
Move code to node core, tidy up some unused deps

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,7 @@ jobs:
       DB_USER: postgres
       DB_PASS: postgres
       DB_DATABASE: postgres
-      DB_HOST: postgres
+      DB_HOST: localhost
       DB_PORT: 5432
     steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,7 @@ jobs:
       DB_USER: postgres
       DB_PASS: postgres
       DB_DATABASE: postgres
-      DB_HOST: localhost
+      DB_HOST: postgres
       DB_PORT: 5432
     steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,9 @@ jobs:
     steps:
         - uses: actions/checkout@v4
 
+        - name: Enable btree btree_gist
+          run: psql "postgresql://$DB_USER:$DB_PASS@$DB_HOST:$DB_PORT/$DB_DATABASE" -c "CREATE EXTENSION IF NOT EXISTS btree_gist;"
+
         - name: Use Node 18
           uses: actions/setup-node@v4
           with:

--- a/jest.config.js
+++ b/jest.config.js
@@ -168,9 +168,10 @@ module.exports = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: [
+    '.*\\.fixtures\\.ts$',
+    "/node_modules/"
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   testRegex: '.*\\.spec\\.ts$',

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node-fetch": "2.6.7"
   },
   "scripts": {
-    "build": "yarn workspaces foreach -ptA run build",
+    "build": "yarn workspaces foreach -tA run build",
     "lint": "eslint packages --ext .ts",
     "test": "jest --coverage",
     "test:ci": "jest --testRegex='.*\\.(spec|test)\\.ts$'",

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -7,30 +7,14 @@ import os from 'os';
 import path from 'path';
 import {promisify} from 'util';
 import {DEFAULT_MANIFEST, mapToObject, ReaderFactory, toJsonObject} from '@subql/common';
-import {parseSubstrateProjectManifest, ProjectManifestV1_0_0Impl} from '@subql/common-substrate';
-import {create} from 'ipfs-http-client';
+import {parseSubstrateProjectManifest} from '@subql/common-substrate';
 import rimraf from 'rimraf';
 import Build from '../commands/build';
 import Codegen from '../commands/codegen';
 import Publish from '../commands/publish';
-import {ProjectSpecBase, ProjectSpecV0_0_1, ProjectSpecV0_2_0, ProjectSpecV1_0_0} from '../types';
+import {ProjectSpecBase, ProjectSpecV1_0_0} from '../types';
 import {cloneProjectTemplate, fetchExampleProjects, prepare} from './init-controller';
-import {uploadFile, uploadToIpfs} from './publish-controller';
-
-const projectSpecV0_0_1: ProjectSpecV0_0_1 = {
-  name: 'mocked_starter',
-  endpoint: 'wss://rpc.polkadot.io/public-ws',
-  author: 'jay',
-  description: 'this is test for init controller',
-};
-
-const projectSpecV0_2_0: ProjectSpecV0_2_0 = {
-  name: 'mocked_starter',
-  genesisHash: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
-  endpoint: 'wss://rpc.polkadot.io/public-ws',
-  author: 'jay',
-  description: 'this is test for init controller',
-};
+import {uploadToIpfs} from './publish-controller';
 
 // eslint-disable-next-line jest/no-export
 export const projectSpecV1_0_0: ProjectSpecV1_0_0 = {
@@ -51,11 +35,8 @@ export const projectSpecV1_0_0: ProjectSpecV1_0_0 = {
   },
 };
 
-const ipfsEndpoint = 'http://localhost:5001/api/v0';
 // Replace/Update your access token when test locally
 const testAuth = process.env.SUBQL_ACCESS_TOKEN;
-
-jest.setTimeout(150000);
 
 // eslint-disable-next-line jest/no-export
 export async function createTestProject(projectSpec: ProjectSpecBase): Promise<string> {
@@ -74,10 +55,16 @@ export async function createTestProject(projectSpec: ProjectSpecBase): Promise<s
   return projectDir;
 }
 
+jest.setTimeout(200_000); // 200s
 describe('Cli publish', () => {
   let projectDir: string;
 
-  afterEach(async () => {
+  beforeAll(async () => {
+    console.log('Setting up test project');
+    projectDir = await createTestProject(projectSpecV1_0_0);
+  });
+
+  afterAll(async () => {
     try {
       if (!projectDir) return;
       await promisify(rimraf)(projectDir);
@@ -86,45 +73,23 @@ describe('Cli publish', () => {
     }
   });
 
-  it('should not allow uploading a v0.0.1 spec version project', async () => {
-    projectDir = await createTestProject(projectSpecV0_0_1);
-    await expect(uploadToIpfs([''], ipfsEndpoint, projectDir)).rejects.toBeDefined();
-  });
-
-  it(`upload file to ipfs`, async () => {
-    // only enable when test locally
-    const ipfs = create({url: ipfsEndpoint});
-
-    //test string
-    const cid = await uploadFile({path: '', content: 'Test for upload string to ipfs'}, testAuth);
-    console.log(`upload file cid: ${cid}`);
-  });
-
   it('should upload appropriate project to IPFS', async () => {
-    projectDir = await createTestProject(projectSpecV0_2_0);
     const cid = await uploadToIpfs([projectDir], testAuth);
     expect(cid).toBeDefined();
-    // validation no longer required, as it is deployment object been published
-    // await expect(Validate.run(['-l', cid, '--ipfs', ipfsEndpoint])).resolves.toBe(undefined);
   });
 
   it('upload project from a manifest', async () => {
-    projectDir = await createTestProject(projectSpecV0_2_0);
     const manifestPath = path.resolve(projectDir, DEFAULT_MANIFEST);
     const testManifestPath = path.resolve(projectDir, 'test.yaml');
     fs.renameSync(manifestPath, testManifestPath);
     await expect(Publish.run(['-f', testManifestPath])).resolves.not.toThrow();
-  });
+    // Revert file name to get other tests to pass
+    fs.renameSync(testManifestPath, manifestPath);
 
-  it('v1.0.0 should deploy', async () => {
-    projectDir = await createTestProject(projectSpecV1_0_0);
-    const reader = await ReaderFactory.create(projectDir);
-    const manifest = parseSubstrateProjectManifest(await reader.getProjectSchema()).asImpl;
-    expect((manifest as ProjectManifestV1_0_0Impl).runner).toBeDefined();
+    expect(fs.existsSync(path.resolve(projectDir, '.test-cid'))).toBeTruthy();
   });
 
   it('convert to deployment and removed descriptive field', async () => {
-    projectDir = await createTestProject(projectSpecV1_0_0);
     const reader = await ReaderFactory.create(projectDir);
     const manifest = parseSubstrateProjectManifest(await reader.getProjectSchema());
     const deployment = manifest.toDeployment();

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -1,67 +1,25 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import childProcess from 'child_process';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import {promisify} from 'util';
 import {DEFAULT_MANIFEST, mapToObject, ReaderFactory, toJsonObject} from '@subql/common';
 import {parseSubstrateProjectManifest} from '@subql/common-substrate';
 import rimraf from 'rimraf';
-import Build from '../commands/build';
-import Codegen from '../commands/codegen';
 import Publish from '../commands/publish';
-import {ProjectSpecBase, ProjectSpecV1_0_0} from '../types';
-import {cloneProjectTemplate, fetchExampleProjects, prepare} from './init-controller';
+import {createTestProject} from '../createProject.fixtures';
 import {uploadToIpfs} from './publish-controller';
-
-// eslint-disable-next-line jest/no-export
-export const projectSpecV1_0_0: ProjectSpecV1_0_0 = {
-  name: 'mocked_starter',
-  chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
-  endpoint: 'wss://rpc.polkadot.io/public-ws',
-  author: 'jay',
-  description: 'this is test for init controller',
-  runner: {
-    node: {
-      name: '@subql/node',
-      version: '>=1.0.0',
-    },
-    query: {
-      name: '@subql/query',
-      version: '*',
-    },
-  },
-};
 
 // Replace/Update your access token when test locally
 const testAuth = process.env.SUBQL_ACCESS_TOKEN;
 
-// eslint-disable-next-line jest/no-export
-export async function createTestProject(projectSpec: ProjectSpecBase): Promise<string> {
-  const tmpdir = await fs.promises.mkdtemp(`${os.tmpdir()}${path.sep}`);
-  const projectDir = path.join(tmpdir, projectSpec.name);
-  const projects = await fetchExampleProjects('polkadot', 'polkadot');
-  const projectPath = await cloneProjectTemplate(tmpdir, projectSpec.name, projects[0]);
-  await prepare(projectPath, projectSpec);
-
-  // Install dependencies
-  childProcess.execSync(`npm i`, {cwd: projectDir});
-
-  await Codegen.run(['-l', projectDir]);
-  await Build.run(['-f', projectDir]);
-
-  return projectDir;
-}
-
-jest.setTimeout(200_000); // 200s
+jest.setTimeout(300_000); // 300s
 describe('Cli publish', () => {
   let projectDir: string;
 
   beforeAll(async () => {
-    console.log('Setting up test project');
-    projectDir = await createTestProject(projectSpecV1_0_0);
+    projectDir = await createTestProject();
   });
 
   afterAll(async () => {
@@ -76,17 +34,6 @@ describe('Cli publish', () => {
   it('should upload appropriate project to IPFS', async () => {
     const cid = await uploadToIpfs([projectDir], testAuth);
     expect(cid).toBeDefined();
-  });
-
-  it('upload project from a manifest', async () => {
-    const manifestPath = path.resolve(projectDir, DEFAULT_MANIFEST);
-    const testManifestPath = path.resolve(projectDir, 'test.yaml');
-    fs.renameSync(manifestPath, testManifestPath);
-    await expect(Publish.run(['-f', testManifestPath])).resolves.not.toThrow();
-    // Revert file name to get other tests to pass
-    fs.renameSync(testManifestPath, manifestPath);
-
-    expect(fs.existsSync(path.resolve(projectDir, '.test-cid'))).toBeTruthy();
   });
 
   it('convert to deployment and removed descriptive field', async () => {

--- a/packages/cli/src/createProject.fixtures.ts
+++ b/packages/cli/src/createProject.fixtures.ts
@@ -1,0 +1,61 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import childProcess from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Build from './commands/build';
+import Codegen from './commands/codegen';
+import {cloneProjectTemplate, ExampleProjectInterface, prepare} from './controller/init-controller';
+import {ProjectSpecV1_0_0} from './types';
+
+const projectSpecV1_0_0: ProjectSpecV1_0_0 = {
+  name: 'mocked_starter',
+  chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
+  endpoint: 'wss://rpc.polkadot.io/public-ws',
+  author: 'jay',
+  description: 'this is test for init controller',
+  runner: {
+    node: {
+      name: '@subql/node',
+      version: '>=1.0.0',
+    },
+    query: {
+      name: '@subql/query',
+      version: '*',
+    },
+  },
+};
+
+async function getExampleProject(networkFamily: string, network: string): Promise<ExampleProjectInterface | undefined> {
+  const res = await fetch('https://raw.githubusercontent.com/subquery/templates/main/dist/output.json');
+
+  if (!res.ok) {
+    throw new Error('Failed to get template');
+  }
+
+  const templates = (await res.json()) as {
+    code: string;
+    networks: {code: string; examples: ExampleProjectInterface[]}[];
+  }[];
+  return templates.find((t) => t.code === networkFamily)?.networks.find((n) => n.code === network)?.examples[0];
+}
+
+export async function createTestProject(): Promise<string> {
+  const tmpdir = await fs.promises.mkdtemp(`${os.tmpdir()}${path.sep}`);
+  const projectDir = path.join(tmpdir, projectSpecV1_0_0.name);
+
+  const exampleProject = await getExampleProject('polkadot', 'polkadot');
+
+  const projectPath = await cloneProjectTemplate(tmpdir, projectSpecV1_0_0.name, exampleProject);
+  await prepare(projectPath, projectSpecV1_0_0);
+
+  // Install dependencies
+  childProcess.execSync(`npm i`, {cwd: projectDir});
+
+  await Codegen.run(['-l', projectDir]);
+  await Build.run(['-f', projectDir]);
+
+  return projectDir;
+}

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Various pieces of code from node and generalised them (#2357)
+
+### Changed
+- Tidy up block dispatcher constructor args (#2357)
 
 ## [9.0.0] - 2024-04-12
 ### Added

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
@@ -76,9 +76,6 @@ describe('SchemaMigration integration tests', () => {
 
   afterEach(async () => {
     await sequelize.dropSchema(schemaName, {logging: false});
-  });
-
-  afterAll(async () => {
     await sequelize?.close();
   });
 

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
@@ -66,21 +66,12 @@ describe('SchemaMigration integration tests', () => {
   let schemaName: string;
 
   beforeEach(async () => {
-    try {
-      // Need to create a new instance for each test because sequelize keeps reference to modle instances
-      sequelize = new Sequelize(
-        `postgresql://${option.username}:${option.password}@${option.host}:${option.port}/${option.database}`,
-        option
-      );
-      await sequelize.authenticate();
-    } catch (e) {
-      console.log(
-        'Failed to postgres connect',
-        `postgresql://${option.username}:${option.password}@${option.host}:${option.port}/${option.database}`,
-        e
-      );
-      throw e;
-    }
+    // Need to create a new instance for each test because sequelize keeps reference to modle instances
+    sequelize = new Sequelize(
+      `postgresql://${option.username}:${option.password}@${option.host}:${option.port}/${option.database}`,
+      option
+    );
+    await sequelize.authenticate();
   });
 
   afterEach(async () => {

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
@@ -66,12 +66,21 @@ describe('SchemaMigration integration tests', () => {
   let schemaName: string;
 
   beforeEach(async () => {
-    // Need to create a new instance for each test because sequelize keeps reference to modle instances
-    sequelize = new Sequelize(
-      `postgresql://${option.username}:${option.password}@${option.host}:${option.port}/${option.database}`,
-      option
-    );
-    await sequelize.authenticate();
+    try {
+      // Need to create a new instance for each test because sequelize keeps reference to modle instances
+      sequelize = new Sequelize(
+        `postgresql://${option.username}:${option.password}@${option.host}:${option.port}/${option.database}`,
+        option
+      );
+      await sequelize.authenticate();
+    } catch (e) {
+      console.log(
+        'Failed to postgres connect',
+        `postgresql://${option.username}:${option.password}@${option.host}:${option.port}/${option.database}`,
+        e
+      );
+      throw e;
+    }
   });
 
   afterEach(async () => {

--- a/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
@@ -12,8 +12,6 @@ import {getBlockHeight, IBlock, PoiSyncService} from '../../indexer';
 import {getLogger} from '../../logger';
 import {profilerWrap} from '../../profiler';
 import {Queue, AutoQueue, delay, memoryLock, waitForBatchSize, isTaskFlushedError} from '../../utils';
-import {DynamicDsService} from '../dynamic-ds.service';
-import {SmartBatchService} from '../smartBatch.service';
 import {StoreService} from '../store.service';
 import {StoreCacheService} from '../storeCache';
 import {IProjectService, ISubqueryProject} from '../types';
@@ -45,12 +43,10 @@ export abstract class BlockDispatcher<B, DS>
     eventEmitter: EventEmitter2,
     projectService: IProjectService<DS>,
     projectUpgradeService: IProjectUpgradeService,
-    smartBatchService: SmartBatchService,
     storeService: StoreService,
     storeCacheService: StoreCacheService,
     poiSyncService: PoiSyncService,
     project: ISubqueryProject,
-    dynamicDsService: DynamicDsService<DS>,
     fetchBlocksBatches: BatchBlockFetcher<B>
   ) {
     super(
@@ -60,11 +56,9 @@ export abstract class BlockDispatcher<B, DS>
       projectService,
       projectUpgradeService,
       new Queue(nodeConfig.batchSize * 3),
-      smartBatchService,
       storeService,
       storeCacheService,
-      poiSyncService,
-      dynamicDsService
+      poiSyncService
     );
     this.processQueue = new AutoQueue(nodeConfig.batchSize * 3, 1, nodeConfig.timeout, 'Process');
     this.fetchQueue = new AutoQueue(nodeConfig.batchSize * 3, nodeConfig.batchSize, nodeConfig.timeout, 'Fetch');

--- a/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.spec.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.spec.ts
@@ -3,9 +3,7 @@
 
 import {EventEmitter2} from '@nestjs/event-emitter';
 import {IProjectUpgradeService, NodeConfig} from '../../configure';
-import {DynamicDsService} from '../dynamic-ds.service';
 import {PoiSyncService} from '../poi';
-import {SmartBatchService} from '../smartBatch.service';
 import {StoreService} from '../store.service';
 import {StoreCacheService} from '../storeCache';
 import {IProjectService, ISubqueryProject} from '../types';
@@ -14,6 +12,10 @@ import {WorkerBlockDispatcher} from './worker-block-dispatcher';
 class TestWorkerBlockDispatcher extends WorkerBlockDispatcher<any, any, any> {
   async fetchBlock(worker: any, height: number): Promise<void> {
     return Promise.resolve();
+  }
+
+  get minimumHeapLimit(): number {
+    return 150;
   }
 }
 describe('WorkerBlockDispatcher', () => {
@@ -32,12 +34,10 @@ describe('WorkerBlockDispatcher', () => {
       null as unknown as EventEmitter2,
       null as unknown as IProjectService<any>,
       null as unknown as IProjectUpgradeService,
-      {minimumHeapRequired: 150} as unknown as SmartBatchService,
       null as unknown as StoreService,
       null as unknown as StoreCacheService,
       null as unknown as PoiSyncService,
       null as unknown as ISubqueryProject,
-      null as unknown as DynamicDsService<any>,
       null as unknown as () => Promise<any>
     );
     (dispatcher as any).workers = mockWorkers;

--- a/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.ts
@@ -12,8 +12,6 @@ import {IndexerEvent} from '../../events';
 import {IBlock, PoiSyncService} from '../../indexer';
 import {getLogger} from '../../logger';
 import {AutoQueue, isTaskFlushedError} from '../../utils';
-import {DynamicDsService} from '../dynamic-ds.service';
-import {SmartBatchService} from '../smartBatch.service';
 import {StoreService} from '../store.service';
 import {StoreCacheService} from '../storeCache';
 import {ISubqueryProject, IProjectService} from '../types';
@@ -57,12 +55,10 @@ export abstract class WorkerBlockDispatcher<DS, W extends Worker, B>
     eventEmitter: EventEmitter2,
     projectService: IProjectService<DS>,
     projectUpgradeService: IProjectUpgradeService,
-    smartBatchService: SmartBatchService,
     storeService: StoreService,
     storeCacheService: StoreCacheService,
     poiSyncService: PoiSyncService,
     project: ISubqueryProject,
-    dynamicDsService: DynamicDsService<DS>,
     private createIndexerWorker: () => Promise<W>
   ) {
     super(
@@ -72,11 +68,9 @@ export abstract class WorkerBlockDispatcher<DS, W extends Worker, B>
       projectService,
       projectUpgradeService,
       initAutoQueue(nodeConfig.workers, nodeConfig.batchSize, nodeConfig.timeout, 'Worker'),
-      smartBatchService,
       storeService,
       storeCacheService,
-      poiSyncService,
-      dynamicDsService
+      poiSyncService
     );
     // initAutoQueue will assert that workers is set. unfortunately we cant do anything before the super call
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/node-core/src/indexer/connectionPool.service.spec.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.spec.ts
@@ -35,22 +35,28 @@ const mockApiConnection: IApiConnectionSpecific = {
   },
 };
 
+const TEST_URL = 'https://example.com/api';
+
 describe('ConnectionPoolService', () => {
   let connectionPoolService: ConnectionPoolService<typeof mockApiConnection>;
+  let stateManager: ConnectionPoolStateManager<typeof mockApiConnection>;
   const nodeConfig: NodeConfig = new NodeConfig({
     batchSize: 1,
     subquery: 'example',
   });
-
-  beforeEach(() => {
-    connectionPoolService = new ConnectionPoolService<typeof mockApiConnection>(
-      nodeConfig,
-      new ConnectionPoolStateManager()
-    );
-    connectionPoolService.addToConnections(mockApiConnection, 'https://example.com/api');
+  const allConnectionsRemoved = jest.fn(() => {
+    /* nothing*/
   });
 
-  afterEach(() => {
+  beforeEach(async () => {
+    stateManager = new ConnectionPoolStateManager(allConnectionsRemoved);
+    connectionPoolService = new ConnectionPoolService<typeof mockApiConnection>(nodeConfig, stateManager);
+    await connectionPoolService.addToConnections(mockApiConnection, TEST_URL);
+  });
+
+  afterEach(async () => {
+    // Clean up timeouts/intervals
+    await Promise.all([stateManager.onApplicationShutdown(), connectionPoolService.onApplicationShutdown()]);
     jest.clearAllMocks();
   });
 
@@ -59,7 +65,7 @@ describe('ConnectionPoolService', () => {
       (mockApiConnection.apiConnect as any).mockImplementation(() => Promise.resolve());
       const apiConnectSpy = jest.spyOn(mockApiConnection, 'apiConnect');
 
-      (connectionPoolService as any).handleApiDisconnects('https://example.com/api');
+      (connectionPoolService as any).handleApiDisconnects(TEST_URL);
 
       await waitFor(() => (mockApiConnection.apiConnect as any).mock.calls.length === 1);
       expect(apiConnectSpy).toHaveBeenCalledTimes(1);
@@ -74,7 +80,7 @@ describe('ConnectionPoolService', () => {
 
       const apiConnectSpy = jest.spyOn(mockApiConnection, 'apiConnect');
 
-      (connectionPoolService as any).handleApiDisconnects('https://example.com/api');
+      (connectionPoolService as any).handleApiDisconnects(TEST_URL);
 
       await waitFor(() => (mockApiConnection.apiConnect as any).mock.calls.length === 3);
       expect(apiConnectSpy).toHaveBeenCalledTimes(3);
@@ -85,26 +91,31 @@ describe('ConnectionPoolService', () => {
       (mockApiConnection.apiConnect as any).mockImplementation(() => Promise.reject(new Error('Reconnection failed')));
       const apiConnectSpy = jest.spyOn(mockApiConnection, 'apiConnect');
 
-      (connectionPoolService as any).handleApiDisconnects('https://example.com/api');
+      (connectionPoolService as any).handleApiDisconnects(TEST_URL);
 
       await waitFor(() => (mockApiConnection.apiConnect as any).mock.calls.length === 5);
       expect(apiConnectSpy).toHaveBeenCalledTimes(5);
       expect(connectionPoolService.numConnections).toBe(0);
+
+      // Application would exit under normal circumstances as there is only one connection
+      expect(allConnectionsRemoved).toHaveBeenCalledTimes(1);
     }, 50000);
 
     it('should call handleApiDisconnects only once when multiple connection errors are triggered', async () => {
+      // Create another connection to remove a special case, TODO fix this weird behaviour
+      await connectionPoolService.addToConnections(mockApiConnection, `${TEST_URL}/2`);
       // Mock apiConnection.apiConnect() to not resolve for a considerable time
       (mockApiConnection.apiConnect as any).mockImplementation(() => delay(10));
 
       const handleApiDisconnectsSpy = jest.spyOn(connectionPoolService as any, 'handleApiDisconnects');
 
       // Trigger handleApiError with connection issue twice
-      void connectionPoolService.handleApiError('https://example.com/api', {
+      void connectionPoolService.handleApiError(TEST_URL, {
         name: 'ConnectionError',
         errorType: ApiErrorType.Connection,
         message: 'Connection error',
       });
-      void connectionPoolService.handleApiError('https://example.com/api', {
+      void connectionPoolService.handleApiError(TEST_URL, {
         name: 'ConnectionError',
         errorType: ApiErrorType.Connection,
         message: 'Connection error',

--- a/packages/node-core/src/indexer/index.ts
+++ b/packages/node-core/src/indexer/index.ts
@@ -14,7 +14,7 @@ export * from './storeCache';
 export * from './worker';
 export * from './dictionary';
 export * from './sandbox';
-export * from './smartBatch.service';
+export * from './sandbox.service';
 export * from './blockDispatcher';
 export * from './dynamic-ds.service';
 export * from './testing.service';

--- a/packages/node-core/src/indexer/indexer.manager.ts
+++ b/packages/node-core/src/indexer/indexer.manager.ts
@@ -31,8 +31,8 @@ export interface CustomHandler<K extends string = string, F = Record<string, unk
 }
 
 export abstract class BaseIndexerManager<
-  SA, // Api Type
-  A, // SafeApi Type
+  A, // Api Type
+  SA, // SafeApi Type
   B, // Block Type
   API extends IApi<A, SA, IBlock<B>[]>,
   DS extends BaseDataSource,
@@ -62,7 +62,7 @@ export abstract class BaseIndexerManager<
   constructor(
     protected readonly apiService: API,
     protected readonly nodeConfig: NodeConfig,
-    private sandboxService: {getDsProcessor: (ds: DS, api: SA) => IndexerSandbox},
+    private sandboxService: {getDsProcessor: (ds: DS, api: SA, unsafeApi: A) => IndexerSandbox},
     private dsProcessorService: BaseDsProcessorService<DS, CDS>,
     private dynamicDsService: DynamicDsService<DS>,
     private unfinalizedBlocksService: IUnfinalizedBlocksService<B>,
@@ -93,7 +93,7 @@ export abstract class BaseIndexerManager<
         // Injected runtimeVersion from fetch service might be outdated
         apiAt = apiAt ?? (await getApi());
 
-        const vm = this.sandboxService.getDsProcessor(ds, apiAt);
+        const vm = this.sandboxService.getDsProcessor(ds, apiAt, this.apiService.unsafeApi);
 
         // Inject function to create ds into vm
         vm.freeze(async (templateName: string, args?: Record<string, unknown>) => {

--- a/packages/node-core/src/indexer/indexer.manager.ts
+++ b/packages/node-core/src/indexer/indexer.manager.ts
@@ -8,7 +8,7 @@ import {NodeConfig} from '../configure';
 import {getLogger} from '../logger';
 import {profilerWrap} from '../profiler';
 import {ProcessBlockResponse} from './blockDispatcher';
-import {BaseDsProcessorService} from './ds-processor.service';
+import {asSecondLayerHandlerProcessor_1_0_0, BaseDsProcessorService} from './ds-processor.service';
 import {DynamicDsService} from './dynamic-ds.service';
 import {IndexerSandbox} from './sandbox';
 import {IBlock, IIndexerManager} from './types';
@@ -46,9 +46,6 @@ export abstract class BaseIndexerManager<
 
   protected abstract isRuntimeDs(ds: DS): ds is DS;
   protected abstract isCustomDs(ds: DS): ds is CDS;
-
-  // Uses asSecondLayerHandlerProcessor_1_0_0 in substrate to transfrom from v0.0.0 -> v1.0.0
-  protected abstract updateCustomProcessor: (processor: any) => any;
 
   protected abstract indexBlockData(
     block: B,
@@ -221,7 +218,7 @@ export abstract class BaseIndexerManager<
         return false;
       })
       .filter((handler) => {
-        const processor = this.updateCustomProcessor(plugin.handlerProcessors[handler.kind]);
+        const processor = asSecondLayerHandlerProcessor_1_0_0(plugin.handlerProcessors[handler.kind]);
 
         try {
           return processor.filterProcessor({
@@ -245,7 +242,7 @@ export abstract class BaseIndexerManager<
     const plugin = this.dsProcessorService.getDsProcessor(ds);
     const assets = await this.dsProcessorService.getAssets(ds);
 
-    const processor = this.updateCustomProcessor(plugin.handlerProcessors[handler.kind]);
+    const processor = asSecondLayerHandlerProcessor_1_0_0(plugin.handlerProcessors[handler.kind]);
 
     const transformedData = await processor
       .transformer({

--- a/packages/node-core/src/indexer/sandbox.service.ts
+++ b/packages/node-core/src/indexer/sandbox.service.ts
@@ -1,37 +1,31 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import { isMainThread } from 'worker_threads';
-import { Inject, Injectable } from '@nestjs/common';
-import {
-  hostStoreToStore,
-  IndexerSandbox,
-  NodeConfig,
-  StoreService,
-  ISubqueryProject,
-  InMemoryCacheService,
-} from '@subql/node-core';
-import { BaseDataSource, Store } from '@subql/types-core';
-import { ApiService } from './api.service';
+import {isMainThread} from 'worker_threads';
+import {Inject, Injectable} from '@nestjs/common';
+import {BaseDataSource, Store} from '@subql/types-core';
+import {NodeConfig} from '../configure';
+import {InMemoryCacheService} from './inMemoryCache.service';
+import {IndexerSandbox} from './sandbox';
+import {StoreService} from './store.service';
+import {ISubqueryProject} from './types';
+import {hostStoreToStore} from './worker';
 
 /* It would be nice to move this to node core but need to find a way to inject other things into the sandbox */
 @Injectable()
-export class SandboxService<Api> {
+export class SandboxService<Api, UnsafeApi> {
   private processorCache: Record<string, IndexerSandbox> = {};
 
   constructor(
-    private readonly apiService: ApiService,
     @Inject(isMainThread ? StoreService : 'Null')
     private readonly storeService: StoreService,
     private readonly cacheService: InMemoryCacheService,
     private readonly nodeConfig: NodeConfig,
-    @Inject('ISubqueryProject') private readonly project: ISubqueryProject,
+    @Inject('ISubqueryProject') private readonly project: ISubqueryProject
   ) {}
 
-  getDsProcessor(ds: BaseDataSource, api: Api): IndexerSandbox {
-    const store: Store = isMainThread
-      ? this.storeService.getStore()
-      : hostStoreToStore((global as any).host); // Provided in worker.ts
+  getDsProcessor(ds: BaseDataSource, api: Api, unsafeApi: UnsafeApi): IndexerSandbox {
+    const store: Store = isMainThread ? this.storeService.getStore() : hostStoreToStore((global as any).host); // Provided in worker.ts
 
     const cache = this.cacheService.getCache();
     const entry = this.getDataSourceEntry(ds);
@@ -45,13 +39,13 @@ export class SandboxService<Api> {
           entry,
           chainId: this.project.network.chainId,
         },
-        this.nodeConfig,
+        this.nodeConfig
       );
       this.processorCache[entry] = processor;
     }
     processor.freeze(api, 'api');
     if (this.nodeConfig.unsafe) {
-      processor.freeze(this.apiService.api, 'unsafeApi');
+      processor.freeze(unsafeApi, 'unsafeApi');
     }
     processor.freeze(this.project.network.chainId, 'chainId');
     return processor;

--- a/packages/node-core/src/subcommands/foreceClean.init.ts
+++ b/packages/node-core/src/subcommands/foreceClean.init.ts
@@ -1,0 +1,21 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {NestFactory} from '@nestjs/core';
+import {getLogger} from '../logger';
+import {ForceCleanService} from './forceClean.service';
+
+const logger = getLogger('CLI');
+export async function forceClean(forceCleanModule: any): Promise<void> {
+  try {
+    const app = await NestFactory.create(forceCleanModule);
+    await app.init();
+    const forceCleanService = app.get(ForceCleanService);
+    await forceCleanService.forceClean();
+  } catch (e: any) {
+    logger.error(e, 'Force-clean failed to execute');
+    process.exit(1);
+  }
+
+  process.exit(0);
+}

--- a/packages/node-core/src/subcommands/index.ts
+++ b/packages/node-core/src/subcommands/index.ts
@@ -3,4 +3,6 @@
 
 export * from './forceClean.service';
 export * from './forceClean.module';
+export * from './foreceClean.init';
+export * from './reindex.init';
 export * from './reindex.service';

--- a/packages/node-core/src/subcommands/reindex.init.ts
+++ b/packages/node-core/src/subcommands/reindex.init.ts
@@ -1,0 +1,29 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {NestFactory} from '@nestjs/core';
+import {getLogger} from '../logger';
+import {ReindexService} from './reindex.service';
+
+const logger = getLogger('CLI-Reindex');
+export async function reindexInit(reindexModule: any, targetHeight: number): Promise<void> {
+  try {
+    const app = await NestFactory.create(reindexModule);
+
+    await app.init();
+    const reindexService = app.get(ReindexService);
+
+    await reindexService.init();
+    const actualReindexHeight = await reindexService.getTargetHeightWithUnfinalizedBlocks(targetHeight);
+    if (actualReindexHeight !== targetHeight) {
+      logger.info(
+        `Found index target height ${targetHeight} beyond indexed unfinalized block ${actualReindexHeight}, will index to ${actualReindexHeight}`
+      );
+    }
+    await reindexService.reindex(actualReindexHeight);
+  } catch (e: any) {
+    logger.error(e, 'Reindex failed to execute');
+    process.exit(1);
+  }
+  process.exit(0);
+}

--- a/packages/node-core/src/utils/reindex.ts
+++ b/packages/node-core/src/utils/reindex.ts
@@ -1,12 +1,11 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {getAllEntitiesRelations} from '@subql/utils';
 import {Sequelize} from '@subql/x-sequelize';
 import {IProjectUpgradeService} from '../configure';
 import {DynamicDsService, IUnfinalizedBlocksService, StoreService, PoiService, ISubqueryProject} from '../indexer';
 import {getLogger} from '../logger';
-import {ForceCleanService} from '../subcommands';
+import {ForceCleanService} from '../subcommands/forceClean.service';
 
 const logger = getLogger('Reindex');
 

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use code that has been moved to node core, tidy up dependencies (#2357)
 
 ## [4.1.0] - 2024-04-12
 ### Removed

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { ApiOptions } from '@polkadot/api/types';
 import { ProviderInterface } from '@polkadot/rpc-provider/types';
 import { RegisteredTypes } from '@polkadot/types/types';
 import {

--- a/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
@@ -5,7 +5,6 @@ import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   NodeConfig,
-  SmartBatchService,
   StoreCacheService,
   StoreService,
   IProjectService,
@@ -18,7 +17,6 @@ import {
 import { SubstrateDatasource } from '@subql/types';
 import { SubqueryProject } from '../../configure/SubqueryProject';
 import { ApiService } from '../api.service';
-import { DynamicDsService } from '../dynamic-ds.service';
 import { IndexerManager } from '../indexer.manager';
 import { RuntimeService } from '../runtime/runtimeService';
 import { BlockContent, isFullBlock, LightBlockContent } from '../types';
@@ -42,24 +40,20 @@ export class BlockDispatcherService
     projectService: IProjectService<SubstrateDatasource>,
     @Inject('IProjectUpgradeService')
     projectUpgradeService: IProjectUpgradeService,
-    smartBatchService: SmartBatchService,
     storeService: StoreService,
     storeCacheService: StoreCacheService,
     poiSyncService: PoiSyncService,
     @Inject('ISubqueryProject') project: SubqueryProject,
-    dynamicDsService: DynamicDsService,
   ) {
     super(
       nodeConfig,
       eventEmitter,
       projectService,
       projectUpgradeService,
-      smartBatchService,
       storeService,
       storeCacheService,
       poiSyncService,
       project,
-      dynamicDsService,
       async (
         blockNums: number[],
       ): Promise<IBlock<BlockContent>[] | IBlock<LightBlockContent>[]> => {

--- a/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
@@ -6,7 +6,6 @@ import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   NodeConfig,
-  SmartBatchService,
   StoreService,
   StoreCacheService,
   IProjectService,
@@ -48,7 +47,6 @@ export class WorkerBlockDispatcherService
     projectService: IProjectService<SubstrateDatasource>,
     @Inject('IProjectUpgradeService')
     projectUpgadeService: IProjectUpgradeService,
-    smartBatchService: SmartBatchService,
     cacheService: InMemoryCacheService,
     storeService: StoreService,
     storeCacheService: StoreCacheService,
@@ -63,12 +61,10 @@ export class WorkerBlockDispatcherService
       eventEmitter,
       projectService,
       projectUpgadeService,
-      smartBatchService,
       storeService,
       storeCacheService,
       poiSyncService,
       project,
-      dynamicDsService,
       () =>
         createIndexerWorkerCore<
           IIndexerWorker,

--- a/packages/node/src/indexer/ds-processor.service.ts
+++ b/packages/node/src/indexer/ds-processor.service.ts
@@ -2,81 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { Injectable } from '@nestjs/common';
-import { AnyTuple } from '@polkadot/types-codec/types';
-import {
-  isCustomDs,
-  SubstrateDatasourceProcessor,
-} from '@subql/common-substrate';
+import { isCustomDs } from '@subql/common-substrate';
 import { BaseDsProcessorService } from '@subql/node-core';
 import {
-  SecondLayerHandlerProcessor_0_0_0,
-  SecondLayerHandlerProcessor_1_0_0,
   SubstrateCustomDatasource,
   SubstrateCustomHandler,
   SubstrateDatasource,
-  SubstrateHandlerKind,
+  SubstrateDatasourceProcessor,
   SubstrateMapping,
 } from '@subql/types';
-
-export function isSecondLayerHandlerProcessor_0_0_0<
-  K extends SubstrateHandlerKind,
-  F extends Record<string, unknown>,
-  E,
-  IT extends AnyTuple = AnyTuple,
-  DS extends SubstrateCustomDatasource = SubstrateCustomDatasource,
->(
-  processor:
-    | SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS>
-    | SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS>,
-): processor is SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS> {
-  // Exisiting datasource processors had no concept of specVersion, therefore undefined is equivalent to 0.0.0
-  return processor.specVersion === undefined;
-}
-
-export function isSecondLayerHandlerProcessor_1_0_0<
-  K extends SubstrateHandlerKind,
-  F extends Record<string, unknown>,
-  E,
-  IT extends AnyTuple = AnyTuple,
-  DS extends SubstrateCustomDatasource = SubstrateCustomDatasource,
->(
-  processor:
-    | SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS>
-    | SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS>,
-): processor is SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS> {
-  return processor.specVersion === '1.0.0';
-}
-
-export function asSecondLayerHandlerProcessor_1_0_0<
-  K extends SubstrateHandlerKind,
-  F extends Record<string, unknown>,
-  E,
-  IT extends AnyTuple = AnyTuple,
-  DS extends SubstrateCustomDatasource = SubstrateCustomDatasource,
->(
-  processor:
-    | SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS>
-    | SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS>,
-): SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS> {
-  if (isSecondLayerHandlerProcessor_1_0_0(processor)) {
-    return processor;
-  }
-
-  if (!isSecondLayerHandlerProcessor_0_0_0(processor)) {
-    throw new Error('Unsupported ds processor version');
-  }
-
-  return {
-    ...processor,
-    specVersion: '1.0.0',
-    filterProcessor: (params) =>
-      processor.filterProcessor(params.filter, params.input, params.ds),
-    transformer: (params) =>
-      processor
-        .transformer(params.input, params.ds, params.api, params.assets)
-        .then((res) => [res]),
-  };
-}
 
 @Injectable()
 export class DsProcessorService extends BaseDsProcessorService<

--- a/packages/node/src/indexer/fetch.module.ts
+++ b/packages/node/src/indexer/fetch.module.ts
@@ -10,12 +10,12 @@ import {
   PoiService,
   NodeConfig,
   ConnectionPoolService,
-  SmartBatchService,
   StoreCacheService,
   ConnectionPoolStateManager,
   IProjectUpgradeService,
   PoiSyncService,
   InMemoryCacheService,
+  SandboxService,
 } from '@subql/node-core';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { ApiService } from './api.service';
@@ -31,7 +31,6 @@ import { FetchService } from './fetch.service';
 import { IndexerManager } from './indexer.manager';
 import { ProjectService } from './project.service';
 import { RuntimeService } from './runtime/runtimeService';
-import { SandboxService } from './sandbox.service';
 import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
 
 @Module({
@@ -43,13 +42,6 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
     IndexerManager,
     ConnectionPoolStateManager,
     {
-      provide: SmartBatchService,
-      useFactory: (nodeConfig: NodeConfig) => {
-        return new SmartBatchService(nodeConfig.batchSize);
-      },
-      inject: [NodeConfig],
-    },
-    {
       provide: 'IBlockDispatcher',
       useFactory: (
         nodeConfig: NodeConfig,
@@ -58,7 +50,6 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
         projectUpgradeService: IProjectUpgradeService,
         apiService: ApiService,
         indexerManager: IndexerManager,
-        smartBatchService: SmartBatchService,
         cacheService: InMemoryCacheService,
         storeService: StoreService,
         storeCacheService: StoreCacheService,
@@ -74,7 +65,6 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
               eventEmitter,
               projectService,
               projectUpgradeService,
-              smartBatchService,
               cacheService,
               storeService,
               storeCacheService,
@@ -91,12 +81,10 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
               eventEmitter,
               projectService,
               projectUpgradeService,
-              smartBatchService,
               storeService,
               storeCacheService,
               poiSyncService,
               project,
-              dynamicDsService,
             ),
       inject: [
         NodeConfig,
@@ -105,7 +93,6 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
         'IProjectUpgradeService',
         ApiService,
         IndexerManager,
-        SmartBatchService,
         InMemoryCacheService,
         StoreService,
         StoreCacheService,

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -15,6 +15,7 @@ import {
   StoreCacheService,
   IProjectUpgradeService,
   InMemoryCacheService,
+  SandboxService,
 } from '@subql/node-core';
 import { Sequelize } from '@subql/x-sequelize';
 import { GraphQLSchema } from 'graphql';
@@ -25,7 +26,6 @@ import { DsProcessorService } from './ds-processor.service';
 import { DynamicDsService } from './dynamic-ds.service';
 import { IndexerManager } from './indexer.manager';
 import { ProjectService } from './project.service';
-import { SandboxService } from './sandbox.service';
 import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
 
 jest.mock('@subql/x-sequelize', () => {
@@ -182,7 +182,6 @@ function createIndexerManager(
     storeCache,
   );
   const sandboxService = new SandboxService(
-    apiService,
     storeService,
     cacheService,
     nodeConfig,

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -18,6 +18,7 @@ import {
   NodeConfig,
   getLogger,
   profiler,
+  SandboxService,
   IndexerSandbox,
   ProcessBlockResponse,
   BaseIndexerManager,
@@ -39,7 +40,6 @@ import {
   DsProcessorService,
 } from './ds-processor.service';
 import { DynamicDsService } from './dynamic-ds.service';
-import { SandboxService } from './sandbox.service';
 import { ApiAt, BlockContent, isFullBlock, LightBlockContent } from './types';
 import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
 
@@ -47,8 +47,8 @@ const logger = getLogger('indexer');
 
 @Injectable()
 export class IndexerManager extends BaseIndexerManager<
-  ApiAt,
   ApiPromise,
+  ApiAt,
   BlockContent | LightBlockContent,
   SubstrateApiService,
   SubstrateDatasource,
@@ -64,7 +64,7 @@ export class IndexerManager extends BaseIndexerManager<
   constructor(
     apiService: SubstrateApiService,
     nodeConfig: NodeConfig,
-    sandboxService: SandboxService<ApiAt>,
+    sandboxService: SandboxService<ApiAt, ApiPromise>,
     dsProcessorService: DsProcessorService,
     dynamicDsService: DynamicDsService,
     unfinalizedBlocksService: UnfinalizedBlocksService,

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -36,7 +36,7 @@ import { SubstrateProjectDs } from '../configure/SubqueryProject';
 import * as SubstrateUtil from '../utils/substrate';
 import { ApiService as SubstrateApiService } from './api.service';
 import {
-  asSecondLayerHandlerProcessor_1_0_0,
+  // asSecondLayerHandlerProcessor_1_0_0,
   DsProcessorService,
 } from './ds-processor.service';
 import { DynamicDsService } from './dynamic-ds.service';
@@ -59,7 +59,6 @@ export class IndexerManager extends BaseIndexerManager<
 > {
   protected isRuntimeDs = isRuntimeDs;
   protected isCustomDs = isCustomDs;
-  protected updateCustomProcessor = asSecondLayerHandlerProcessor_1_0_0;
 
   constructor(
     apiService: SubstrateApiService,

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -35,10 +35,7 @@ import {
 import { SubstrateProjectDs } from '../configure/SubqueryProject';
 import * as SubstrateUtil from '../utils/substrate';
 import { ApiService as SubstrateApiService } from './api.service';
-import {
-  // asSecondLayerHandlerProcessor_1_0_0,
-  DsProcessorService,
-} from './ds-processor.service';
+import { DsProcessorService } from './ds-processor.service';
 import { DynamicDsService } from './dynamic-ds.service';
 import { ApiAt, BlockContent, isFullBlock, LightBlockContent } from './types';
 import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';

--- a/packages/node/src/indexer/project.service.ts
+++ b/packages/node/src/indexer/project.service.ts
@@ -41,7 +41,7 @@ export class ProjectService extends BaseProjectService<
     @Inject(isMainThread ? Sequelize : 'Null') sequelize: Sequelize,
     @Inject('ISubqueryProject') project: SubqueryProject,
     @Inject('IProjectUpgradeService')
-    protected readonly projectUpgradeService: IProjectUpgradeService<SubqueryProject>,
+    projectUpgradeService: IProjectUpgradeService<SubqueryProject>,
     @Inject(isMainThread ? StoreService : 'Null') storeService: StoreService,
     nodeConfig: NodeConfig,
     dynamicDsService: DynamicDsService,

--- a/packages/node/src/indexer/worker/worker-fetch.module.ts
+++ b/packages/node/src/indexer/worker/worker-fetch.module.ts
@@ -12,6 +12,7 @@ import {
   InMemoryCacheService,
   WorkerInMemoryCacheService,
   WorkerUnfinalizedBlocksService,
+  SandboxService,
 } from '@subql/node-core';
 import { SubqueryProject } from '../../configure/SubqueryProject';
 import { ApiService } from '../api.service';
@@ -21,7 +22,6 @@ import { DynamicDsService } from '../dynamic-ds.service';
 import { IndexerManager } from '../indexer.manager';
 import { ProjectService } from '../project.service';
 import { WorkerRuntimeService } from '../runtime/workerRuntimeService';
-import { SandboxService } from '../sandbox.service';
 import { UnfinalizedBlocksService } from '../unfinalizedBlocks.service';
 import { WorkerService } from './worker.service';
 

--- a/packages/node/src/subcommands/forceClean.init.ts
+++ b/packages/node/src/subcommands/forceClean.init.ts
@@ -1,21 +1,7 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import { NestFactory } from '@nestjs/core';
-import { ForceCleanService, getLogger } from '@subql/node-core';
+import { forceClean } from '@subql/node-core';
 import { ForceCleanModule } from './forceClean.module';
 
-const logger = getLogger('CLI');
-export async function forceCleanInit(): Promise<void> {
-  try {
-    const app = await NestFactory.create(ForceCleanModule);
-    await app.init();
-    const forceCleanService = app.get(ForceCleanService);
-    await forceCleanService.forceClean();
-  } catch (e) {
-    logger.error(e, 'Force-clean failed to execute');
-    process.exit(1);
-  }
-
-  process.exit(0);
-}
+export const forceCleanInit = (): Promise<void> => forceClean(ForceCleanModule);

--- a/packages/node/src/subcommands/reindex.init.ts
+++ b/packages/node/src/subcommands/reindex.init.ts
@@ -1,30 +1,8 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import { NestFactory } from '@nestjs/core';
-import { getLogger, ReindexService } from '@subql/node-core';
+import { reindexInit as baseReindexInit } from '@subql/node-core';
 import { ReindexModule } from './reindex.module';
 
-const logger = getLogger('CLI-Reindex');
-export async function reindexInit(targetHeight: number): Promise<void> {
-  try {
-    const app = await NestFactory.create(ReindexModule);
-
-    await app.init();
-    const reindexService = app.get(ReindexService);
-
-    await reindexService.init();
-    const actualReindexHeight =
-      await reindexService.getTargetHeightWithUnfinalizedBlocks(targetHeight);
-    if (actualReindexHeight !== targetHeight) {
-      logger.info(
-        `Found index target height ${targetHeight} beyond indexed unfinalized block ${actualReindexHeight}, will index to ${actualReindexHeight}`,
-      );
-    }
-    await reindexService.reindex(actualReindexHeight);
-  } catch (e) {
-    logger.error(e, 'Reindex failed to execute');
-    process.exit(1);
-  }
-  process.exit(0);
-}
+export const reindexInit = (targetHeight: number) =>
+  baseReindexInit(ReindexModule, targetHeight);

--- a/packages/node/src/subcommands/testing.module.ts
+++ b/packages/node/src/subcommands/testing.module.ts
@@ -9,12 +9,12 @@ import {
   ConnectionPoolStateManager,
   DbModule,
   InMemoryCacheService,
-  NodeConfig,
   PoiService,
   PoiSyncService,
   StoreCacheService,
   StoreService,
   TestRunner,
+  SandboxService,
 } from '@subql/node-core';
 import { ConfigureModule } from '../configure/configure.module';
 import { ApiService } from '../indexer/api.service';
@@ -22,7 +22,6 @@ import { DsProcessorService } from '../indexer/ds-processor.service';
 import { DynamicDsService } from '../indexer/dynamic-ds.service';
 import { IndexerManager } from '../indexer/indexer.manager';
 import { ProjectService } from '../indexer/project.service';
-import { SandboxService } from '../indexer/sandbox.service';
 import { UnfinalizedBlocksService } from '../indexer/unfinalizedBlocks.service';
 
 @Module({

--- a/packages/node/src/subcommands/testing.service.ts
+++ b/packages/node/src/subcommands/testing.service.ts
@@ -9,7 +9,6 @@ import {
   TestingService as BaseTestingService,
   NestLogger,
   TestRunner,
-  SubqlProjectDs,
   IBlock,
 } from '@subql/node-core';
 import { SubstrateDatasource } from '@subql/types';

--- a/packages/node/src/utils/project.ts
+++ b/packages/node/src/utils/project.ts
@@ -19,7 +19,6 @@ import { Reader } from '@subql/types-core';
 import yaml from 'js-yaml';
 import { NodeVM, VMScript } from 'vm2';
 import {
-  SubqlProjectDsTemplate,
   SubqueryProject,
   SubstrateProjectDs,
 } from '../configure/SubqueryProject';

--- a/packages/types-core/CHANGELOG.md
+++ b/packages/types-core/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 - GetOptions type with support for ordering store methods (#2325)
+- Generic ds processor types from types (#2357)
 
 ## [0.6.0] - 2024-03-28
 ### Changed

--- a/packages/types-core/src/project/datasourceProcessors.ts
+++ b/packages/types-core/src/project/datasourceProcessors.ts
@@ -34,57 +34,6 @@ export interface HandlerInputTransformer_1_0_0<
   (params: {input: IM[K]; ds: DS; api: API; filter?: F; assets?: Record<string, string>}): Promise<E[]>;
 }
 
-// export interface HandlerInputTransformer_0_0_0<
-//   T extends SubstrateHandlerKind,
-//   E,
-//   IT extends AnyTuple,
-//   DS extends BaseCustomDataSource = SubstrateCustomDatasource
-// > {
-//   (input: RuntimeHandlerInputMap<IT>[T], ds: DS, api: ApiPromise, assets?: Record<string, string>): Promise<E>; //  | SubstrateBuiltinDataSource
-// }
-
-// export interface HandlerInputTransformer_1_0_0<
-//   T extends SubstrateHandlerKind,
-//   F extends Record<string, unknown>,
-//   E,
-//   IT extends AnyTuple,
-//   DS extends BaseCustomDataSource = SubstrateCustomDatasource
-// > {
-//   (params: {
-//     input: RuntimeHandlerInputMap<IT>[T];
-//     ds: DS;
-//     filter?: F;
-//     api: ApiPromise;
-//     assets?: Record<string, string>;
-//   }): Promise<E[]>;
-// }
-
-// type SecondLayerHandlerProcessorArray<
-//   K extends string,
-//   F extends Record<string, unknown>,
-//   T,
-//   IT extends AnyTuple = AnyTuple,
-//   DS extends BaseCustomDataSource<K> = SubstrateCustomDatasource<K>
-// > =
-//   | SecondLayerHandlerProcessor<SubstrateHandlerKind.Block, F, T, IT, DS>
-//   | SecondLayerHandlerProcessor<SubstrateHandlerKind.Call, F, T, IT, DS>
-//   | SecondLayerHandlerProcessor<SubstrateHandlerKind.Event, F, T, IT, DS>;
-
-// export interface SubstrateDatasourceProcessor<
-//   K extends string,
-//   F extends Record<string, unknown>,
-//   DS extends SubstrateCustomDatasource<K> = SubstrateCustomDatasource<K>,
-//   P extends Record<string, SecondLayerHandlerProcessorArray<K, F, any, any, DS>> = Record<
-//     string,
-//     SecondLayerHandlerProcessorArray<K, F, any, any, DS>
-//   >
-// > {
-//   kind: K;
-//   validate(ds: DS, assets: Record<string, string>): void;
-//   dsFilterProcessor(ds: DS, api: ApiPromise): boolean;
-//   handlerProcessors: P;
-// }
-
 interface SecondLayerHandlerProcessorBase<
   IM extends HandlerInputMap,
   K extends keyof IM,

--- a/packages/types-core/src/project/datasourceProcessors.ts
+++ b/packages/types-core/src/project/datasourceProcessors.ts
@@ -1,0 +1,134 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {DictionaryQueryEntry} from './types';
+import {BaseCustomDataSource} from './versioned';
+
+/**
+ * Maps a handler kind to the data type
+ * @example {
+ * 'block': BlockType,
+ * 'transaction': TransactionType,
+ * 'event': EventType,
+ * }*/
+export type HandlerInputMap = Record<string, any>;
+
+export interface HandlerInputTransformer_0_0_0<
+  IM extends HandlerInputMap,
+  K extends keyof IM,
+  DS extends BaseCustomDataSource,
+  API,
+  E // Output type
+> {
+  (input: IM[K], ds: DS, api: API, assets?: Record<string, string>): Promise<E>;
+}
+
+export interface HandlerInputTransformer_1_0_0<
+  IM extends HandlerInputMap,
+  K extends keyof IM,
+  DS extends BaseCustomDataSource,
+  API,
+  F extends Record<string, unknown>,
+  E // Output type
+> {
+  (params: {input: IM[K]; ds: DS; api: API; filter?: F; assets?: Record<string, string>}): Promise<E[]>;
+}
+
+// export interface HandlerInputTransformer_0_0_0<
+//   T extends SubstrateHandlerKind,
+//   E,
+//   IT extends AnyTuple,
+//   DS extends BaseCustomDataSource = SubstrateCustomDatasource
+// > {
+//   (input: RuntimeHandlerInputMap<IT>[T], ds: DS, api: ApiPromise, assets?: Record<string, string>): Promise<E>; //  | SubstrateBuiltinDataSource
+// }
+
+// export interface HandlerInputTransformer_1_0_0<
+//   T extends SubstrateHandlerKind,
+//   F extends Record<string, unknown>,
+//   E,
+//   IT extends AnyTuple,
+//   DS extends BaseCustomDataSource = SubstrateCustomDatasource
+// > {
+//   (params: {
+//     input: RuntimeHandlerInputMap<IT>[T];
+//     ds: DS;
+//     filter?: F;
+//     api: ApiPromise;
+//     assets?: Record<string, string>;
+//   }): Promise<E[]>;
+// }
+
+// type SecondLayerHandlerProcessorArray<
+//   K extends string,
+//   F extends Record<string, unknown>,
+//   T,
+//   IT extends AnyTuple = AnyTuple,
+//   DS extends BaseCustomDataSource<K> = SubstrateCustomDatasource<K>
+// > =
+//   | SecondLayerHandlerProcessor<SubstrateHandlerKind.Block, F, T, IT, DS>
+//   | SecondLayerHandlerProcessor<SubstrateHandlerKind.Call, F, T, IT, DS>
+//   | SecondLayerHandlerProcessor<SubstrateHandlerKind.Event, F, T, IT, DS>;
+
+// export interface SubstrateDatasourceProcessor<
+//   K extends string,
+//   F extends Record<string, unknown>,
+//   DS extends SubstrateCustomDatasource<K> = SubstrateCustomDatasource<K>,
+//   P extends Record<string, SecondLayerHandlerProcessorArray<K, F, any, any, DS>> = Record<
+//     string,
+//     SecondLayerHandlerProcessorArray<K, F, any, any, DS>
+//   >
+// > {
+//   kind: K;
+//   validate(ds: DS, assets: Record<string, string>): void;
+//   dsFilterProcessor(ds: DS, api: ApiPromise): boolean;
+//   handlerProcessors: P;
+// }
+
+interface SecondLayerHandlerProcessorBase<
+  IM extends HandlerInputMap,
+  K extends keyof IM,
+  F extends Record<string, unknown>,
+  DS extends BaseCustomDataSource
+> {
+  baseHandlerKind: K;
+  baseFilter: IM[K] | IM[K][];
+  filterValidator: (filter?: F) => void;
+  dictionaryQuery?: (filter: F, ds: DS) => DictionaryQueryEntry | undefined;
+}
+
+// only allow one custom handler for each baseHandler kind
+export interface SecondLayerHandlerProcessor_0_0_0<
+  IM extends HandlerInputMap,
+  K extends keyof IM,
+  F extends Record<string, unknown>,
+  E,
+  DS extends BaseCustomDataSource,
+  API
+> extends SecondLayerHandlerProcessorBase<IM, K, F, DS> {
+  specVersion: undefined;
+  transformer: HandlerInputTransformer_0_0_0<IM, K, DS, API, E>;
+  filterProcessor: (filter: F | undefined, input: IM[K], ds: DS) => boolean;
+}
+
+export interface SecondLayerHandlerProcessor_1_0_0<
+  IM extends HandlerInputMap,
+  K extends keyof IM,
+  F extends Record<string, unknown>,
+  E,
+  DS extends BaseCustomDataSource,
+  API
+> extends SecondLayerHandlerProcessorBase<IM, K, F, DS> {
+  specVersion: '1.0.0';
+  transformer: HandlerInputTransformer_1_0_0<IM, K, DS, API, F, E>;
+  filterProcessor: (params: {filter: F | undefined; input: IM[K]; ds: DS}) => boolean;
+}
+
+export type SecondLayerHandlerProcessor<
+  IM extends HandlerInputMap,
+  K extends keyof IM,
+  F extends Record<string, unknown>,
+  E,
+  DS extends BaseCustomDataSource,
+  API
+> = SecondLayerHandlerProcessor_0_0_0<IM, K, F, E, DS, API> | SecondLayerHandlerProcessor_1_0_0<IM, K, F, E, DS, API>;

--- a/packages/types-core/src/project/index.ts
+++ b/packages/types-core/src/project/index.ts
@@ -4,3 +4,4 @@
 export * from './types';
 export * from './versioned';
 export * from './readers';
+export * from './datasourceProcessors';

--- a/packages/types-core/src/project/types.ts
+++ b/packages/types-core/src/project/types.ts
@@ -107,11 +107,11 @@ export interface IProjectNetworkConfig extends ProjectNetworkConfig {
   chainId: string;
 }
 
-export type DsProcessor<DS> = {
+export type DsProcessor<DS, P extends Record<string, any> = Record<string, any>, API = any> = {
   kind: string;
   validate: (ds: DS, assets: Record<string, string>) => void;
-  dsFilterProcessor: (ds: DS, api: any) => boolean;
-  handlerProcessors: Record<string, any>;
+  dsFilterProcessor: (ds: DS, api: API) => boolean;
+  handlerProcessors: P;
 };
 
 export interface ProjectRootAndManifest {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Use ds processor types from `@subql/types-core` (#2357)
 
 ## [3.4.0] - 2024-03-28
 ### Added

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -7,7 +7,6 @@ import {
   BaseTemplateDataSource,
   IProjectNetworkConfig,
   CommonSubqueryProject,
-  DictionaryQueryEntry,
   FileReference,
   Processor,
   ProjectManifestV1_0_0,
@@ -16,6 +15,12 @@ import {
   BaseHandler,
   BaseMapping,
   BaseCustomDataSource,
+  HandlerInputTransformer_0_0_0 as BaseHandlerInputTransformer_0_0_0,
+  HandlerInputTransformer_1_0_0 as BaseHandlerInputTransformer_1_0_0,
+  SecondLayerHandlerProcessor_0_0_0 as BaseSecondLayerHandlerProcessor_0_0_0,
+  SecondLayerHandlerProcessor_1_0_0 as BaseSecondLayerHandlerProcessor_1_0_0,
+  SecondLayerHandlerProcessor as BaseSecondLayerHandlerProcessor,
+  DsProcessor,
 } from '@subql/types-core';
 import {LightSubstrateEvent, SubstrateBlock, SubstrateEvent, SubstrateExtrinsic} from './interfaces';
 
@@ -281,30 +286,28 @@ export interface SubstrateCustomDatasource<
   processor: Processor<O>;
 }
 
-export interface HandlerInputTransformer_0_0_0<
+/**
+ * @deprecated use types core version. datasource processors need updating before this can be removed
+ * */
+export type HandlerInputTransformer_0_0_0<
+  IT extends AnyTuple,
+  IM extends RuntimeHandlerInputMap<IT>,
   T extends SubstrateHandlerKind,
   E,
-  IT extends AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
-> {
-  (input: RuntimeHandlerInputMap<IT>[T], ds: DS, api: ApiPromise, assets?: Record<string, string>): Promise<E>; //  | SubstrateBuiltinDataSource
-}
+> = BaseHandlerInputTransformer_0_0_0<IM, T, DS, ApiPromise, E>;
 
-export interface HandlerInputTransformer_1_0_0<
+/**
+ * @deprecated use types core version. datasource processors need updating before this can be removed
+ * */
+export type HandlerInputTransformer_1_0_0<
+  IT extends AnyTuple,
+  IM extends RuntimeHandlerInputMap<IT>,
   T extends SubstrateHandlerKind,
   F extends Record<string, unknown>,
   E,
-  IT extends AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
-> {
-  (params: {
-    input: RuntimeHandlerInputMap<IT>[T];
-    ds: DS;
-    filter?: F;
-    api: ApiPromise;
-    assets?: Record<string, string>;
-  }): Promise<E[]>;
-}
+> = BaseHandlerInputTransformer_1_0_0<IM, T, DS, ApiPromise, F, E>;
 
 type SecondLayerHandlerProcessorArray<
   K extends string,
@@ -317,7 +320,10 @@ type SecondLayerHandlerProcessorArray<
   | SecondLayerHandlerProcessor<SubstrateHandlerKind.Call, F, T, IT, DS>
   | SecondLayerHandlerProcessor<SubstrateHandlerKind.Event, F, T, IT, DS>;
 
-export interface SubstrateDatasourceProcessor<
+/**
+ * @deprecated use types core version. datasource processors need updating before this can be removed
+ * */
+export type SubstrateDatasourceProcessor<
   K extends string,
   F extends Record<string, unknown>,
   DS extends SubstrateCustomDatasource<K> = SubstrateCustomDatasource<K>,
@@ -325,56 +331,40 @@ export interface SubstrateDatasourceProcessor<
     string,
     SecondLayerHandlerProcessorArray<K, F, any, any, DS>
   >
-> {
-  kind: K;
-  validate(ds: DS, assets: Record<string, string>): void;
-  dsFilterProcessor(ds: DS, api: ApiPromise): boolean;
-  handlerProcessors: P;
-}
+> = DsProcessor<DS, P, ApiPromise>;
 
-interface SecondLayerHandlerProcessorBase<
-  K extends SubstrateHandlerKind,
-  F extends Record<string, unknown>,
-  DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
-> {
-  baseHandlerKind: K;
-  baseFilter: RuntimeFilterMap[K] | RuntimeFilterMap[K][];
-  filterValidator: (filter?: F) => void;
-  dictionaryQuery?: (filter: F, ds: DS) => DictionaryQueryEntry | undefined;
-}
-
-// only allow one custom handler for each baseHandler kind
-export interface SecondLayerHandlerProcessor_0_0_0<
+/**
+ * @deprecated use types core version. datasource processors need updating before this can be removed
+ * */
+export type SecondLayerHandlerProcessor_0_0_0<
   K extends SubstrateHandlerKind,
   F extends Record<string, unknown>,
   E,
   IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
-> extends SecondLayerHandlerProcessorBase<K, F, DS> {
-  specVersion: undefined;
-  transformer: HandlerInputTransformer_0_0_0<K, E, IT, DS>;
-  filterProcessor: (filter: F | undefined, input: RuntimeHandlerInputMap<IT>[K], ds: DS) => boolean;
-}
+> = BaseSecondLayerHandlerProcessor_0_0_0<RuntimeHandlerInputMap<IT>, K, F, E, DS, ApiPromise>;
 
-export interface SecondLayerHandlerProcessor_1_0_0<
+/**
+ * @deprecated use types core version. datasource processors need updating before this can be removed
+ * */
+export type SecondLayerHandlerProcessor_1_0_0<
   K extends SubstrateHandlerKind,
   F extends Record<string, unknown>,
   E,
   IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
-> extends SecondLayerHandlerProcessorBase<K, F, DS> {
-  specVersion: '1.0.0';
-  transformer: HandlerInputTransformer_1_0_0<K, F, E, IT, DS>;
-  filterProcessor: (params: {filter: F | undefined; input: RuntimeHandlerInputMap<IT>[K]; ds: DS}) => boolean;
-}
+> = BaseSecondLayerHandlerProcessor_1_0_0<RuntimeHandlerInputMap<IT>, K, F, E, DS, ApiPromise>;
 
+/**
+ * @deprecated use types core version. datasource processors need updating before this can be removed
+ * */
 export type SecondLayerHandlerProcessor<
   K extends SubstrateHandlerKind,
   F extends Record<string, unknown>,
   E,
   IT extends AnyTuple = AnyTuple,
   DS extends SubstrateCustomDatasource = SubstrateCustomDatasource
-> = SecondLayerHandlerProcessor_0_0_0<K, F, E, IT, DS> | SecondLayerHandlerProcessor_1_0_0<K, F, E, IT, DS>;
+> = BaseSecondLayerHandlerProcessor<RuntimeHandlerInputMap<IT>, K, F, E, DS, ApiPromise>;
 
 /**
  * Represents a Substrate subquery network configuration, which is based on the CommonSubqueryNetworkConfig template.


### PR DESCRIPTION
# Description
- Moves code to Node Core
- Cleans up unused and simplifies dependencies for block dispatchers
- Fixes btree_gist not being enabled on CI tests
- Changes build command to remove parallel in hope of fixing CI issues 
- Move ds processor code from node/types to node-core/types-core

Fixes https://github.com/subquery/subql/issues/2336

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
