### PR TITLE
Return more useful errors when graphql schema invalid

### DIFF
--- a/packages/cli/test/schemaTest/badschema.graphql
+++ b/packages/cli/test/schemaTest/badschema.graphql
@@ -1,3 +1,4 @@
 type badEntity @entity {
-  id: BigDecimal
+  id: ID!
+  value: BigDecimal
 }

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Better error messages for invalid graphql schemas (#2458)
 
 ### Added
 - enable ts strict mode

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -410,4 +410,48 @@ describe('utils that handle schema.graphql', () => {
     const schema = buildSchemaFromDocumentNode(graphqlSchema);
     expect(() => getAllEntitiesRelations(schema)).toThrow(`fullText directive fields only supports String types`);
   });
+
+  it('will throw if entity missing id field', () => {
+    const graphqlSchema = gql`
+      type StarterEntity @entity {
+        field1: Int!
+        field2: String #field2 is an optional field
+        field3: String
+      }
+    `;
+
+    const schema = buildSchemaFromDocumentNode(graphqlSchema);
+    expect(() => getAllEntitiesRelations(schema)).toThrow(`Entity "StarterEntity" is missing required id field.`);
+  });
+
+  it('will throw if entity id field isnt id', () => {
+    const graphqlSchema = gql`
+      type StarterEntity @entity {
+        id: Int!
+        field1: Int!
+        field2: String #field2 is an optional field
+        field3: String
+      }
+    `;
+
+    const schema = buildSchemaFromDocumentNode(graphqlSchema);
+    expect(() => getAllEntitiesRelations(schema)).toThrow(`Entity "StarterEntity" type must be ID, received Int`);
+  });
+
+  it('will throw if 1 to Many relationship is missing directive', () => {
+    const graphqlSchema = gql`
+      type Fruit @entity {
+        id: ID!
+        bananas: [Banana!]!
+      }
+      type Banana @entity {
+        id: ID!
+      }
+    `;
+
+    const schema = buildSchemaFromDocumentNode(graphqlSchema);
+    expect(() => getAllEntitiesRelations(schema)).toThrow(
+      `Field "bananas" on entity "Fruit" is missing "derivedFrom" directive. Unable to construct database.`
+    );
+  });
 });

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -250,6 +250,7 @@ describe('utils that handle schema.graphql', () => {
       }
       type Account @entity {
         field6: [MyJson]!
+        id: ID!
       }
     `;
     const schema = buildSchemaFromDocumentNode(graphqlSchema);
@@ -282,6 +283,7 @@ describe('utils that handle schema.graphql', () => {
         field1: MyJson!
         field2: MyJson2!
         field3: MyJson3!
+        id: ID!
       }
     `;
     const schema = buildSchemaFromDocumentNode(graphqlSchema);

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -215,7 +215,7 @@ describe('utils that handle schema.graphql', () => {
       type Fruit @entity {
         id: ID!
         apple: Apple
-        banana: [Banana] @index(unique: true)
+        banana: [Banana] @derivedFrom(field: "fruit")
       }
       type Fruit2 @entity {
         id: ID!
@@ -226,6 +226,7 @@ describe('utils that handle schema.graphql', () => {
       }
       type Banana @entity {
         id: ID!
+        fruit: Fruit
       }
     `;
     const schema = buildSchemaFromDocumentNode(graphqlSchema);
@@ -233,7 +234,7 @@ describe('utils that handle schema.graphql', () => {
     expect(entities.models?.[0].indexes[0].fields).toEqual(['appleId']);
     expect(entities.models?.[0].indexes[0].using).toEqual('hash');
     expect(entities.models?.[0].indexes[0].unique).toBe(false);
-    expect(entities.models?.[0].indexes[1].unique).toBe(true);
+
     expect(entities.models?.[1].indexes[0].fields).toEqual(['appleId']);
     expect(entities.models?.[1].indexes[0].unique).toBe(false);
   });
@@ -453,7 +454,7 @@ describe('utils that handle schema.graphql', () => {
 
     const schema = buildSchemaFromDocumentNode(graphqlSchema);
     expect(() => getAllEntitiesRelations(schema)).toThrow(
-      `Field "bananas" on entity "Fruit" is missing "derivedFrom" directive. Unable to construct database.`
+      `Field "bananas" on entity "Fruit" is missing "derivedFrom" directive. Please also make sure "Banana" has a field of type "Fruit".`
     );
   });
 });


### PR DESCRIPTION
# Description
Improve errors for graphql schema parsing

- If id field is missing or wrong type it will now throw an error
- Throws an error if `derrivedFrom` directive missing from 1-M relationship

Fixes https://github.com/subquery/subql/issues/1475

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
