### PR TITLE
Fix historical filter being applied to aggregate queries

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
+### Fixed
+- Aggregate queries with historical not filtering by block height (#2367)
 
 ## [2.10.1] - 2024-04-24
 ### Changed


### PR DESCRIPTION
# Description
The aggregates plugin would only consider historical with selected fields but not apply the block range. This PR fixes this by adding the block height to the filter conditions.

Fixes https://github.com/subquery/subql/issues/2362

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
