### PR TITLE
chore: Update PostgreSQL connection pool handling

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update how idle psql pool connections are handled (#2520)
 
 ## [2.14.0] - 2024-08-05
 ### Changed

--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import assert from 'assert';
+import {setInterval} from 'timers';
 import PgPubSub from '@graphile/pg-pubsub';
 import {Module, OnModuleDestroy, OnModuleInit} from '@nestjs/common';
 import {HttpAdapterHost} from '@nestjs/core';
@@ -127,6 +128,18 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  private setupKeepAlive(pgClient) {
+    setInterval(() => {
+      (async () => {
+        try {
+          await pgClient.query('SELECT 1');
+        } catch (err) {
+          getLogger('db').error('Schema listener client keep-alive query failed: ', err);
+        }
+      })();
+    }, this.config.get('keep_alive_interval'));
+  }
+
   private async createServer() {
     const app = this.httpAdapterHost.httpAdapter.getInstance();
     const httpServer = this.httpAdapterHost.httpAdapter.getHttpServer();
@@ -164,6 +177,14 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
       try {
         const pgClient = await this.pgPool.connect();
         await pgClient.query(`LISTEN "${hashName(dbSchema, 'schema_channel', '_metadata')}"`);
+
+        // Set up a keep-alive interval to prevent the connection from being killed
+        this.setupKeepAlive(pgClient);
+
+        pgClient.on('error', (err: Error) => {
+          getLogger('db').error('PostgreSQL schema listener client error: ', err);
+          process.exit(1);
+        });
 
         pgClient.on('notification', (msg) => {
           if (msg.payload === 'schema_updated') {

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -151,6 +151,12 @@ export function getYargsOption() {
         type: 'boolean',
         default: false,
       },
+      'keep-alive-interval': {
+        demandOption: false,
+        describe: 'Schema listener keep-alive interval in milliseconds',
+        type: 'number',
+        default: 180000,
+      },
     });
 }
 


### PR DESCRIPTION
# Description

This adds a better handling of db pool connections that are explicitly used in the code to verify SSL settings and to setup the database schema-change listener. These two clients were sitting idle either doing nothing or listening for a rare event of a schema change.

In environments where idle tcp connections are killed eventually, these connections were killed and that caused the whole app was killed due to uncaught exception.

Fixes ([#2520 ](https://github.com/subquery/subql/issues/2520))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
