### PR TITLE
add support for null ordering in 'order by' query (#2387)

### DIFF
--- a/packages/cli/src/controller/codegen-controller.test.ts
+++ b/packages/cli/src/controller/codegen-controller.test.ts
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import {rimraf} from 'rimraf';
-import {codegen, generateModels} from './codegen-controller';
+import {codegen} from './codegen-controller';
 
 jest.setTimeout(30000);
 
@@ -95,9 +95,6 @@ describe('Codegen can generate schema', () => {
 
     const fooFile = await fs.promises.readFile(`${projectPath}/src/types/models/Foo.ts`, 'utf8');
 
-    const fooFile2 = await fs.promises.readFile(`${projectPath}/src/types/models/index.ts`, 'utf8');
-    console.log(fooFile2);
-    expect(fooFile2).toContain(` `);
     expect(fooFile).toContain(
       `import {
     Bar,

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update dependencies (#2518)
 
+### Added
+- add support for null ordering in 'order by' query (#2387)
+
 ## [2.13.3] - 2024-07-25
 ### Changed
 - Bump version with `@subql/common` and `@subql/utils` (#2498)


### PR DESCRIPTION
# Description
adds support for null ordering in 'order by' query

Fixes #2387 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [X] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [X] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
