### PR TITLE
[SKIPCI] fix docker build 20240716

### DIFF
--- a/packages/node/Dockerfile
+++ b/packages/node/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 FROM node:18-alpine as builder
-ENV TZ utc
+ENV TZ ='UTC'
 # Set working directory
 WORKDIR /app
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
       "@subql/types/*": ["packages/types/src/*"],
       "@subql/testing": ["packages/testing/src"],
       "@subql/testing/*": ["packages/testing/src/*"]
-    },
+    }
   },
   "references": [
     {"path": "packages/cli"},


### PR DESCRIPTION
# Description

Fix ci docker build failed due to extra `,` in ts config file. 
`jq: parse error: Expected another key-value pair at line 38, column 3`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
