### PR TITLE
Fix project upgrade override

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix `reindex` command failed due to `projectUpgradeService` not been initialized 
+- Fix project upgrade to an earlier height, deployments in metadata not been updated, and app restart will lead to reindex.
 
 ## [10.1.2] - 2024-05-03
 ### Fixed


### PR DESCRIPTION
# Description

Fixes #2390

After investigate above issue, found two causes:

1. After project upgrade service rewind, deployments beyond rewind height in metadata is not been cleared. 
2. After rewind, this line set current project to next project https://github.com/subquery/subql/compare/fix-project-upgrade-override?expand=1#diff-b5fe28bf6ce8205180ba79c027cf0a3c422d9827cca075fee1c6172bcb929436L224, 
when processing new block this will never detect project changed https://github.com/subquery/subql/compare/fix-project-upgrade-override?expand=1#diff-b5fe28bf6ce8205180ba79c027cf0a3c422d9827cca075fee1c6172bcb929436L258. Hence new deployment is not update/override in the metadata, after app restart will lead to reindex from project upgrade point again. 
 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
