### PR TITLE
Set an interval for flushing cache

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Create interval for flushing the cache, this is to support chains that only produce blocks with new transactions (#2485)
 
 ## [10.10.2] - 2024-07-10
 ### Fixed

--- a/packages/node-core/src/configure/ProjectUpgrade.service.spec.ts
+++ b/packages/node-core/src/configure/ProjectUpgrade.service.spec.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import {SchedulerRegistry} from '@nestjs/schedule';
 import {Sequelize} from '@subql/x-sequelize';
 import {CacheMetadataModel, ISubqueryProject, StoreCacheService, StoreService} from '../indexer';
 import {NodeConfig} from './NodeConfig';
@@ -291,7 +292,7 @@ describe('Project Upgrades', () => {
     let storeCache: StoreCacheService;
 
     beforeEach(async () => {
-      storeCache = new StoreCacheService({} as any, {} as any, {} as any);
+      storeCache = new StoreCacheService({} as any, {} as any, {} as any, new SchedulerRegistry());
       // eslint-disable-next-line @typescript-eslint/dot-notation
       (storeCache as any).cachedModels['_metadata'] = mockMetadata();
 

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.test.ts
@@ -4,6 +4,7 @@
 import {readFileSync} from 'fs';
 import * as path from 'path';
 import {EventEmitter2} from '@nestjs/event-emitter';
+import {SchedulerRegistry} from '@nestjs/schedule';
 import {buildSchemaFromString} from '@subql/utils';
 import {IndexesOptions, QueryTypes, Sequelize} from '@subql/x-sequelize';
 import {GraphQLSchema} from 'graphql';
@@ -36,7 +37,7 @@ async function setup(
     },
   } as unknown as ISubqueryProject;
 
-  const storeCache = new StoreCacheService(sequelize, config, new EventEmitter2());
+  const storeCache = new StoreCacheService(sequelize, config, new EventEmitter2(), new SchedulerRegistry());
 
   const storeService = new StoreService(sequelize, config, storeCache, project);
 

--- a/packages/node-core/src/indexer/poi/poi.service.spec.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {EventEmitter2} from '@nestjs/event-emitter';
+import {SchedulerRegistry} from '@nestjs/schedule';
 import {Test, TestingModule} from '@nestjs/testing';
 import {delay} from '@subql/common';
 import {Sequelize, Transaction} from '@subql/x-sequelize';
@@ -60,7 +61,7 @@ describe('PoiService', () => {
     } as unknown as NodeConfig;
 
     const sequelize = new Sequelize();
-    storeCache = new StoreCacheService(sequelize, nodeConfig, new EventEmitter2());
+    storeCache = new StoreCacheService(sequelize, nodeConfig, new EventEmitter2(), new SchedulerRegistry());
 
     storeCache.init(true, true, {} as any, {} as any);
     (storeCache as any).cachedModels._metadata = {

--- a/packages/node-core/src/indexer/storeCache/baseCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/baseCache.service.ts
@@ -13,6 +13,12 @@ export abstract class BaseCacheService implements BeforeApplicationShutdown {
   private queuedFlush?: Promise<void>;
   protected logger: Pino.Logger;
 
+  abstract _flushCache(): Promise<void>;
+  abstract _resetCache(): Promise<void> | void;
+  abstract isFlushable(): boolean;
+  abstract get flushableRecords(): number;
+  abstract flushExportStores(): Promise<void>;
+
   protected constructor(loggerName: string) {
     this.logger = getLogger(loggerName);
   }
@@ -42,14 +48,10 @@ export abstract class BaseCacheService implements BeforeApplicationShutdown {
 
     return this.queuedFlush;
   }
+
   async resetCache(): Promise<void> {
     await this._resetCache();
   }
-  abstract _flushCache(): Promise<void>;
-  abstract _resetCache(): Promise<void> | void;
-  abstract isFlushable(): boolean;
-  abstract get flushableRecords(): number;
-  abstract flushExportStores(): Promise<void>;
 
   async beforeApplicationShutdown(): Promise<void> {
     await timeout(this.flushCache(true), 60, 'Before shutdown flush cache timeout');

--- a/packages/node-core/src/indexer/storeCache/storeCache.service.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {EventEmitter2} from '@nestjs/event-emitter';
+import {SchedulerRegistry} from '@nestjs/schedule';
 import {Sequelize} from '@subql/x-sequelize';
 import {NodeConfig} from '../../configure';
 import {delay} from '../../utils';
@@ -61,7 +62,7 @@ describe('Store Cache Service historical', () => {
   const nodeConfig: NodeConfig = {} as any;
 
   beforeEach(() => {
-    storeService = new StoreCacheService(sequelize, nodeConfig, eventEmitter);
+    storeService = new StoreCacheService(sequelize, nodeConfig, eventEmitter, new SchedulerRegistry());
   });
 
   it('could init store cache service and init cache for models', () => {
@@ -147,7 +148,7 @@ describe('Store Cache flush with order', () => {
   const nodeConfig: NodeConfig = {} as any;
 
   beforeEach(() => {
-    storeService = new StoreCacheService(sequelize, nodeConfig, eventEmitter);
+    storeService = new StoreCacheService(sequelize, nodeConfig, eventEmitter, new SchedulerRegistry());
     storeService.init(false, true, {} as any, undefined);
   });
 
@@ -184,7 +185,7 @@ describe('Store Cache flush with non-historical', () => {
   const nodeConfig: NodeConfig = {disableHistorical: true} as any;
 
   beforeEach(() => {
-    storeService = new StoreCacheService(sequelize, nodeConfig, eventEmitter);
+    storeService = new StoreCacheService(sequelize, nodeConfig, eventEmitter, new SchedulerRegistry());
     storeService.init(false, false, {} as any, undefined);
   });
 
@@ -242,7 +243,7 @@ describe('Store cache upper threshold', () => {
   } as NodeConfig;
 
   beforeEach(() => {
-    storeService = new StoreCacheService(sequelize, nodeConfig, eventEmitter);
+    storeService = new StoreCacheService(sequelize, nodeConfig, eventEmitter, new SchedulerRegistry());
     storeService.init(false, false, {findByPk: () => Promise.resolve({toJSON: () => 1})} as any, undefined);
   });
 

--- a/packages/node-core/src/indexer/unfinalizedBlocks.service.spec.ts
+++ b/packages/node-core/src/indexer/unfinalizedBlocks.service.spec.ts
@@ -3,6 +3,7 @@
 
 // import { Header } from '@polkadot/types/interfaces';
 import {EventEmitter2} from '@nestjs/event-emitter';
+import {SchedulerRegistry} from '@nestjs/schedule';
 import {Header, IBlock} from '../indexer';
 import {StoreCacheService, CacheMetadataModel} from './storeCache';
 import {
@@ -241,7 +242,12 @@ describe('UnfinalizedBlocksService', () => {
   });
 
   it('can rewind any unfinalized blocks when restarted and unfinalized blocks is disabled', async () => {
-    const storeCache = new StoreCacheService(null as any, {storeCacheThreshold: 300} as any, new EventEmitter2());
+    const storeCache = new StoreCacheService(
+      null as any,
+      {storeCacheThreshold: 300} as any,
+      new EventEmitter2(),
+      new SchedulerRegistry()
+    );
 
     storeCache.init(true, false, {} as any, undefined);
 

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import {
   SubstrateDatasourceKind,
   SubstrateHandlerKind,
@@ -165,7 +166,12 @@ function createIndexerManager(
   const dsProcessorService = new DsProcessorService(project, nodeConfig);
   const dynamicDsService = new DynamicDsService(dsProcessorService, project);
 
-  const storeCache = new StoreCacheService(sequelize, nodeConfig, eventEmitter);
+  const storeCache = new StoreCacheService(
+    sequelize,
+    nodeConfig,
+    eventEmitter,
+    new SchedulerRegistry(),
+  );
   const storeService = new StoreService(
     sequelize,
     nodeConfig,


### PR DESCRIPTION
# Description
Sets up an interval that matches the `storeFlushInterval` so that the store cache will flush data when there are no new blocks to index. This happens when chains only produce blocks when there are new transactions (e.g Avalanche and its subnets)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
