### PR TITLE
Fix testing showing the same date if unmatching dates are within 1s

### DIFF
--- a/packages/node-core/src/indexer/test.runner.ts
+++ b/packages/node-core/src/indexer/test.runner.ts
@@ -102,8 +102,15 @@ export class TestRunner<A, SA, B, DS> {
             const actualAttr = (actualEntity as Record<string, any>)[attr] ?? null;
 
             if (!isEqual(expectedAttr, actualAttr)) {
+              // Converts dates into a format so that ms is visible
+              const fmtValue = (value: any) => {
+                if (value instanceof Date) {
+                  return value.toISOString();
+                }
+                return value;
+              };
               failedAttributes.push(
-                `\t\tattribute: "${attr}":\n\t\t\texpected: "${expectedAttr}"\n\t\t\tactual:   "${actualAttr}"\n`
+                `\t\tattribute: "${attr}":\n\t\t\texpected: "${fmtValue(expectedAttr)}"\n\t\t\tactual:   "${fmtValue(actualAttr)}"\n`
               );
             }
           });


### PR DESCRIPTION
# Description
Fix logging the same date when they dont match

Fixes https://github.com/subquery/subql/issues/2294

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
