### PR TITLE
Move reusable SubqueryProject code to node core

### DIFF
--- a/packages/common-substrate/src/project/utils.ts
+++ b/packages/common-substrate/src/project/utils.ts
@@ -38,6 +38,8 @@ export function isCustomDs<F extends SubstrateMapping<SubstrateCustomHandler>>(
   return ds.kind !== SubstrateDatasourceKind.Runtime && !!(ds as SubstrateCustomDatasource<string, F>).processor;
 }
 
-export function isRuntimeDs(ds: SubstrateDatasource): ds is SubstrateRuntimeDatasource {
+export function isRuntimeDs(
+  ds: SubstrateDatasource | BaseTemplateDataSource<SubstrateDatasource>
+): ds is SubstrateRuntimeDatasource {
   return ds.kind === SubstrateDatasourceKind.Runtime;
 }

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,12 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Changed
 - Breaking change: Require indexing environment timezone set to UTC, avoid inconsistent result from cache and database (#2495)
+
 ### Fixed
 - Fix handle bigint type in jsonb array, both get and set method will generate consistent result (#2495)
 
+### Added
+- SubqueryProject base from extracing common code (#2496)
 
 ## [12.0.0] - 2024-07-22
 ### Changed

--- a/packages/node-core/src/configure/SubqueryProject.ts
+++ b/packages/node-core/src/configure/SubqueryProject.ts
@@ -1,0 +1,145 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import assert from 'assert';
+import {CommonProjectManifestV1_0_0Impl, validateSemver} from '@subql/common';
+import {
+  BaseCustomDataSource,
+  BaseDataSource,
+  BaseTemplateDataSource,
+  IProjectNetworkConfig,
+  ParentProject,
+  Reader,
+  RunnerSpecs,
+} from '@subql/types-core';
+import {buildSchemaFromString} from '@subql/utils';
+import {GraphQLSchema} from 'graphql';
+import {ISubqueryProject} from '../indexer';
+import {
+  insertBlockFiltersCronSchedules,
+  IsCustomDs,
+  IsRuntimeDs,
+  loadProjectTemplates,
+  updateDataSourcesV1_0_0,
+} from '../utils';
+
+class NotSupportedError extends Error {
+  constructor(expected: string, received: string) {
+    super(`Manifest specVersion ${expected} is not, supported. Received ${received}`);
+  }
+}
+
+export class BaseSubqueryProject<
+  DS extends BaseDataSource = BaseDataSource,
+  TemplateDS extends BaseTemplateDataSource = BaseTemplateDataSource,
+  NetworkConfig extends IProjectNetworkConfig = IProjectNetworkConfig,
+> implements ISubqueryProject
+{
+  #dataSources: DS[];
+
+  constructor(
+    readonly id: string,
+    readonly root: string,
+    readonly network: NetworkConfig,
+    readonly schema: GraphQLSchema,
+    dataSources: DS[],
+    readonly templates: TemplateDS[],
+    private blockHandlerKind: string,
+    private isRuntimeDs: IsRuntimeDs<any>,
+    readonly runner?: RunnerSpecs,
+    readonly parent?: ParentProject
+  ) {
+    this.#dataSources = dataSources;
+  }
+
+  static async create<Project extends BaseSubqueryProject>(config: {
+    parseManifest: (raw: unknown) => CommonProjectManifestV1_0_0Impl;
+    path: string;
+    rawManifest: unknown;
+    reader: Reader;
+    root: string; // If project local then directory otherwise temp directory
+    nodeSemver: string;
+    blockHandlerKind: string;
+    isCustomDs: IsCustomDs<Project['dataSources'][0], Project['dataSources'][0] & BaseCustomDataSource>;
+    isRuntimeDs: IsRuntimeDs<any>; // This could be better
+    networkOverrides?: Partial<Project['network']>;
+  }): Promise<Project> {
+    // rawManifest and reader can be reused here.
+    // It has been pre-fetched and used for rebase manifest runner options with args
+    // in order to generate correct configs.
+
+    // But we still need reader here, because path can be remote or local
+    // and the `loadProjectManifest(projectPath)` only support local mode
+    assert(config.rawManifest !== undefined, new Error(`Get manifest from project path ${config.path} failed`));
+
+    const manifest = config.parseManifest(config.rawManifest);
+
+    // Note this needs to be updated if a new version is created, or use semver
+    if (manifest.specVersion !== '1.0.0') {
+      throw new NotSupportedError('<1.0.0', manifest.specVersion);
+    }
+
+    if (typeof manifest.network.endpoint === 'string') {
+      manifest.network.endpoint = [manifest.network.endpoint];
+    }
+
+    const network = processChainId({
+      ...manifest.network,
+      ...config.networkOverrides,
+    });
+
+    assert(network.endpoint, new Error(`Network endpoint must be provided for network. chainId="${network.chainId}"`));
+
+    const schemaString: string = await config.reader.getFile(manifest.schema.file);
+    assert(schemaString, 'Schema file is empty');
+    const schema = buildSchemaFromString(schemaString);
+
+    const [dataSources, templates] = await Promise.all([
+      updateDataSourcesV1_0_0(manifest.dataSources, config.reader, config.root, config.isCustomDs),
+      loadProjectTemplates(manifest.templates, config.root, config.reader, config.isCustomDs),
+    ]);
+
+    const runner = manifest.runner;
+    assert(
+      validateSemver(config.nodeSemver, runner.node.version),
+      new Error(`Runner require node version ${runner.node.version}, current node ${config.nodeSemver}`)
+    );
+
+    return new BaseSubqueryProject(
+      config.reader.root ? config.reader.root : config.path, //TODO, need to method to get project_id
+      config.root,
+      network,
+      schema,
+      dataSources,
+      templates,
+      // chainTypes,
+      config.blockHandlerKind,
+      config.isRuntimeDs,
+      runner,
+      manifest.parent
+    ) as Project;
+  }
+
+  get dataSources(): DS[] {
+    return this.#dataSources;
+  }
+
+  async applyCronTimestamps(getTimestamp: (height: number) => Promise<Date>): Promise<void> {
+    this.#dataSources = await insertBlockFiltersCronSchedules(
+      this.dataSources,
+      getTimestamp,
+      this.isRuntimeDs,
+      this.blockHandlerKind
+    );
+  }
+}
+
+function processChainId<NetworkConfig extends IProjectNetworkConfig>(network: any): NetworkConfig {
+  if (network.chainId && network.genesisHash) {
+    throw new Error('Please only provide one of chainId and genesisHash');
+  } else if (network.genesisHash && !network.chainId) {
+    network.chainId = network.genesisHash;
+  }
+  delete network.genesisHash;
+  return network;
+}

--- a/packages/node-core/src/configure/index.ts
+++ b/packages/node-core/src/configure/index.ts
@@ -4,3 +4,4 @@
 export * from './configure.module';
 export * from './NodeConfig';
 export * from './ProjectUpgrade.service';
+export * from './SubqueryProject';

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -88,7 +88,7 @@ export async function getEnumDeprecated(sequelize: Sequelize, enumTypeNameDeprec
   return resultsDeprecated;
 }
 
-type IsCustomDs<DS, CDS> = (x: DS | CDS) => x is CDS;
+export type IsCustomDs<DS, CDS> = (x: DS | CDS) => x is CDS;
 // TODO remove this type, it would result in a breaking change though
 /**
  * @deprecated Please unwrap the datasource from this type
@@ -227,7 +227,7 @@ export async function initDbSchema(schema: string, storeService: StoreService): 
   await storeService.init(schema);
 }
 
-type IsRuntimeDs<DS> = (ds: DS) => ds is DS;
+export type IsRuntimeDs<DS> = (ds: DS) => ds is DS;
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function insertBlockFiltersCronSchedules<DS extends BaseDataSource = BaseDataSource>(

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update SubqueryProject to use code from node-core (#2496)
 
 ## [4.9.0] - 2024-07-22
 ### Changed

--- a/packages/node/src/configure/SubqueryProject.spec.ts
+++ b/packages/node/src/configure/SubqueryProject.spec.ts
@@ -22,7 +22,7 @@ import {
   SubstrateRuntimeDatasource,
 } from '@subql/types';
 import { Reader } from '@subql/types-core';
-import { SubqueryProject } from './SubqueryProject';
+import { createSubQueryProject } from './SubqueryProject';
 
 // eslint-disable-next-line jest/no-export
 export async function getProjectRoot(reader: Reader): Promise<string> {
@@ -72,7 +72,7 @@ describe('SubqueryProject', () => {
         },
       };
       const rawManifest = await reader.getProjectSchema();
-      const project = await SubqueryProject.create(
+      const project = await createSubQueryProject(
         projectDirV1_0_0,
         rawManifest,
         reader,
@@ -88,7 +88,7 @@ describe('SubqueryProject', () => {
     it('check processChainId', async () => {
       const reader = await ReaderFactory.create(projectDirV1_0_0);
       const rawManifest = await reader.getProjectSchema();
-      const project = await SubqueryProject.create(
+      const project = await createSubQueryProject(
         projectDirV1_0_0,
         rawManifest,
         reader,
@@ -105,7 +105,7 @@ describe('SubqueryProject', () => {
     it('check loadProjectTemplates', async () => {
       const reader0 = await ReaderFactory.create(templateProject);
       const templateRawManifest = await reader0.getProjectSchema();
-      const project = await SubqueryProject.create(
+      const project = await createSubQueryProject(
         templateProject,
         templateRawManifest,
         reader0,
@@ -116,7 +116,7 @@ describe('SubqueryProject', () => {
       );
       const reader1 = await ReaderFactory.create(projectDirV1_0_0);
       const rawManifest = await reader1.getProjectSchema();
-      const project_v1 = await SubqueryProject.create(
+      const project_v1 = await createSubQueryProject(
         projectDirV1_0_0,
         rawManifest,
         reader1,
@@ -136,7 +136,7 @@ describe('SubqueryProject', () => {
       { ipfs: IPFS_NODE_ENDPOINT },
     );
 
-    const project = await SubqueryProject.create(
+    const project = await createSubQueryProject(
       'ipfs://QmZYR6tpRYvmnKoUtugpwYfH9CpP7a8fYYcLVX3d7dph2j',
       await reader.getProjectSchema(),
       reader,
@@ -155,7 +155,7 @@ describe('SubqueryProject', () => {
       { ipfs: IPFS_NODE_ENDPOINT },
     );
 
-    const project = await SubqueryProject.create(
+    const project = await createSubQueryProject(
       'ipfs://QmRoosV27325uAeepKqaTEPFKjC3nk4rrKmZJSd7QXYKZQ',
       await reader.getProjectSchema(),
       reader,

--- a/packages/node/src/configure/configure.module.ts
+++ b/packages/node/src/configure/configure.module.ts
@@ -4,7 +4,7 @@
 import { DynamicModule, Global, Module } from '@nestjs/common';
 import { NodeConfig, registerApp } from '@subql/node-core';
 import { yargsOptions } from '../yargs';
-import { SubqueryProject } from './SubqueryProject';
+import { createSubQueryProject, SubqueryProject } from './SubqueryProject';
 
 const pjson = require('../../package.json');
 
@@ -18,7 +18,7 @@ export class ConfigureModule {
     const { argv } = yargsOptions;
     return registerApp<SubqueryProject>(
       argv,
-      SubqueryProject.create.bind(SubqueryProject),
+      createSubQueryProject,
       yargsOptions.showHelp.bind(yargsOptions),
       pjson,
     );

--- a/packages/node/src/indexer/api.service.spec.ts
+++ b/packages/node/src/indexer/api.service.spec.ts
@@ -60,27 +60,27 @@ const nodeConfig = new NodeConfig({
 });
 
 function testSubqueryProject(): SubqueryProject {
-  return new SubqueryProject(
-    'test',
-    './',
-    {
+  return {
+    id: 'test',
+    root: './',
+    network: {
       endpoint: testNetwork.endpoint,
       // genesisHash:
       //   '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe',
       chainId:
         '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe',
     },
-    [],
-    new GraphQLSchema({}),
-    [],
-    {
+    dataSources: [],
+    schema: new GraphQLSchema({}),
+    templates: [],
+    chainTypes: {
       types: testNetwork.types,
       typesAlias: testNetwork.typesAlias,
       typesBundle: testNetwork.typesBundle,
       typesChain: testNetwork.typesChain,
       typesSpec: testNetwork.typesSpec,
     },
-  );
+  } as unknown as SubqueryProject;
 }
 
 describe('ApiService', () => {

--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -27,23 +27,23 @@ function testSubqueryProject(
   endpoint: string[],
   chainId: string,
 ): SubqueryProject {
-  return new SubqueryProject(
-    'test',
-    './',
-    {
+  return {
+    id: 'test',
+    root: './',
+    network: {
       endpoint,
       dictionary: `https://api.subquery.network/sq/subquery/dictionary-polkadot`,
       chainId: chainId,
     },
-    [],
-    new GraphQLSchema({}),
-    [],
-    {
+    dataSources: [],
+    schema: new GraphQLSchema({}),
+    templates: [],
+    chainTypes: {
       types: {
         TestType: 'u32',
       },
     },
-  );
+  } as unknown as SubqueryProject;
 }
 
 jest.setTimeout(90000);
@@ -452,29 +452,28 @@ describe('Load chain type hasher', () => {
         ConnectionPoolService,
         {
           provide: 'ISubqueryProject',
-          useFactory: () =>
-            new SubqueryProject(
-              'test',
-              './',
-              {
-                endpoint,
-                chainId: chainId,
-              },
-              [],
-              new GraphQLSchema({}),
-              [],
-              {
-                typesBundle: {
-                  spec: {
-                    gargantua: {
-                      // @ts-ignore, we allow it to be string here
-                      hasher: 'keccakAsU8a',
-                      types: [{ minmax: [0, undefined], types: {} }],
-                    },
+          useFactory: () => ({
+            id: 'test',
+            root: './',
+            network: {
+              endpoint,
+              chainId: chainId,
+            },
+            dataSources: [],
+            schema: new GraphQLSchema({}),
+            templates: [],
+            chainTypes: {
+              typesBundle: {
+                spec: {
+                  gargantua: {
+                    // @ts-ignore, we allow it to be string here
+                    hasher: 'keccakAsU8a',
+                    types: [{ minmax: [0, undefined], types: {} }],
                   },
                 },
               },
-            ),
+            },
+          }),
         },
         {
           provide: NodeConfig,

--- a/packages/node/src/indexer/dictionary/substrateDictionary.service.spec.ts
+++ b/packages/node/src/indexer/dictionary/substrateDictionary.service.spec.ts
@@ -16,18 +16,18 @@ function testSubqueryProject(
   endpoint: string[],
   chainId: string,
 ): SubqueryProject {
-  return new SubqueryProject(
-    'test',
-    './',
-    {
+  return {
+    id: 'test',
+    root: './',
+    network: {
       endpoint,
       dictionary: ['http://mock-dictionary-v2'],
       chainId: chainId,
     },
-    [],
-    new GraphQLSchema({}),
-    [],
-  );
+    dataSources: [],
+    schema: new GraphQLSchema({}),
+    templates: [],
+  } as unknown as SubqueryProject;
 }
 
 // Mock jest and set the type

--- a/packages/node/src/indexer/dictionary/v1/substrateDictionaryV1.spec.ts
+++ b/packages/node/src/indexer/dictionary/v1/substrateDictionaryV1.spec.ts
@@ -18,18 +18,18 @@ import { SubstrateDictionaryService } from '../substrateDictionary.service';
 import { buildDictionaryV1QueryEntries } from './substrateDictionaryV1';
 
 function testSubqueryProject(): SubqueryProject {
-  return new SubqueryProject(
-    'test',
-    './',
-    {
+  return {
+    id: 'test',
+    root: './',
+    network: {
       endpoint: '',
       chainId:
         '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
     },
-    [],
-    new GraphQLSchema({}),
-    [],
-  );
+    dataSources: [],
+    schema: new GraphQLSchema({}),
+    templates: [],
+  } as unknown as SubqueryProject;
 }
 const nodeConfig = new NodeConfig({
   subquery: 'asdf',

--- a/packages/node/src/indexer/ds-processor.service.spec.ts
+++ b/packages/node/src/indexer/ds-processor.service.spec.ts
@@ -12,14 +12,14 @@ import { DsProcessorService } from './ds-processor.service';
 function getTestProject(
   extraDataSources: SubstrateCustomDatasource[],
 ): SubqueryProject {
-  return new SubqueryProject(
-    'test',
-    path.resolve(__dirname, '../../'),
-    {
+  return {
+    id: 'test',
+    root: path.resolve(__dirname, '../../'),
+    network: {
       chainId: '0x',
       endpoint: ['wss://polkadot.api.onfinality.io/public-ws'],
     },
-    [
+    dataSources: [
       {
         kind: 'substrate/Jsonfy',
         processor: { file: 'test/jsonfy.js' },
@@ -30,9 +30,9 @@ function getTestProject(
       },
       ...extraDataSources,
     ] as any,
-    new GraphQLSchema({}),
-    [],
-  );
+    schema: new GraphQLSchema({}),
+    templates: [],
+  } as unknown as SubqueryProject;
 }
 const nodeConfig = new NodeConfig({
   subquery: 'asdf',

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -63,14 +63,14 @@ const nodeConfig = new NodeConfig({
 });
 
 function testSubqueryProject_1(): SubqueryProject {
-  return new SubqueryProject(
-    'test',
-    './',
-    {
+  return {
+    id: 'test',
+    root: './',
+    network: {
       chainId: '0x',
       endpoint: ['wss://polkadot.api.onfinality.io/public-ws'],
     },
-    [
+    dataSources: [
       {
         kind: SubstrateDatasourceKind.Runtime,
         startBlock: 1,
@@ -92,22 +92,22 @@ function testSubqueryProject_1(): SubqueryProject {
         },
       },
     ],
-    new GraphQLSchema({}),
-    [],
-  );
+    schema: new GraphQLSchema({}),
+    templates: [],
+  } as unknown as SubqueryProject;
 }
 
 function testSubqueryProject_2(): SubqueryProject {
-  return new SubqueryProject(
-    'test',
-    './',
-    {
+  return {
+    id: 'test',
+    root: './',
+    network: {
       endpoint: ['wss://polkadot.api.onfinality.io/public-ws'],
       dictionary: `https://api.subquery.network/sq/subquery/dictionary-polkadot`,
       chainId:
         '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
     },
-    [
+    dataSources: [
       {
         kind: SubstrateDatasourceKind.Runtime,
         startBlock: 1,
@@ -119,9 +119,9 @@ function testSubqueryProject_2(): SubqueryProject {
         },
       },
     ],
-    new GraphQLSchema({}),
-    [],
-  );
+    schema: new GraphQLSchema({}),
+    templates: [],
+  } as unknown as SubqueryProject;
 }
 
 // eslint-disable-next-line jest/no-export

--- a/packages/node/src/utils/test.utils.ts
+++ b/packages/node/src/utils/test.utils.ts
@@ -14,7 +14,10 @@ import {
   registerApp,
 } from '@subql/node-core';
 import { ConfigureModule } from '../configure/configure.module';
-import { SubqueryProject } from '../configure/SubqueryProject';
+import {
+  createSubQueryProject,
+  SubqueryProject,
+} from '../configure/SubqueryProject';
 import { FetchModule } from '../indexer/fetch.module';
 
 const mockInstance = async (
@@ -37,7 +40,7 @@ const mockInstance = async (
   };
   return registerApp<SubqueryProject>(
     argv,
-    SubqueryProject.create.bind(SubqueryProject),
+    createSubQueryProject,
     jest.fn(),
     '',
   );


### PR DESCRIPTION
# Description
Allows deduplicating code from creating subquery project instances.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
