### PR TITLE
Improve error if project start height is moved to after indexed point

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Provide a better error message when user increases project start height beyond indexed height (#2492)
 
 ## [11.0.0] - 2024-07-11
 ### Changed

--- a/packages/node-core/src/utils/blockHeightMap.ts
+++ b/packages/node-core/src/utils/blockHeightMap.ts
@@ -3,6 +3,12 @@
 
 type GetRange<T> = {value: T; startHeight: number; endHeight?: number};
 
+export class EntryNotFoundError extends Error {
+  constructor(height: number) {
+    super(`Entry not found at height ${height}`);
+  }
+}
+
 export class BlockHeightMap<T> {
   #map: Map<number, T>;
 
@@ -19,7 +25,7 @@ export class BlockHeightMap<T> {
     const details = this.getDetails(height);
 
     if (details === undefined) {
-      throw new Error(`Value at height ${height} was undefined`);
+      throw new EntryNotFoundError(height);
     }
 
     return details.value;

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update error log format to specify the name of the error instance where possible (#2492)
 
 ## [2.12.1] - 2024-07-09
 ### Changed

--- a/packages/utils/src/logger/logger.ts
+++ b/packages/utils/src/logger/logger.ts
@@ -22,7 +22,8 @@ export interface LoggerOption {
 
 function formatErrorString(err: unknown, stack = false): string {
   if (err instanceof Error) {
-    let formattedError = `${ctx.red('Error:')} ${ctx.yellow(err.message)}`;
+    const t = err.constructor.name ?? 'Error';
+    let formattedError = `${ctx.red(`${t}:`)} ${ctx.yellow(err.message)}`;
 
     if (stack) {
       formattedError += `\n${ctx.red('Stack:')} ${ctx.gray(err.stack)}`;


### PR DESCRIPTION
# Description
If a user is developing their project and they increase the start height beyond the current indexed height it will throw the following error `Value at height 10954 was undefined`. This is not useful to users and they cannot resolve it.

The error is now updated to: 
```
Error: Unable to find project for height 10954. If the project start height is increased it will not jump to that block. Please either reindex or specify blocks to bypass.
Cause: EntryNotFoundError: Entry not found at height 10954
```

Another change is also when formatting errors it will try to resolve the error type.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
