### PR TITLE
Skip dictionary if within batch size of latest height

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Testing framework logging the same date if they were within 1s (#2453)
 
 ### Fixed
-- Handle edge case when last processed height is same as chain target height, app will wait for new block rather than exit. 
+- Handle edge case when last processed height is same as chain target height, app will wait for new block rather than exit.
+
+### Changed
+- Skip using the dictionary if processing data within batch size of latest height (#2454)
 
 ## [10.5.1] - 2024-06-12
 ### Changed

--- a/packages/node-core/src/indexer/fetch.service.spec.ts
+++ b/packages/node-core/src/indexer/fetch.service.spec.ts
@@ -655,8 +655,8 @@ describe('Fetch Service', () => {
   });
 
   it('throws if the start block is greater than the chain latest height', async () => {
-    await expect(() => fetchService.init(1001)).rejects.toThrow(
-      `The startBlock of dataSources in your project manifest (1001) is higher than the current chain height (1000). Please adjust your startBlock to be less that the current chain height.`
+    await expect(() => fetchService.init(1002)).rejects.toThrow(
+      `The startBlock of dataSources in your project manifest (1002) is higher than the current chain height (1000). Please adjust your startBlock to be less that the current chain height.`
     );
   });
 
@@ -676,12 +676,27 @@ describe('Fetch Service', () => {
     (fetchService as any).dictionaryService.scopedDictionaryEntries = () => {
       return undefined;
     };
+    fetchService.bestHeight = 500;
     const dictionarySpy = jest.spyOn((fetchService as any).dictionaryService, 'scopedDictionaryEntries');
     await fetchService.init(10);
     expect(dictionarySpy).toHaveBeenCalledTimes(1);
     expect(spyOnEnqueueSequential).toHaveBeenCalledTimes(1);
 
     expect(enqueueBlocksSpy).toHaveBeenLastCalledWith([10, 11, 12, 13, 14, 15, 16, 17, 18, 19], 19);
+  });
+
+  it(`doesn't use dictionary if processing near latest height`, async () => {
+    enableDictionary();
+    (fetchService as any).dictionaryService.scopedDictionaryEntries = () => {
+      return undefined;
+    };
+    fetchService.bestHeight = 500;
+    const dictionarySpy = jest.spyOn((fetchService as any).dictionaryService, 'scopedDictionaryEntries');
+    await fetchService.init(490);
+    expect(dictionarySpy).toHaveBeenCalledTimes(0);
+    expect(spyOnEnqueueSequential).toHaveBeenCalledTimes(1);
+
+    expect(enqueueBlocksSpy).toHaveBeenLastCalledWith([490, 491, 492, 493, 494, 495, 496, 497, 498, 499], 499);
   });
 
   it('fetch init when last processed height is same as', async () => {

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -224,7 +224,10 @@ export abstract class BaseFetchService<DS extends BaseDataSource, B extends IBlo
         continue;
       }
 
-      if (startBlockHeight < this.latestFinalizedHeight) {
+      // This could be latestBestHeight, dictionary should never include finalized blocks
+      // TODO add buffer so dictionary not used when project synced
+      if (startBlockHeight < this.latestBestHeight - scaledBatchSize) {
+        // if (startBlockHeight < this.latestFinalizedHeight) {
         try {
           const dictionary = await this.dictionaryService.scopedDictionaryEntries(
             startBlockHeight,


### PR DESCRIPTION
# Description
Skips using the dictionary if project nearly fully indexed and within a batch size of the latest height

Fixes https://github.com/subquery/subql/issues/1963

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
