### PR TITLE
Do not emit duplicate enum imports in codegen

### DIFF
--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -340,7 +340,7 @@ export async function generateModels(projectPath: string, schema: string): Promi
 
     const fields = processFields('entity', className, entity.fields, entity.indexes);
     const importJsonInterfaces = uniq(fields.filter((field) => field.isJsonInterface).map((f) => f.type));
-    const importEnums = fields.filter((field) => field.isEnum).map((f) => f.type);
+    const importEnums = uniq(fields.filter((field) => field.isEnum).map((f) => f.type));
     const indexedFields = fields.filter((field) => field.indexed && !field.isJsonInterface);
     const modelTemplate = {
       props: {


### PR DESCRIPTION
Basically the same issue as https://github.com/subquery/subql/pull/784.

The following schema will lead to duplicate `Bar` enum import to be generated:
```graphql
enum Bar {
  FOO
  BAR
}

type Foo @entity {
  id: ID! 
  a: Bar!
  b: Bar!
}
```