### PR TITLE
Fix admin api db size

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix issue admin api can not get `dbSize` due to it not been set in _metadata table
+
 ## [10.10.1] - 2024-07-09
 ### Added
 - Enable ts strict setting

--- a/packages/node-core/src/db/sync-helper.test.ts
+++ b/packages/node-core/src/db/sync-helper.test.ts
@@ -1,0 +1,48 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {INestApplication} from '@nestjs/common';
+import {Test} from '@nestjs/testing';
+import {getDbSizeAndUpdateMetadata} from '@subql/node-core';
+import {Sequelize} from '@subql/x-sequelize';
+import {NodeConfig} from '../configure/NodeConfig';
+import {DbModule} from './db.module';
+
+const nodeConfig = new NodeConfig({subquery: 'packages/node-core/test/v1.0.0', subqueryName: 'test'});
+
+describe('sync helper test', () => {
+  let app: INestApplication;
+
+  afterEach(async () => {
+    return app?.close();
+  });
+
+  it('can check project db size', async () => {
+    const module = await Test.createTestingModule({
+      imports: [DbModule.forRootWithConfig(nodeConfig)],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+    const sequelize = app.get(Sequelize);
+
+    const schema = 'admin-test';
+
+    await sequelize.createSchema(schema, {});
+
+    // mock create metadata table
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS "${schema}"._metadata (
+        key VARCHAR(255) NOT NULL PRIMARY KEY,
+        value JSONB,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL
+    )`);
+
+    const dbSize = await getDbSizeAndUpdateMetadata(sequelize, schema);
+    expect(dbSize).not.toBeUndefined();
+
+    await sequelize.dropSchema(schema, {});
+    await sequelize.close();
+  }, 50000);
+});

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Bump with `@subql/node-core`, fix admin api `dbSize` issue
+
 ## [4.7.1] - 2024-07-09
 ### Added
 - Enable ts strict model


### PR DESCRIPTION
# Description

Fixed issue for admin api, when dbSize not been set in the metadata, fetch and update dbSize will return undefined issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
