### PR TITLE
Update PostgreSQL connection pool handling

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Revert yargs version
 
+### Changed
+- Update how idle psql pool connections are handled (#2520)
+
 ## [2.14.0] - 2024-08-05
 ### Changed
 - Update dependencies (#2518)

--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -20,7 +20,7 @@ import {NextFunction, Request, Response} from 'express';
 import PinoLogger from 'express-pino-logger';
 import {execute, GraphQLSchema, subscribe} from 'graphql';
 import {set} from 'lodash';
-import {Pool} from 'pg';
+import {Pool, PoolClient} from 'pg';
 import {makePluginHook} from 'postgraphile';
 import {SubscriptionServer} from 'subscriptions-transport-ws';
 import {Config} from '../configure';
@@ -128,9 +128,9 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  private setupKeepAlive(pgClient) {
+  private setupKeepAlive(pgClient: PoolClient) {
     setInterval(() => {
-      (async () => {
+      void (async () => {
         try {
           await pgClient.query('SELECT 1');
         } catch (err) {

--- a/packages/query/src/yargs.ts
+++ b/packages/query/src/yargs.ts
@@ -151,6 +151,12 @@ export function getYargsOption() {
         type: 'boolean',
         default: false,
       },
+      'sl-keep-alive-interval': {
+        demandOption: false,
+        describe: 'Schema listener keep-alive interval in milliseconds',
+        type: 'number',
+        default: 180000,
+      },
     });
 }
 


### PR DESCRIPTION
# Description

This improves the handling of database pool connections that are explicitly used in the code to verify SSL settings and to set up the database schema-change listener. Previously, these two clients were either idle or waiting for the rare event of a schema change.

In environments where idle TCP connections are eventually killed, these connections were terminated, causing the entire app to crash due to an uncaught exception.

Additionally, an error handler has been attached to the schema change PostgreSQL client to listen for `error` events. This should improve visibility into any issues that arise. When an error occurs, it will be logged, and the application will be terminated to prevent potential data corruption.

Fixes ([#2520 ](https://github.com/subquery/subql/issues/2520))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)