### PR TITLE
Make endpoints more configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ts-loader": "^9.2.6",
     "ts-node": "^10.4.0",
     "tsconfig-paths": "^3.12.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.5.4"
   },
   "resolutions": {
     "@polkadot/api": "11.2.1",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update inquirer dependencies (#2501)
+- Improve endpoint type to be based on core type (#2511)
 
 ### Fixed
 - Not being able to select a custom repo when initializing a project (#2501)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -199,6 +199,7 @@ export default class Init extends Command {
     }
     this.log(`${project.name} is ready`);
   }
+
   async createProjectScaffold(projectPath: string): Promise<void> {
     await prepareProjectScaffold(projectPath);
 

--- a/packages/cli/src/controller/codegen-controller.test.ts
+++ b/packages/cli/src/controller/codegen-controller.test.ts
@@ -95,7 +95,7 @@ describe('Codegen can generate schema', () => {
     const projectPath = path.join(__dirname, '../../test/schemaTest');
     await codegen(projectPath, ['project-duplicate-enum.yaml']);
 
-    const fooFile = await fs.promises.readFile(`${projectPath}/src/types/models/foo.ts`, 'utf8');
+    const fooFile = await fs.promises.readFile(`${projectPath}/src/types/models/Foo.ts`, 'utf8');
 
     expect(fooFile).toContain(
       `import {

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import * as path from 'path';
 import {promisify} from 'util';
 import {DEFAULT_MANIFEST, DEFAULT_TS_MANIFEST, loadFromJsonOrYaml, makeTempDir, NETWORK_FAMILY} from '@subql/common';
-import {ProjectManifestV1_0_0} from '@subql/types-core';
+import {ProjectManifestV1_0_0, ProjectNetworkConfig} from '@subql/types-core';
 import axios from 'axios';
 import {copySync} from 'fs-extra';
 import rimraf from 'rimraf';
@@ -142,7 +142,7 @@ export async function cloneProjectTemplate(
 export async function readDefaults(projectPath: string): Promise<string[]> {
   const packageData = await fs.promises.readFile(`${projectPath}/package.json`);
   const currentPackage = JSON.parse(packageData.toString());
-  let endpoint: string | string[];
+  let endpoint: ProjectNetworkConfig['endpoint'];
   const defaultTsPath = defaultTSManifestPath(projectPath);
   const defaultYamlPath = defaultYamlManifestPath(projectPath);
 

--- a/packages/cli/src/controller/publish-controller.spec.ts
+++ b/packages/cli/src/controller/publish-controller.spec.ts
@@ -9,7 +9,7 @@ import {createMultiChainTestProject, createTestProject} from '../createProject.f
 import {getDirectoryCid, uploadToIpfs} from './publish-controller';
 
 // Replace/Update your access token when test locally
-const testAuth = process.env.SUBQL_ACCESS_TOKEN!;
+const testAuth = process.env.SUBQL_ACCESS_TOKEN_TEST!;
 
 jest.setTimeout(300_000); // 300s
 describe('Cli publish', () => {

--- a/packages/common-substrate/CHANGELOG.md
+++ b/packages/common-substrate/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Updated `@subql\common` with support for endpoint specific configs (#2511)
 
 ## [4.1.1] - 2024-07-25
 ### Changed

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New type for endpoint to allow specifying endpoint options (#2511)
 
 ## [4.1.1] - 2024-07-25
 ### Changed

--- a/packages/common/src/project/IpfsHttpClientLite/IpfsHttpClientLite.spec.ts
+++ b/packages/common/src/project/IpfsHttpClientLite/IpfsHttpClientLite.spec.ts
@@ -5,7 +5,7 @@ import {u8aConcat} from '@polkadot/util';
 import {IPFS_NODE_ENDPOINT, IPFS_WRITE_ENDPOINT} from '../../constants';
 import {IPFSHTTPClientLite} from './IPFSHTTPClientLite';
 
-const testAuth = process.env.SUBQL_ACCESS_TOKEN!;
+const testAuth = process.env.SUBQL_ACCESS_TOKEN_TEST!;
 
 describe('IPFSClient Lite', () => {
   let readClient: IPFSHTTPClientLite;

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -4,9 +4,17 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import {BaseDataSource, FileReference, MultichainProjectManifest, ProjectRootAndManifest} from '@subql/types-core';
+import {
+  BaseDataSource,
+  FileReference,
+  IEndpointConfig,
+  MultichainProjectManifest,
+  ProjectRootAndManifest,
+} from '@subql/types-core';
+import {ClassConstructor, plainToInstance} from 'class-transformer';
 import {
   registerDecorator,
+  validate,
   validateSync,
   ValidationArguments,
   ValidationOptions,
@@ -19,6 +27,7 @@ import Pino from 'pino';
 import {lt, prerelease, satisfies, valid, validRange} from 'semver';
 import updateNotifier, {Package} from 'update-notifier';
 import {RUNNER_ERROR_REGEX} from '../constants';
+import {CommonEndpointConfig} from './versioned';
 
 export const DEFAULT_MULTICHAIN_MANIFEST = 'subquery-multichain.yaml';
 export const DEFAULT_MULTICHAIN_TS_MANIFEST = 'subquery-multichain.ts';
@@ -224,7 +233,7 @@ export function extensionIsYamlOrJSON(ext: string): boolean {
 }
 
 export function forbidNonWhitelisted(keys: any, validationOptions?: ValidationOptions) {
-  return function (object: object, propertyName: string) {
+  return function (object: object, propertyName: string): void {
     registerDecorator({
       name: 'forbidNonWhitelisted',
       target: object.constructor,
@@ -246,6 +255,62 @@ export function forbidNonWhitelisted(keys: any, validationOptions?: ValidationOp
       },
     });
   };
+}
+
+export function IsNetworkEndpoint<T extends object>(cls: ClassConstructor<T>, validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string): void {
+    registerDecorator({
+      name: 'IsNetworkEndpoint',
+      target: object.constructor,
+      propertyName: propertyName,
+      constraints: [],
+      options: {message: 'Invalid network endpoint'},
+      validator: {
+        validate(value: string | string[] | Record<string, CommonEndpointConfig>, args: ValidationArguments) {
+          if (typeof value === 'string') {
+            return true;
+          }
+          if (Array.isArray(value)) {
+            return value.every((v) => typeof v === 'string');
+          }
+          if (typeof value === 'object') {
+            return (
+              Object.keys(value).every((v) => typeof v === 'string') &&
+              Object.values(value).every((v) => {
+                const instance = plainToInstance(cls, v);
+                const errors = validateSync(instance);
+                return errors === undefined || !errors.length;
+              })
+            );
+          }
+          return false;
+        },
+      },
+    });
+  };
+}
+
+// Overload the function so that if input is undefineable then output is undefineable
+export function normalizeNetworkEndpoints<T extends IEndpointConfig = IEndpointConfig>(
+  input: string | string[] | Record<string, T>,
+  defaultConfig?: T
+): Record<string, T>;
+export function normalizeNetworkEndpoints<T extends IEndpointConfig = IEndpointConfig>(
+  input: string | string[] | Record<string, T> | undefined,
+  defaultConfig: T
+): Record<string, T> | undefined {
+  if (typeof input === 'string') {
+    return {[input]: defaultConfig ?? {}};
+  } else if (Array.isArray(input)) {
+    return input.reduce(
+      (acc, endpoint) => {
+        acc[endpoint] = defaultConfig ?? {};
+        return acc;
+      },
+      {} as Record<string, T>
+    );
+  }
+  return input;
 }
 
 export function notifyUpdates(pjson: Package, logger: Pino.Logger): void {

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -310,6 +310,11 @@ export function normalizeNetworkEndpoints<T extends IEndpointConfig = IEndpointC
       {} as Record<string, T>
     );
   }
+
+  for (const key in input) {
+    // Yaml can make this null so we ensure it exists
+    input[key] = input[key] ?? {};
+  }
   return input;
 }
 

--- a/packages/common/src/project/versioned/v1_0_0/model.spec.ts
+++ b/packages/common/src/project/versioned/v1_0_0/model.spec.ts
@@ -1,0 +1,75 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {IProjectNetworkConfig} from '@subql/types-core';
+import {plainToClass} from 'class-transformer';
+import {validateSync} from 'class-validator';
+import {CommonProjectNetworkV1_0_0} from './models';
+
+describe('Validating base v1_0_0 model', () => {
+  it('correctly validates the various endpoint structures in a network config', () => {
+    const config1: IProjectNetworkConfig = {
+      chainId: '1',
+      endpoint: 'https://example.com',
+    };
+
+    const config2: IProjectNetworkConfig = {
+      chainId: '1',
+      endpoint: ['https://example.com', 'https://foo.bar'],
+    };
+
+    const config3: IProjectNetworkConfig = {
+      chainId: '1',
+      endpoint: {
+        'https://example.com': {
+          headers: {'api-key': '1234'},
+        },
+      },
+    };
+
+    const bad1 = {
+      chainId: '1',
+      endpoint: 1,
+    };
+
+    const bad2 = {
+      chainId: '1',
+      endpoint: [1],
+    };
+
+    const bad3 = {
+      chainId: '1',
+      endpoint: [
+        {
+          2: {},
+        },
+      ],
+    };
+
+    const bad4 = {
+      chainId: '1',
+      endpoint: [
+        {
+          'https://example.com': undefined,
+        },
+      ],
+    };
+
+    function validate(raw: unknown) {
+      const projectManifest = plainToClass<CommonProjectNetworkV1_0_0, unknown>(CommonProjectNetworkV1_0_0, raw);
+      const errors = validateSync(projectManifest, {whitelist: true});
+
+      if (errors.length) {
+        throw new Error(errors.map((e) => e.value).join('\n'));
+      }
+    }
+
+    expect(() => validate(config1)).not.toThrow();
+    expect(() => validate(config2)).not.toThrow();
+    expect(() => validate(config3)).not.toThrow();
+    expect(() => validate(bad1)).toThrow();
+    expect(() => validate(bad2)).toThrow();
+    expect(() => validate(bad3)).toThrow();
+    expect(() => validate(bad4)).toThrow();
+  });
+});

--- a/packages/common/src/project/versioned/v1_0_0/models.ts
+++ b/packages/common/src/project/versioned/v1_0_0/models.ts
@@ -4,6 +4,7 @@
 import {
   BlockFilter,
   CommonSubqueryProject,
+  IEndpointConfig,
   IProjectNetworkConfig,
   NodeOptions,
   NodeSpec,
@@ -26,8 +27,9 @@ import {
   IsNotEmpty,
   Allow,
   ValidateIf,
+  IsPositive,
 } from 'class-validator';
-import {SemverVersionValidator} from '../../utils';
+import {IsNetworkEndpoint, SemverVersionValidator} from '../../utils';
 import {FileType} from '../base';
 
 export class RunnerQueryBaseModel implements QuerySpec {
@@ -139,10 +141,16 @@ export class CommonRunnerSpecsImpl implements RunnerSpecs {
   query!: QuerySpec;
 }
 
-export class CommonProjectNetworkV1_0_0<C = any> implements IProjectNetworkConfig {
-  @IsString({each: true})
+export class CommonEndpointConfig implements IEndpointConfig {
   @IsOptional()
-  endpoint!: string | string[];
+  // Class validator doesn't have any way of validating records
+  headers?: Record<string, string>;
+}
+
+export class CommonProjectNetworkV1_0_0<C = any> implements IProjectNetworkConfig {
+  @IsOptional()
+  @IsNetworkEndpoint(CommonEndpointConfig)
+  endpoint!: string | string[] | Record<string, CommonEndpointConfig>;
   @IsString({each: true})
   @IsOptional()
   dictionary!: string | string[];

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for endpoint configs (#2511)
+
 ## [13.0.2] - 2024-07-31
 ### Fixed
 - Fixed project upgrade missing reload network chainTypes when `onProjectChange` (#2505)

--- a/packages/node-core/src/api.service.spec.ts
+++ b/packages/node-core/src/api.service.spec.ts
@@ -34,7 +34,7 @@ describe('ApiService', () => {
   it('should throw creating connections if all endpoints are invalid', async () => {
     await expect(
       apiService.createConnections(
-        {chainId: 'test', endpoint: ['fail', 'fail']} as any,
+        {chainId: 'test', endpoint: {fail: {}, fail2: {}}} as any,
         (endpoint) => Promise.resolve({networkMeta: {chain: endpoint}} as any) // Fail meta validation
       )
     ).rejects.toThrow();
@@ -43,7 +43,7 @@ describe('ApiService', () => {
   it('should succeed creating connections if one endpoint is invalid', async () => {
     await expect(
       apiService.createConnections(
-        {chainId: 'test', endpoint: ['test', 'fail']} as any,
+        {chainId: 'test', endpoint: {test: {}, fail: {}}} as any,
         (endpoint) => Promise.resolve({networkMeta: {chain: endpoint}} as any) // Fail meta validation
       )
     ).resolves.not.toThrow();

--- a/packages/node-core/src/api.service.spec.ts
+++ b/packages/node-core/src/api.service.spec.ts
@@ -34,7 +34,7 @@ describe('ApiService', () => {
   it('should throw creating connections if all endpoints are invalid', async () => {
     await expect(
       apiService.createConnections(
-        {chainId: 'test', endpoint: {fail: {}, fail2: {}}} as any,
+        {chainId: 'test', endpoint: {fail: {}, fail2: {}}},
         (endpoint) => Promise.resolve({networkMeta: {chain: endpoint}} as any) // Fail meta validation
       )
     ).rejects.toThrow();
@@ -43,7 +43,7 @@ describe('ApiService', () => {
   it('should succeed creating connections if one endpoint is invalid', async () => {
     await expect(
       apiService.createConnections(
-        {chainId: 'test', endpoint: {test: {}, fail: {}}} as any,
+        {chainId: 'test', endpoint: {test: {}, fail: {}}},
         (endpoint) => Promise.resolve({networkMeta: {chain: endpoint}} as any) // Fail meta validation
       )
     ).resolves.not.toThrow();
@@ -51,7 +51,7 @@ describe('ApiService', () => {
 
   it(`doesn't set network meta if a connection fails validation`, async () => {
     await expect(
-      apiService.createConnections({chainId: 'test', endpoint: ['fail']} as any, (endpoint) =>
+      apiService.createConnections({chainId: 'test', endpoint: ['fail']}, (endpoint) =>
         Promise.resolve({networkMeta: {chain: endpoint}} as any)
       )
     ).rejects.toThrow();
@@ -62,7 +62,7 @@ describe('ApiService', () => {
   it('should retry connections if they fail with something other than metadata', async () => {
     const retrySpy = jest.spyOn(apiService, 'retryConnection');
 
-    await apiService.createConnections({chainId: 'test', endpoint: ['test', 'fail']} as any, (endpoint) =>
+    await apiService.createConnections({chainId: 'test', endpoint: {test: {}, fail: {}}}, (endpoint) =>
       endpoint === 'test'
         ? Promise.resolve({networkMeta: {chain: endpoint}} as any) // At least one endpoint needs to succeed
         : Promise.reject(new Error('Test'))

--- a/packages/node-core/src/api.service.spec.ts
+++ b/packages/node-core/src/api.service.spec.ts
@@ -3,17 +3,18 @@
 
 import {EventEmitter2} from '@nestjs/event-emitter';
 import {delay} from '@subql/common';
-import {ProjectNetworkConfig} from '@subql/types-core';
+import {IEndpointConfig, ProjectNetworkConfig} from '@subql/types-core';
 import {ApiService, IApiConnectionSpecific} from './api.service';
 import {NodeConfig} from './configure';
 import {ConnectionPoolService, ConnectionPoolStateManager} from './indexer';
 
 class TestApiService extends ApiService {
   retryConnection(
-    createConnection: (endpoint: string) => Promise<IApiConnectionSpecific>,
+    createConnection: (endpoint: string, config: IEndpointConfig) => Promise<IApiConnectionSpecific>,
     network: ProjectNetworkConfig & {chainId: string},
     index: number,
     endpoint: string,
+    config: IEndpointConfig,
     postConnectedHook?: ((connection: IApiConnectionSpecific, endpoint: string, index: number) => void) | undefined
   ): void {
     /* No Op to avoid creating intervals/timeouts in tests*/

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -4,7 +4,8 @@
 import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
-import {getFileContent, loadFromJsonOrYaml} from '@subql/common';
+import {getFileContent, loadFromJsonOrYaml, normalizeNetworkEndpoints} from '@subql/common';
+import {IEndpointConfig} from '@subql/types-core';
 import {last} from 'lodash';
 import {LevelWithSilent} from 'pino';
 import {getLogger} from '../logger';
@@ -21,8 +22,8 @@ export interface IConfig {
   readonly blockTime: number;
   readonly debug?: string;
   readonly preferRange: boolean;
-  readonly networkEndpoint?: string[];
-  readonly primaryNetworkEndpoint?: string;
+  readonly networkEndpoint?: Record<string, IEndpointConfig>;
+  readonly primaryNetworkEndpoint?: [string, IEndpointConfig];
   readonly networkDictionary?: string[];
   readonly dictionaryRegistry: string;
   readonly outputFmt?: 'json';
@@ -133,14 +134,18 @@ export class NodeConfig<C extends IConfig = IConfig> implements IConfig {
     return this._config.batchSize;
   }
 
-  get networkEndpoints(): string[] | undefined {
-    return typeof this._config.networkEndpoint === 'string'
-      ? [this._config.networkEndpoint]
-      : this._config.networkEndpoint;
+  get networkEndpoints(): Record<string, IEndpointConfig> | undefined {
+    return normalizeNetworkEndpoints(
+      this._config.networkEndpoint as string | string[] | Record<string, IEndpointConfig>
+    );
   }
 
-  get primaryNetworkEndpoint(): string | undefined {
+  get primaryNetworkEndpoint(): [string, IEndpointConfig] | undefined {
     return this._config.primaryNetworkEndpoint;
+    // if (!this._config.primaryNetworkEndpoint) {
+    //   return undefined;
+    // }
+    // return [this._config.primaryNetworkEndpoint, {}];
   }
 
   get networkDictionaries(): string[] | undefined | false {

--- a/packages/node-core/src/configure/SubqueryProject.ts
+++ b/packages/node-core/src/configure/SubqueryProject.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import assert from 'assert';
-import {CommonProjectManifestV1_0_0Impl, validateSemver} from '@subql/common';
+import {CommonProjectManifestV1_0_0Impl, normalizeNetworkEndpoints, validateSemver} from '@subql/common';
 import {
   BaseCustomDataSource,
   BaseDataSource,
@@ -79,9 +79,9 @@ export class BaseSubqueryProject<
       throw new NotSupportedError('<1.0.0', manifest.specVersion);
     }
 
-    if (typeof manifest.network.endpoint === 'string') {
-      manifest.network.endpoint = [manifest.network.endpoint];
-    }
+    // Convert endpoints to the latest format
+
+    manifest.network.endpoint = normalizeNetworkEndpoints(manifest.network.endpoint);
 
     const network = processChainId({
       ...manifest.network,

--- a/packages/node-core/src/configure/configure.module.spec.ts
+++ b/packages/node-core/src/configure/configure.module.spec.ts
@@ -1,25 +1,115 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {validDbSchemaName} from './configure.module';
+import {validDbSchemaName, yargsToIConfig} from './configure.module';
 
 describe('Configure', () => {
-  it('validDbSchemaName - works', () => {
-    expect(validDbSchemaName('subquery_1')).toBeTruthy();
+  describe('validateDbSchemaName', () => {
+    it('works', () => {
+      expect(validDbSchemaName('subquery_1')).toBeTruthy();
+    });
+    it('works not alphanumeric', () => {
+      expect(validDbSchemaName('subquery_-/1')).toBeTruthy();
+    });
+    it('long', () => {
+      expect(validDbSchemaName('a'.repeat(64))).toBeFalsy();
+    });
+    it('invalid prefix', () => {
+      expect(validDbSchemaName('pg_whatever')).toBeFalsy();
+    });
+    it('invalid tokens', () => {
+      expect(validDbSchemaName('he$$*')).toBeFalsy();
+    });
+    it('empty', () => {
+      expect(validDbSchemaName('')).toBeFalsy();
+    });
   });
-  it('validDbSchemaName - works not alphanumeric', () => {
-    expect(validDbSchemaName('subquery_-/1')).toBeTruthy();
-  });
-  it('validDbSchemaName - long', () => {
-    expect(validDbSchemaName('a'.repeat(64))).toBeFalsy();
-  });
-  it('validDbSchemaName - invalid prefix', () => {
-    expect(validDbSchemaName('pg_whatever')).toBeFalsy();
-  });
-  it('validDbSchemaName - invalid tokens', () => {
-    expect(validDbSchemaName('he$$*')).toBeFalsy();
-  });
-  it('validDbSchemaName - empty', () => {
-    expect(validDbSchemaName('')).toBeFalsy();
+
+  describe('network endpoint options', () => {
+    it('should work without network-endpoint-config options', () => {
+      const {networkEndpoint} = yargsToIConfig({
+        'network-endpoint': 'https://example.com',
+      });
+
+      expect(networkEndpoint).toEqual({['https://example.com']: {}});
+    });
+
+    it('should work without network-endpoint-config options (array)', () => {
+      const {networkEndpoint} = yargsToIConfig({
+        'network-endpoint': ['https://example.com', 'https://foo.bar'],
+      });
+
+      expect(networkEndpoint).toEqual({
+        ['https://example.com']: {},
+        ['https://foo.bar']: {},
+      });
+    });
+
+    it('should work with network-endpoint-config options', () => {
+      const option = {headers: {'api-key': '<your-api-key>'}};
+      const {networkEndpoint} = yargsToIConfig({
+        'network-endpoint': 'https://example.com',
+        'network-endpoint-config': JSON.stringify(option),
+      });
+
+      expect(networkEndpoint).toEqual({['https://example.com']: option});
+    });
+
+    it('should work with network-endpoint-config options (array)', () => {
+      const option = {headers: {'api-key': '<your-api-key>'}};
+      const {networkEndpoint} = yargsToIConfig({
+        'network-endpoint': ['https://example.com', 'https://foo.bar'],
+        'network-endpoint-config': [JSON.stringify(option), JSON.stringify(option)],
+      });
+
+      expect(networkEndpoint).toEqual({
+        ['https://example.com']: option,
+        ['https://foo.bar']: option,
+      });
+    });
+
+    it('should work with network-endpoint-config options (mixed-arrays)', () => {
+      const option = {headers: {'api-key': '<your-api-key>'}};
+      const {networkEndpoint} = yargsToIConfig({
+        'network-endpoint': ['https://example.com', 'https://foo.bar'],
+        'network-endpoint-config': [JSON.stringify(option)],
+      });
+
+      expect(networkEndpoint).toEqual({
+        ['https://example.com']: option,
+        ['https://foo.bar']: {},
+      });
+    });
+
+    it('should work without primary-network-endpoint-config options', () => {
+      const {primaryNetworkEndpoint} = yargsToIConfig({
+        'primary-network-endpoint': 'https://example.com',
+      });
+
+      expect(primaryNetworkEndpoint).toEqual(['https://example.com', {}]);
+    });
+
+    it('should work with primary-network-endpoint-config options', () => {
+      const option = {headers: {'api-key': '<your-api-key>'}};
+      const {primaryNetworkEndpoint} = yargsToIConfig({
+        'primary-network-endpoint': 'https://example.com',
+        'primary-network-endpoint-config': JSON.stringify(option),
+      });
+
+      expect(primaryNetworkEndpoint).toEqual(['https://example.com', option]);
+    });
+
+    it('doesnt add config flags to IConfig', () => {
+      const option = {headers: {'api-key': '<your-api-key>'}};
+      const config = yargsToIConfig({
+        'network-endpoint': ['https://example.com', 'https://foo.bar'],
+        'network-endpoint-config': [JSON.stringify(option), JSON.stringify(option)],
+        'primary-network-endpoint': 'https://example.com',
+        'primary-network-endpoint-config': JSON.stringify(option),
+      });
+
+      expect((config as any).networkEndpointConfig).toBe(undefined);
+      expect((config as any).primaryNetworkEndpointConfig).toBe(undefined);
+    });
   });
 });

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -53,7 +53,7 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
 
   async addToConnections(api: T, endpoint: string): Promise<void> {
     this.allApi[endpoint] = api;
-    await this.poolStateManager.addToConnections(endpoint, endpoint === this.nodeConfig.primaryNetworkEndpoint);
+    await this.poolStateManager.addToConnections(endpoint, endpoint === this.nodeConfig.primaryNetworkEndpoint?.[0]);
     if (api !== null) {
       await this.updateNextConnectedApiIndex();
     }

--- a/packages/node-core/src/indexer/dictionary/dictionary.service.spec.ts
+++ b/packages/node-core/src/indexer/dictionary/dictionary.service.spec.ts
@@ -77,7 +77,7 @@ describe('Dictionary service', function () {
     const nodeConfig = new NodeConfig({
       subquery: 'dictionaryService',
       subqueryName: 'asdf',
-      networkEndpoint: ['wss://eth.api.onfinality.io/public-ws'],
+      networkEndpoint: {'wss://eth.api.onfinality.io/public-ws': {}},
       dictionaryTimeout: 10,
       networkDictionary: [...dictionaryV1Endpoints, ...dictionaryV2Endpoints],
     });

--- a/packages/node-core/src/indexer/dictionary/v1/dictionaryV1.spec.ts
+++ b/packages/node-core/src/indexer/dictionary/v1/dictionaryV1.spec.ts
@@ -16,7 +16,7 @@ const DICTIONARY_CHAINID = `0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb492
 const nodeConfig = new NodeConfig({
   subquery: 'asdf',
   subqueryName: 'asdf',
-  networkEndpoint: ['wss://polkadot.api.onfinality.io/public-ws'],
+  networkEndpoint: {'wss://polkadot.api.onfinality.io/public-ws': {}},
   dictionaryTimeout: 10,
 });
 // Need longer timeout

--- a/packages/node-core/src/utils/project.ts
+++ b/packages/node-core/src/utils/project.ts
@@ -280,7 +280,7 @@ export async function loadProjectTemplates<T extends BaseTemplateDataSource>(
   templates: T[] | undefined,
   root: string,
   reader: Reader,
-  isCustomDs: IsCustomDs<T, Omit<T & BaseCustomDataSource, keyof TemplateBase>>
+  isCustomDs: IsCustomDs<T, T & BaseCustomDataSource>
 ): Promise<T[]> {
   if (!templates || !templates.length) {
     return [];

--- a/packages/node-core/src/yargs.ts
+++ b/packages/node-core/src/yargs.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import yargs from 'yargs';
+import yargs, {example} from 'yargs';
 import {hideBin} from 'yargs/helpers';
 import {initLogger} from './logger';
 
@@ -32,7 +32,7 @@ type YargsOptions<RootO extends Record<string, yargs.Options>, RunO extends Reco
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function yargsBuilder<
   RootO extends Record<string, yargs.Options> = Record<string, never>,
-  RunO extends Record<string, yargs.Options> = Record<string, never>
+  RunO extends Record<string, yargs.Options> = Record<string, never>,
 >(options: YargsOptions<RootO, RunO>) {
   return (
     yargs(hideBin(process.argv))
@@ -134,6 +134,20 @@ export function yargsBuilder<
                 demandOption: false,
                 type: 'string',
                 describe: 'Primary blockchain endpoint, used as the first choice for connections.',
+              },
+              'network-endpoint-config': {
+                demandOption: false,
+                type: 'string',
+                describe: 'A json encoded string of a network endpoint configuration',
+
+                // example: JSON.stringify({ headers: { 'api-key': '<your-api-key>'}})
+              },
+              'primary-network-endpoint-config': {
+                demandOption: false,
+                type: 'string',
+
+                describe: 'Same as the network-endpoint.config but for the primary network endpoint',
+                // example: JSON.stringify({ headers: { 'api-key': '<your-api-key>'}})
               },
               'output-fmt': {
                 demandOption: false,

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support endpoint configs and specifying headers for network endpoints (#2511)
+
 ## [5.0.2] - 2024-07-31
 ### Fixed
 - Fixed api not reloading new deployment chainTypes when project upgrades (#2505)

--- a/packages/node/src/indexer/api.service.spec.ts
+++ b/packages/node/src/indexer/api.service.spec.ts
@@ -29,7 +29,7 @@ jest.mock('@polkadot/api', () => {
 });
 
 const testNetwork = {
-  endpoint: ['ws://kusama.api.onfinality.io/public-ws'],
+  endpoint: { 'ws://kusama.api.onfinality.io/public-ws': {} },
   types: {
     TestType: 'u32',
   },
@@ -55,7 +55,7 @@ const testNetwork = {
 const nodeConfig = new NodeConfig({
   subquery: 'asdf',
   subqueryName: 'asdf',
-  networkEndpoint: ['https://polkadot.api.onfinality.io/public'],
+  networkEndpoint: { 'https://polkadot.api.onfinality.io/public': {} },
   dictionaryTimeout: 10,
 });
 
@@ -109,9 +109,13 @@ describe('ApiService', () => {
     );
     await apiService.init();
     const { version } = require('../../package.json');
-    expect(WsProvider).toHaveBeenCalledWith(testNetwork.endpoint[0], 2500, {
-      'User-Agent': `SubQuery-Node ${version}`,
-    });
+    expect(WsProvider).toHaveBeenCalledWith(
+      Object.keys(testNetwork.endpoint)[0],
+      2500,
+      {
+        'User-Agent': `SubQuery-Node ${version}`,
+      },
+    );
     expect(createSpy).toHaveBeenCalledWith({
       provider: expect.anything(),
       throwOnConnect: expect.anything(),

--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -12,6 +12,7 @@ import {
   NodeConfig,
 } from '@subql/node-core';
 import { SubstrateBlock } from '@subql/types';
+import { IEndpointConfig } from '@subql/types-core';
 import { GraphQLSchema } from 'graphql';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { wrapBlock } from '../utils/substrate';
@@ -24,7 +25,7 @@ const TEST_BLOCKHASH =
   '0x70070f6c1ad5b9ce3d0a09e94086e22b8d4f08a18491183de96614706bf59600'; // kusama #6721189
 
 function testSubqueryProject(
-  endpoint: string[],
+  endpoint: Record<string, IEndpointConfig>,
   chainId: string,
 ): SubqueryProject {
   return {
@@ -64,7 +65,7 @@ describe('ApiService', () => {
         ConnectionPoolService,
         {
           provide: 'ISubqueryProject',
-          useFactory: () => testSubqueryProject([endpoint], chainId),
+          useFactory: () => testSubqueryProject({ endpoint: {} }, chainId),
         },
         {
           provide: NodeConfig,

--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -65,7 +65,7 @@ describe('ApiService', () => {
         ConnectionPoolService,
         {
           provide: 'ISubqueryProject',
-          useFactory: () => testSubqueryProject({ endpoint: {} }, chainId),
+          useFactory: () => testSubqueryProject({ [endpoint]: {} }, chainId),
         },
         {
           provide: NodeConfig,

--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -444,7 +444,7 @@ describe('Load chain type hasher', () => {
   });
 
   const prepareApiService = async (
-    endpoint = ['wss://hyperbridge-paseo-rpc.blockops.network'],
+    endpoint = { 'wss://hyperbridge-paseo-rpc.blockops.network': {} },
     chainId = '0x5388faf792c5232566d21493929b32c1f20a9c2b03e95615eefec2aa26d64b73',
   ): Promise<ApiService> => {
     const module = await Test.createTestingModule({

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -86,7 +86,6 @@ export class ApiPromiseConnection
       noInitWarn: true,
       ...args.chainTypes,
     };
-
     const api = await ApiPromise.create(apiOption);
     return new ApiPromiseConnection(api, fetchBlocksBatches);
   }

--- a/packages/node/src/indexer/apiPromise.connection.ts
+++ b/packages/node/src/indexer/apiPromise.connection.ts
@@ -16,6 +16,7 @@ import {
   IApiConnectionSpecific,
   IBlock,
 } from '@subql/node-core';
+import { IEndpointConfig } from '@subql/types-core';
 import * as SubstrateUtil from '../utils/substrate';
 import { ApiAt, BlockContent, LightBlockContent } from './types';
 import { createCachedProvider } from './x-provider/cachedProvider';
@@ -58,12 +59,14 @@ export class ApiPromiseConnection
     endpoint: string,
     fetchBlocksBatches: GetFetchFunc,
     args: { chainTypes?: RegisteredTypes },
+    config: IEndpointConfig,
   ): Promise<ApiPromiseConnection> {
     let provider: ProviderInterface;
     let throwOnConnect = false;
 
     const headers = {
       'User-Agent': `SubQuery-Node ${packageVersion}`,
+      ...config.headers,
     };
 
     if (endpoint.startsWith('ws')) {

--- a/packages/node/src/indexer/dictionary/substrateDictionary.service.spec.ts
+++ b/packages/node/src/indexer/dictionary/substrateDictionary.service.spec.ts
@@ -41,7 +41,7 @@ describe('Substrate Dictionary service', function () {
     const nodeConfig = new NodeConfig({
       subquery: 'dictionaryService',
       subqueryName: 'asdf',
-      networkEndpoint: ['wss://polkadot.api.onfinality.io/public-ws'],
+      networkEndpoint: { 'wss://polkadot.api.onfinality.io/public-ws': {} },
       dictionaryTimeout: 10,
       networkDictionary: ['http://mock-dictionary-v2'],
       dictionaryRegistry: 'false',

--- a/packages/node/src/indexer/indexer.manager.spec.ts
+++ b/packages/node/src/indexer/indexer.manager.spec.ts
@@ -59,7 +59,7 @@ jest.setTimeout(200000);
 const nodeConfig = new NodeConfig({
   subquery: 'asdf',
   subqueryName: 'asdf',
-  networkEndpoint: ['wss://polkadot.api.onfinality.io/public-ws'],
+  networkEndpoint: { 'wss://polkadot.api.onfinality.io/public-ws': {} },
 });
 
 function testSubqueryProject_1(): SubqueryProject {

--- a/packages/node/src/indexer/project.service.spec.ts
+++ b/packages/node/src/indexer/project.service.spec.ts
@@ -24,7 +24,7 @@ function testSubqueryProject(): SubqueryProject {
     id: 'test',
     root: './',
     network: {
-      endpoint: ['https://polkadot.api.onfinality.io/public'],
+      endpoint: { 'https://polkadot.api.onfinality.io/public': {} },
       chainId:
         '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
     },

--- a/packages/types-core/CHANGELOG.md
+++ b/packages/types-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New endpoint type to allow specifying endpoint config (#2511)
 
 ## [0.10.0] - 2024-07-11
 ### Changed

--- a/packages/types-core/src/project/types.ts
+++ b/packages/types-core/src/project/types.ts
@@ -138,7 +138,7 @@ export interface IEndpointConfig {
  * Represents the network configuration for a project.
  * @interface
  */
-export interface ProjectNetworkConfig {
+export interface ProjectNetworkConfig<EndpointConfig extends IEndpointConfig = IEndpointConfig> {
   /**
    * The endpoint(s) for the network connection, which can be a single string or an array of strings.
    *
@@ -149,7 +149,7 @@ export interface ProjectNetworkConfig {
    *
    * @type {string | string[] | Record<string, IEndpointConfig> }
    */
-  endpoint: string | string[] | Record<string, IEndpointConfig>;
+  endpoint: string | string[] | Record<string, EndpointConfig>;
 
   /**
    * The SubQuery network dictionary endpoint (optional).

--- a/packages/types-core/src/project/types.ts
+++ b/packages/types-core/src/project/types.ts
@@ -12,7 +12,7 @@ import {BaseDataSource, BaseTemplateDataSource, ParentProject, RunnerSpecs} from
 export interface CommonSubqueryProject<
   N extends IProjectNetworkConfig = IProjectNetworkConfig,
   DS extends BaseDataSource = BaseDataSource,
-  T extends BaseTemplateDataSource<DS> = BaseTemplateDataSource<DS>
+  T extends BaseTemplateDataSource<DS> = BaseTemplateDataSource<DS>,
 > {
   /**
    * The repository of your SubQuery project.
@@ -128,6 +128,12 @@ export interface IProjectManifest<D> {
   validate(): void;
 }
 
+/* Define specific behaviour for rate limits*/
+export interface IEndpointConfig {
+  /* Headers to be supplied with the requests to the endpoint */
+  headers?: Record<string, string>;
+}
+
 /**
  * Represents the network configuration for a project.
  * @interface
@@ -141,9 +147,9 @@ export interface ProjectNetworkConfig {
    * Public nodes may be rate limited, which can affect indexing speed
    * When developing your project we suggest adding a private API key
    *
-   * @type {string | string[]}
+   * @type {string | string[] | Record<string, IEndpointConfig> }
    */
-  endpoint: string | string[];
+  endpoint: string | string[] | Record<string, IEndpointConfig>;
 
   /**
    * The SubQuery network dictionary endpoint (optional).

--- a/yarn.lock
+++ b/yarn.lock
@@ -20481,7 +20481,7 @@ __metadata:
     ts-loader: ^9.2.6
     ts-node: ^10.4.0
     tsconfig-paths: ^3.12.0
-    typescript: ^4.9.5
+    typescript: ^5.5.4
   languageName: unknown
   linkType: soft
 
@@ -21334,13 +21334,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:^5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: b309040f3a1cd91c68a5a58af6b9fdd4e849b8c42d837b2c2e73f9a4f96a98c4f1ed398a9aab576ee0a4748f5690cf594e6b99dbe61de7839da748c41e6d6ca8
   languageName: node
   linkType: hard
 
@@ -21354,13 +21354,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=701156"
+"typescript@patch:typescript@^5.5.4#~builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#~builtin<compat/typescript>::version=5.5.4&hash=701156"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
+  checksum: fc52962f31a5bcb716d4213bef516885e4f01f30cea797a831205fc9ef12b405a40561c40eae3127ab85ba1548e7df49df2bcdee6b84a94bfbe3a0d7eff16b14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
This allows making endpoints more configurable, for now it just allows setting header but in the future this can be extended to other options such as weighting, rate limits.

This is an initial part of https://github.com/subquery/subql/issues/1925

### Example manifest

```ts
// Network portion of a manifest
network: {
    /* The genesis hash of the network (hash of block 0) */
    chainId:
      "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
    endpoint: {
      "wss://kusama.api.onfinality.io/public-ws": {
        headers: {
          'api-key': 'YOUR_API_KEY',
        }
      },
      "wss://kusama-rpc.polkadot.io": {},
    },
    bypassBlocks: [1, 2, 3, '4-5'],
  },
```

```yaml
network:
  chainId: '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe'
  endpoint:
    wss://kusama.api.onfinality.io/public-ws:
      headers:
        api-key: YOUR_API_KEY
    wss://kusama-rpc.polkadot.io:
  bypassBlocks:
    - 1
    - 2
    - 3
    - 4-5
```

### Example cli

`subql-node -f ./path/to/project --network-endpoint="wss://kusama.api.onfinality.io/public-ws" --network-endpoint-config='{ "headers": { "api-key": "<your-api-key>"}}'`


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/548
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
