### PR TITLE
Fix debug flag not enabling worker loggers

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Expose option to add workerData to workers (#2372)
 
+### Changed
+- Simplify logger function (#2374)
+
 ## [10.0.0] - 2024-04-24
 ### Added
 - Various pieces of code from node and generalised them (#2357)

--- a/packages/node-core/src/indexer/worker/worker.service.ts
+++ b/packages/node-core/src/indexer/worker/worker.service.ts
@@ -1,14 +1,13 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {threadId} from 'node:worker_threads';
 import {BaseDataSource} from '@subql/types-core';
 import {IProjectUpgradeService, NodeConfig} from '../../configure';
 import {getLogger} from '../../logger';
 import {AutoQueue, isTaskFlushedError, memoryLock} from '../../utils';
 import {ProcessBlockResponse} from '../blockDispatcher';
 import {IBlock, IProjectService} from '../types';
-import {BlockUnavailableError, isBlockUnavailableError} from './utils';
+import {isBlockUnavailableError} from './utils';
 
 export type FetchBlockResponse = {specVersion: number; parentHash: string} | undefined;
 
@@ -19,7 +18,7 @@ export type WorkerStatusResponse = {
   toFetchBlocks: number;
 };
 
-const logger = getLogger(`Worker Service #${threadId}`);
+const logger = getLogger(`WorkerService`);
 
 export abstract class BaseWorkerService<
   B /* BlockContent */,

--- a/packages/node-core/src/logger.ts
+++ b/packages/node-core/src/logger.ts
@@ -42,7 +42,7 @@ export function setDebugFilter(debug: string | undefined): void {
 }
 
 export class NestLogger implements LoggerService {
-  private logger = logger.getLogger(`nestjs${isMainThread ? '' : `-#${threadId}`}`);
+  private logger = getLogger(`nestjs`);
 
   constructor(private readonly debugLevel = false) {}
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Debug flag not working with worker loggers (#2374)
 
 ## [2.9.1] - 2024-04-12
 ### Changed


### PR DESCRIPTION
# Description
In workers loggers have a suffix to them, this would cause the debug flag not to match. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
