### PR TITLE
Fix startup failing with ds-processors

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Startup error with DS processors (`this.isCustomDs is not a function`) (#2369)
 
 ## [4.2.0] - 2024-04-24
 ### Changed

--- a/packages/node/src/indexer/dictionary/substrateDictionary.service.ts
+++ b/packages/node/src/indexer/dictionary/substrateDictionary.service.ts
@@ -57,7 +57,9 @@ export class SubstrateDictionaryService extends DictionaryService<
           const dictionaryV1 = await SubstrateDictionaryV1.create(
             this.project,
             this.nodeConfig,
-            this.dsProcessorService.getDsProcessor.bind(this),
+            this.dsProcessorService.getDsProcessor.bind(
+              this.dsProcessorService,
+            ),
             endpoint,
           );
           dictionariesV1.push(dictionaryV1);


### PR DESCRIPTION
# Description
`getDsProcessor` was being bound to the wrong scope

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
