### PR TITLE
Fix parseFunction type missing asImpl and its deployment

### DIFF
--- a/packages/common/src/project/versioned/base.ts
+++ b/packages/common/src/project/versioned/base.ts
@@ -1,7 +1,13 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {FileReference, ParentProject, Processor} from '@subql/types-core';
+import {
+  BaseDeploymentV1_0_0Interface,
+  FileReference,
+  ParentProject,
+  Processor,
+  ProjectManifestBaseImplInterface,
+} from '@subql/types-core';
 import {plainToInstance, Type} from 'class-transformer';
 import {
   Allow,
@@ -18,7 +24,9 @@ import yaml from 'js-yaml';
 import {IsEndBlockGreater, toJsonObject} from '../utils';
 import {ParentProjectModel} from './v1_0_0/models';
 
-export abstract class ProjectManifestBaseImpl<D extends BaseDeploymentV1_0_0> {
+export abstract class ProjectManifestBaseImpl<D extends BaseDeploymentV1_0_0>
+  implements ProjectManifestBaseImplInterface<D>
+{
   @Allow()
   definitions!: object;
   @IsOptional()
@@ -66,7 +74,7 @@ export class ProcessorImpl<O = any> extends FileType implements Processor<O> {
   options?: O;
 }
 
-export class BaseDeploymentV1_0_0 {
+export class BaseDeploymentV1_0_0 implements BaseDeploymentV1_0_0Interface {
   @Equals('1.0.0')
   @IsString()
   specVersion!: string;

--- a/packages/types-core/src/project/modulars/types.ts
+++ b/packages/types-core/src/project/modulars/types.ts
@@ -1,14 +1,17 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {BaseCustomDataSource, BaseDataSource, IProjectManifest} from '../index';
+import {BaseCustomDataSource, BaseDataSource, IProjectManifest, ProjectManifestBaseImplInterface} from '../index';
 
 export interface INetworkCommonModule<
   D extends BaseCustomDataSource | BaseDataSource = BaseDataSource,
   RDS extends D = D,
   CDS extends D = D,
 > {
-  parseProjectManifest(raw: unknown): IProjectManifest<D>;
+  parseProjectManifest(raw: unknown): IProjectManifest<D> & {
+    // other missing interfaces ProjectManifestVersioned
+    asImpl: ProjectManifestBaseImplInterface;
+  };
   isRuntimeDs(ds: D): ds is RDS;
   isCustomDs(ds: D): ds is CDS;
 }

--- a/packages/types-core/src/project/versioned/base.ts
+++ b/packages/types-core/src/project/versioned/base.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import {ParentProject} from '../../project';
 import {FileReference, Processor} from '../types';
 
 export interface BaseDataSource<H extends BaseHandler = BaseHandler, M extends BaseMapping<H> = BaseMapping<H>> {
@@ -80,3 +81,16 @@ export interface TemplateBase {
 
 export type BaseTemplateDataSource<DS extends BaseDataSource = BaseDataSource> = Omit<DS, 'startBlock' | 'endBlock'> &
   TemplateBase;
+
+export interface ProjectManifestBaseImplInterface<
+  D extends BaseDeploymentV1_0_0Interface = BaseDeploymentV1_0_0Interface,
+> {
+  deployment: D;
+}
+
+export interface BaseDeploymentV1_0_0Interface {
+  specVersion: string;
+  schema: FileReference;
+  parent?: ParentProject;
+  toYaml(): string;
+}


### PR DESCRIPTION
# Description
Fix cli publish `parseFunction` missing generic method `asImpl` and its `deployment`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
