### PR TITLE
Update logger to support errors with cause

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Add missing networks for migration
+- Update common-ethereum to fix issue with ABI validation (#2435)
 
 ## [4.12.0] - 2024-06-05
 ### Changed

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Add missing networks for migration
+- Fixed init command path issue
 - Update common-ethereum to fix issue with ABI validation (#2435)
 
 ## [4.12.0] - 2024-06-05

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "@subql/common-algorand": "^3.4.0",
     "@subql/common-concordium": "^3.6.0",
     "@subql/common-cosmos": "^4.3.0",
-    "@subql/common-ethereum": "^3.6.0",
+    "@subql/common-ethereum": "^3.8.2",
     "@subql/common-flare": "^3.6.0",
     "@subql/common-near": "^3.5.0",
     "@subql/common-stellar": "^3.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "@subql/common-algorand": "^3.4.0",
     "@subql/common-concordium": "^3.6.0",
     "@subql/common-cosmos": "^4.3.0",
-    "@subql/common-ethereum": "^3.8.3-0",
+    "@subql/common-ethereum": "^3.8.3",
     "@subql/common-flare": "^3.6.0",
     "@subql/common-near": "^3.5.0",
     "@subql/common-stellar": "^3.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "@subql/common-algorand": "^3.4.0",
     "@subql/common-concordium": "^3.6.0",
     "@subql/common-cosmos": "^4.3.0",
-    "@subql/common-ethereum": "^3.8.2",
+    "@subql/common-ethereum": "^3.8.3-0",
     "@subql/common-flare": "^3.6.0",
     "@subql/common-near": "^3.5.0",
     "@subql/common-stellar": "^3.5.0",

--- a/packages/cli/src/controller/init-controller.spec.ts
+++ b/packages/cli/src/controller/init-controller.spec.ts
@@ -186,10 +186,6 @@ describe('Cli can create project (mocked)', () => {
     expect(projectPackage.author).toBe(project.author);
 
     const updatedManifest = await fs.promises.readFile(`${projectPath}/${DEFAULT_TS_MANIFEST}`);
-    const extractedValues = extractFromTs(updatedManifest.toString(), {
-      endpoint: ENDPOINT_REG,
-    });
-    expect(extractedValues.endpoint).toStrictEqual(project.endpoint);
     expect(originalManifest).not.toBe(updatedManifest.toString());
     expect(originalPackage).not.toBe(packageData.toString());
   });

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -222,22 +222,13 @@ export async function prepareManifest(projectPath: string, project: ProjectSpecB
   if (isTs) {
     const tsManifest = (await fs.promises.readFile(tsPath, 'utf8')).toString();
     //adding env config for endpoint.
-    const formattedEnvEndpoint = `process.env.ENDPOINT!?.split(',') as string[] | string`;
-    const formatEndpoint = (endpoint: string | string[]) => {
-      if (Array.isArray(endpoint)) {
-        return JSON.stringify(endpoint);
-      }
-      return `"${endpoint}"`;
-    };
-    const endpoint = project.endpoint ? formatEndpoint(project.endpoint) : formattedEnvEndpoint;
-    const endpointOutput = `endpoint: ${endpoint}`;
-    const endpointUpdatedManifestData = findReplace(tsManifest, ENDPOINT_REG, endpointOutput);
-    const specChainId = isProjectSpecV1_0_0(project) ? project.chainId : undefined;
-
-    const chainId = specChainId ? `"${specChainId}"` : `process.env.CHAIN_ID!`;
-    const chainIdOutput = `chainId: ${chainId}`;
-
-    const chainIdUpdatedManifestData = findReplace(endpointUpdatedManifestData, CHAIN_ID_REG, chainIdOutput);
+    const formattedEndpoint = `process.env.ENDPOINT!?.split(',') as string[] | string`;
+    const endpointUpdatedManifestData = findReplace(tsManifest, ENDPOINT_REG, `endpoint: ${formattedEndpoint}`);
+    const chainIdUpdatedManifestData = findReplace(
+      endpointUpdatedManifestData,
+      CHAIN_ID_REG,
+      `chainId: process.env.CHAIN_ID!`
+    );
     manifestData = addDotEnvConfigCode(chainIdUpdatedManifestData);
   } else {
     //load and write manifest(project.yaml)

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -269,7 +269,7 @@ import path from 'path';
 const mode = process.env.NODE_ENV || 'production';
 
 // Load the appropriate .env file
-const dotenvPath = path.resolve(process.cwd(), \`.env\${mode !== 'production' ? \`.$\{mode}\` : ''}\`);
+const dotenvPath = path.resolve(__dirname, \`.env\${mode !== 'production' ? \`.$\{mode}\` : ''}\`);
 dotenv.config({ path: dotenvPath });
 `;
 

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -1,13 +1,10 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import fs from 'fs';
-import path from 'path';
 import {promisify} from 'util';
-import {DEFAULT_MANIFEST, mapToObject, ReaderFactory, toJsonObject} from '@subql/common';
+import {mapToObject, ReaderFactory, toJsonObject} from '@subql/common';
 import {parseSubstrateProjectManifest} from '@subql/common-substrate';
 import rimraf from 'rimraf';
-import Publish from '../commands/publish';
 import {createTestProject} from '../createProject.fixtures';
 import {uploadToIpfs} from './publish-controller';
 

--- a/packages/cli/src/createProject.fixtures.ts
+++ b/packages/cli/src/createProject.fixtures.ts
@@ -54,6 +54,8 @@ export async function createTestProject(): Promise<string> {
 
   // Install dependencies
   childProcess.execSync(`npm i`, {cwd: projectDir});
+  // Set test env to be develop mode, only limit to test
+  process.env.NODE_ENV = 'develop';
 
   await Codegen.run(['-l', projectDir]);
   await Build.run(['-f', projectDir]);

--- a/packages/cli/src/createProject.fixtures.ts
+++ b/packages/cli/src/createProject.fixtures.ts
@@ -5,6 +5,7 @@ import childProcess from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import fetch from 'cross-fetch';
 import Build from './commands/build';
 import Codegen from './commands/codegen';
 import {cloneProjectTemplate, ExampleProjectInterface, prepare} from './controller/init-controller';

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `exitWithError` logging error messages rather than the error (#2435)
 
+### Changed
+- Logging around switching dictionary (#2435)
+
 ## [10.4.1] - 2024-06-06
 ### Fixed
 - Fix various issue in monitor service, file naming issue and export admin service from node-core

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,9 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
-- Admin api add query `/db_size` to check database size and upsert in metadata 
+- Admin api add query `/db_size` to check database size and upsert in metadata
+
+### Fixed
+- `exitWithError` logging error messages rather than the error (#2435)
 
 ## [10.4.1] - 2024-06-06
 ### Fixed

--- a/packages/node-core/src/admin/admin.controller.spec.ts
+++ b/packages/node-core/src/admin/admin.controller.spec.ts
@@ -5,7 +5,7 @@ import {HttpException, HttpStatus} from '@nestjs/common';
 import {EventEmitter2} from '@nestjs/event-emitter';
 import {Test, TestingModule} from '@nestjs/testing';
 import {TargetBlockPayload, RewindPayload, AdminEvent} from '../events';
-import {MonitorService, PoiService, ProofOfIndex} from '../indexer';
+import {MonitorService, PoiService, ProofOfIndex, StoreService} from '../indexer';
 import {AdminController, AdminListener} from './admin.controller';
 import {BlockRangeDto} from './blockRange';
 
@@ -43,6 +43,12 @@ describe('AdminController', () => {
             emitAsync: jest.fn(),
             once: jest.fn(),
             emit: jest.fn(),
+          },
+        },
+        {
+          provide: StoreService,
+          useValue: {
+            syncDbSize: jest.fn(),
           },
         },
       ],

--- a/packages/node-core/src/db/sync-helper.spec.ts
+++ b/packages/node-core/src/db/sync-helper.spec.ts
@@ -270,9 +270,9 @@ describe('sync-helper', () => {
       `DO $$
   BEGIN
     ALTER TABLE "test"."test-table"
-      ADD 
+      ADD
       CONSTRAINT test-table_transfer_id_id_fkey
-      FOREIGN KEY (transfer_id_id) 
+      FOREIGN KEY (transfer_id_id)
       REFERENCES "test"."transfers" (id) ON DELETE NO ACTION ON UPDATE CASCADE;
   EXCEPTION
     WHEN duplicate_object THEN

--- a/packages/node-core/src/indexer/dictionary/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary/dictionary.service.ts
@@ -45,16 +45,22 @@ export abstract class DictionaryService<DS, FB> implements IDictionaryCtrl<DS, F
     }
 
     // Only log on change of dictionary
-    if (previousIndex !== this._currentDictionaryIndex) {
-      if (this._currentDictionaryIndex === undefined) {
-        if (this._dictionaries.length) {
-          logger.warn(`No supported dictionary found`);
+    try {
+      if (previousIndex !== this._currentDictionaryIndex) {
+        if (this._currentDictionaryIndex === undefined) {
+          if (this._dictionaries.length) {
+            logger.warn(`No supported dictionary found`);
+          } else {
+            logger.debug(`No dictionaries available to use`);
+          }
         } else {
-          logger.debug(`No dictionaries available to use`);
+          logger.info(
+            `Changed dictionray: new index: ${this._currentDictionaryIndex}, type: ${this._dictionaries[this._currentDictionaryIndex]?.constructor?.name}`
+          );
         }
-      } else {
-        logger.debug(`Updated: current dictionary Index is ${this._currentDictionaryIndex}`);
       }
+    } catch (e) {
+      // Do nothing, logging shouldn't cause errors
     }
 
     return dict;

--- a/packages/node-core/src/process.ts
+++ b/packages/node-core/src/process.ts
@@ -12,7 +12,7 @@ export function setMonitorService(service: MonitorServiceInterface): void {
 
 export function exitWithError(error: Error | string, logger?: Pino.Logger, code = 1): never {
   const errorMessage = typeof error === 'string' ? error : error.message;
-  logger?.error(errorMessage);
+  logger?.error(error);
   monitorService?.write(`[EXIT ${code}]: ${errorMessage}`);
   process.exit(code);
 }

--- a/packages/node-core/src/process.ts
+++ b/packages/node-core/src/process.ts
@@ -12,7 +12,7 @@ export function setMonitorService(service: MonitorServiceInterface): void {
 
 export function exitWithError(error: Error | string, logger?: Pino.Logger, code = 1): never {
   const errorMessage = typeof error === 'string' ? error : error.message;
-  logger?.error(error);
+  logger?.error(error as any); /* Bad types */
   monitorService?.write(`[EXIT ${code}]: ${errorMessage}`);
   process.exit(code);
 }

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Support logging errors with provided cause and improve colors (#2435)
 
 ## [2.10.0] - 2024-05-08
 ### Changed

--- a/yarn.lock
+++ b/yarn.lock
@@ -6210,7 +6210,7 @@ __metadata:
     "@subql/common-algorand": ^3.4.0
     "@subql/common-concordium": ^3.6.0
     "@subql/common-cosmos": ^4.3.0
-    "@subql/common-ethereum": ^3.8.3-0
+    "@subql/common-ethereum": ^3.8.3
     "@subql/common-flare": ^3.6.0
     "@subql/common-near": ^3.5.0
     "@subql/common-stellar": ^3.5.0
@@ -6319,9 +6319,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/common-ethereum@npm:^3.8.3-0":
-  version: 3.8.3-0
-  resolution: "@subql/common-ethereum@npm:3.8.3-0"
+"@subql/common-ethereum@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "@subql/common-ethereum@npm:3.8.3"
   dependencies:
     "@subql/common": ^3.5.1
     "@subql/types-ethereum": 3.6.1
@@ -6334,7 +6334,7 @@ __metadata:
   peerDependencies:
     class-transformer: "*"
     class-validator: "*"
-  checksum: cefb46766c58fd19cf4b3a8f6f88352b90fdca39b053d4f2542d7cc283d839b31c5873e8028e3602ba70cb931bdebd9ec5944e50f3a63556b0e4c2038791567d
+  checksum: 12a376e9e97a15c7bc1c0317ce1ba9ef7b46caf6d40a720ce669b3d5d3bea744c9d1492e2bf328951bf8a70c2b6ae7f5ba25d9e4dafd56c9f0d5ba4f59d83a42
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3652,7 +3652,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@npm:5.7.2":
+"@ethersproject/providers@npm:5.7.2, @ethersproject/providers@npm:^5.7.2":
   version: 5.7.2
   resolution: "@ethersproject/providers@npm:5.7.2"
   dependencies:
@@ -6210,7 +6210,7 @@ __metadata:
     "@subql/common-algorand": ^3.4.0
     "@subql/common-concordium": ^3.6.0
     "@subql/common-cosmos": ^4.3.0
-    "@subql/common-ethereum": ^3.6.0
+    "@subql/common-ethereum": ^3.8.2
     "@subql/common-flare": ^3.6.0
     "@subql/common-near": ^3.5.0
     "@subql/common-stellar": ^3.5.0
@@ -6319,12 +6319,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/common-ethereum@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "@subql/common-ethereum@npm:3.6.0"
+"@subql/common-ethereum@npm:^3.8.2":
+  version: 3.8.2
+  resolution: "@subql/common-ethereum@npm:3.8.2"
   dependencies:
     "@subql/common": ^3.5.1
-    "@subql/types-ethereum": 3.6.0
+    "@subql/types-ethereum": 3.6.1
     "@typechain/ethers-v5": ^11.1.1
     "@zilliqa-js/crypto": ^3.5.0
     js-yaml: ^4.1.0
@@ -6334,7 +6334,7 @@ __metadata:
   peerDependencies:
     class-transformer: "*"
     class-validator: "*"
-  checksum: 46bb855bbffa53a33af95d2c1427876f873e0ebb4c6c7b4dd4be7279acb050f8f0eb8b9ab9c5e81758139b6dada6bc86b35e96dd1638b447115527cc841258c6
+  checksum: 87ecbe278f0d750c4900bcaafad019faa6292ad9146245fabb2d7544ff26aa507ac6b2877edca9f2c44322ded8e01a6255927de4565e49b4bc20679ef6beb994
   languageName: node
   linkType: hard
 
@@ -6597,13 +6597,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/types-ethereum@npm:3.6.0":
-  version: 3.6.0
-  resolution: "@subql/types-ethereum@npm:3.6.0"
+"@subql/types-ethereum@npm:3.6.1":
+  version: 3.6.1
+  resolution: "@subql/types-ethereum@npm:3.6.1"
   dependencies:
     "@ethersproject/abstract-provider": ^5.6.1
+    "@ethersproject/providers": ^5.7.2
     "@subql/types-core": ^0.7.0
-  checksum: b463e88d6dca985ea0aab68d43188aa01f185493d91d28c8d97c4b3f1232314f7ce905af90114af169c01b18da540afcc60af1aa96a64fa1fc0878fd0efe384e
+  checksum: dbee1ddef99840eac82a5f562e25a69491e4f95017f1f3d1e7396a69112bdac80b885b3d689867e365a87d9bf5aff44db6e2ec349f68437fadff1828333cbc33
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6210,7 +6210,7 @@ __metadata:
     "@subql/common-algorand": ^3.4.0
     "@subql/common-concordium": ^3.6.0
     "@subql/common-cosmos": ^4.3.0
-    "@subql/common-ethereum": ^3.8.2
+    "@subql/common-ethereum": ^3.8.3-0
     "@subql/common-flare": ^3.6.0
     "@subql/common-near": ^3.5.0
     "@subql/common-stellar": ^3.5.0
@@ -6319,9 +6319,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/common-ethereum@npm:^3.8.2":
-  version: 3.8.2
-  resolution: "@subql/common-ethereum@npm:3.8.2"
+"@subql/common-ethereum@npm:^3.8.3-0":
+  version: 3.8.3-0
+  resolution: "@subql/common-ethereum@npm:3.8.3-0"
   dependencies:
     "@subql/common": ^3.5.1
     "@subql/types-ethereum": 3.6.1
@@ -6334,7 +6334,7 @@ __metadata:
   peerDependencies:
     class-transformer: "*"
     class-validator: "*"
-  checksum: 87ecbe278f0d750c4900bcaafad019faa6292ad9146245fabb2d7544ff26aa507ac6b2877edca9f2c44322ded8e01a6255927de4565e49b4bc20679ef6beb994
+  checksum: cefb46766c58fd19cf4b3a8f6f88352b90fdca39b053d4f2542d7cc283d839b31c5873e8028e3602ba70cb931bdebd9ec5944e50f3a63556b0e4c2038791567d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
Now that we're using [Error cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) we need to update the logger to include the possible nested causes. It also adds some colors
<img width="1176" alt="Screenshot 2024-06-10 at 1 57 27 PM" src="https://github.com/subquery/subql/assets/3432810/6f2f310f-91e5-4988-a9ca-af7d56fbe977">

Also fixes, exitWithError logging the message and not the error

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
