### PR TITLE
Fix schema migration count being incremented on every restart

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
-- Enable ts strict model 
+- Enable ts strict model
+
+### Fixed
+- Incrementing the schemaMigration count on every start (#2476)
+
 ## [10.10.0] - 2024-07-01
 ### Changed
 - Bump version with `@subql/common`

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
@@ -43,7 +43,7 @@ async function setup(
   await sequelize.createSchema(`"${schemaName}"`, {});
 
   await storeService.initCoreTables(schemaName);
-  await initDbSchema(project, schemaName, storeService);
+  await initDbSchema(schemaName, storeService);
 
   return new SchemaMigrationService(
     sequelize,

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.ts
@@ -181,12 +181,10 @@ export class SchemaMigrationService {
         migrationAction.dropEnum(enumValue);
       }
 
-      const results = await migrationAction.run(transaction);
+      const modelChanges = await migrationAction.run(transaction);
 
       // Update any relevant application state so the right models are used
-      if (results?.length) {
-        this.storeService.storeCache.updateModels(results);
-      }
+      this.storeService.storeCache.updateModels(modelChanges);
       await this.storeService.updateModels(this.dbSchema, getAllEntitiesRelations(nextSchema));
 
       await this.flushCache();

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -11,15 +11,7 @@ import {IProjectUpgradeService, NodeConfig} from '../configure';
 import {IndexerEvent} from '../events';
 import {getLogger} from '../logger';
 import {exitWithError, monitorWrite} from '../process';
-import {
-  getExistingProjectSchema,
-  getStartHeight,
-  hasValue,
-  initDbSchema,
-  initHotSchemaReload,
-  mainThreadOnly,
-  reindex,
-} from '../utils';
+import {getExistingProjectSchema, getStartHeight, hasValue, initDbSchema, mainThreadOnly, reindex} from '../utils';
 import {BlockHeightMap} from '../utils/blockHeightMap';
 import {BaseDsProcessorService} from './ds-processor.service';
 import {DynamicDsService} from './dynamic-ds.service';
@@ -41,7 +33,7 @@ class NotInitError extends Error {
 export abstract class BaseProjectService<
   API extends IApi,
   DS extends BaseDataSource,
-  UnfinalizedBlocksService extends IUnfinalizedBlocksService<any> = IUnfinalizedBlocksService<any>
+  UnfinalizedBlocksService extends IUnfinalizedBlocksService<any> = IUnfinalizedBlocksService<any>,
 > implements IProjectService<DS>
 {
   private _schema?: string;
@@ -129,7 +121,6 @@ export abstract class BaseProjectService<
 
       // These need to be init before upgrade and unfinalized services because they may cause rewinds.
       await this.initDbSchema();
-      await this.initHotSchemaReload();
 
       if (this.nodeConfig.proofOfIndex) {
         // Prepare for poi migration and creation
@@ -188,12 +179,8 @@ export abstract class BaseProjectService<
     return schema;
   }
 
-  private async initHotSchemaReload(): Promise<void> {
-    await initHotSchemaReload(this.schema, this.storeService);
-  }
-
   private async initDbSchema(): Promise<void> {
-    await initDbSchema(this.project, this.schema, this.storeService);
+    await initDbSchema(this.schema, this.storeService);
   }
 
   private async ensureMetadata(): Promise<void> {

--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -35,7 +35,11 @@ export class StoreCacheService extends BaseCacheService {
   private _lastFlushTs: Date;
   private exports: Exporter[] = [];
 
-  constructor(private sequelize: Sequelize, private config: NodeConfig, protected eventEmitter: EventEmitter2) {
+  constructor(
+    private sequelize: Sequelize,
+    private config: NodeConfig,
+    protected eventEmitter: EventEmitter2
+  ) {
     super('StoreCache');
     this.storeCacheThreshold = config.storeCacheThreshold;
     this.cacheUpperLimit = config.storeCacheUpperLimit;
@@ -96,11 +100,14 @@ export class StoreCacheService extends BaseCacheService {
   async flushExportStores(): Promise<void> {
     await Promise.all(this.exports.map((f) => f.shutdown()));
   }
-  updateModels(models: ModelStatic<any>[]): void {
-    models.forEach((m) => {
+
+  updateModels({modifiedModels, removedModels}: {modifiedModels: ModelStatic<any>[]; removedModels: string[]}): void {
+    modifiedModels.forEach((m) => {
       this.cachedModels[m.name] = this.createModel(m.name);
     });
+    removedModels.forEach((r) => delete this.cachedModels[r]);
   }
+
   get metadata(): CacheMetadataModel {
     const entity = '_metadata';
     if (!this.cachedModels[entity]) {

--- a/packages/node-core/src/subcommands/reindex.service.ts
+++ b/packages/node-core/src/subcommands/reindex.service.ts
@@ -49,7 +49,7 @@ export class ReindexService<P extends ISubqueryProject, DS extends BaseDataSourc
     if (this.nodeConfig.proofOfIndex) {
       await this.poiService.init(schema);
     }
-    await initDbSchema(this.project, schema, this.storeService);
+    await initDbSchema(schema, this.storeService);
 
     this._metadataRepo = this.storeService.storeCache.metadata;
 
@@ -87,10 +87,6 @@ export class ReindexService<P extends ISubqueryProject, DS extends BaseDataSourc
 
   private async getLastProcessedHeight(): Promise<number | undefined> {
     return this.metadataRepo.find('lastProcessedHeight');
-  }
-
-  private async getSyncedPoiHeight(): Promise<number | undefined> {
-    return this.metadataRepo.find('latestSyncedPoiHeight');
   }
 
   private getStartBlockFromDataSources(): number {

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -223,17 +223,8 @@ export async function loadDataSourceScript(reader: Reader, file?: string): Promi
   return entryScript;
 }
 
-export async function initDbSchema(
-  project: ISubqueryProject,
-  schema: string,
-  storeService: StoreService
-): Promise<void> {
-  const modelsRelation = getAllEntitiesRelations(project.schema);
-  await storeService.init(modelsRelation, schema);
-}
-
-export async function initHotSchemaReload(schema: string, storeService: StoreService): Promise<void> {
-  await storeService.initHotSchemaReloadQueries(schema);
+export async function initDbSchema(schema: string, storeService: StoreService): Promise<void> {
+  await storeService.init(schema);
 }
 
 type IsRuntimeDs<DS> = (ds: DS) => ds is DS;

--- a/packages/node/src/configure/SchemaMigration.service.test.ts
+++ b/packages/node/src/configure/SchemaMigration.service.test.ts
@@ -148,6 +148,10 @@ describe('SchemaMigration integration tests', () => {
 
     const cachedModels = (storeCache as any).cachedModels;
 
-    expect(Object.keys(cachedModels)).toStrictEqual(['_metadata', 'Account']);
+    expect(Object.keys(cachedModels)).toStrictEqual([
+      '_metadata',
+      'Transfer',
+      'Account',
+    ]);
   });
 });

--- a/packages/node/src/configure/SchemaMigration.service.test.ts
+++ b/packages/node/src/configure/SchemaMigration.service.test.ts
@@ -39,6 +39,7 @@ describe('SchemaMigration integration tests', () => {
     await sequelize.dropSchema(schemaName, { logging: false });
     await app?.close();
   });
+
   afterAll(async () => {
     await promisify(rimraf)(tempDir);
     await sequelize?.close();
@@ -71,6 +72,7 @@ describe('SchemaMigration integration tests', () => {
     expect(tableNames).toContain('test_index_ones');
     expect(tableNames).toContain('transfers');
   });
+
   it('On entity drop isRewindable should be false', async () => {
     const cid = 'QmZcEv4UWrCkkiHUmtz7q5AAXdu82aAdkxH8X8BQK3TjCy';
     schemaName = 'test-migrations-7';
@@ -88,6 +90,7 @@ describe('SchemaMigration integration tests', () => {
 
     expect(isRewindable).toBe(false);
   });
+
   it('Should update sequelize Models in cachedModels', async () => {
     const cid = 'QmWKRpKXgmPArnAGRNaK2wTiWNuosUtxBcB581mcth8B82';
     schemaName = 'test-migrations-8';
@@ -109,8 +112,9 @@ describe('SchemaMigration integration tests', () => {
 
     expect(Object.keys(cachedModels)).toStrictEqual([
       '_metadata',
-      'AddedEntity',
+      'Transfer',
       'Account',
+      'AddedEntity',
     ]);
     expect(
       Object.keys((cachedModels.Account.model as any).rawAttributes).includes(
@@ -123,8 +127,9 @@ describe('SchemaMigration integration tests', () => {
       ),
     ).toBe(false);
 
-    expect(cacheSpy).toHaveBeenCalledTimes(1);
+    expect(cacheSpy).toHaveBeenCalledTimes(2);
   });
+
   it('Ensure no duplication in cacheModels', async () => {
     const cid = 'QmSmQvbssnCCH2fdi2VyqCQsjKti7tKsJMtxMUmZKUjhq7';
     schemaName = 'test-migrations-9';


### PR DESCRIPTION
# Description
On every restart of the node it would increment the schema migration count, even if there were no changes. It will now not do that if the project is from IPFS and the project has not changes. 

There are various other minor changes to simplify code. 

A further improvement to this would not be syncing the current gql schema with the current db schema every start.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
