### PR TITLE
fix case sensitive import for schema entities in codegen (#2211)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- fix case sensitive import for schema entities in codegen (#2211)
 
 ## [5.2.1] - 2024-08-12
 ### Changed

--- a/packages/cli/src/controller/codegen-controller.test.ts
+++ b/packages/cli/src/controller/codegen-controller.test.ts
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import {rimraf} from 'rimraf';
-import {codegen} from './codegen-controller';
+import {codegen, generateModels} from './codegen-controller';
 
 jest.setTimeout(30000);
 
@@ -95,10 +95,23 @@ describe('Codegen can generate schema', () => {
 
     const fooFile = await fs.promises.readFile(`${projectPath}/src/types/models/Foo.ts`, 'utf8');
 
+    const fooFile2 = await fs.promises.readFile(`${projectPath}/src/types/models/index.ts`, 'utf8');
+    console.log(fooFile2);
+    expect(fooFile2).toContain(` `);
     expect(fooFile).toContain(
       `import {
     Bar,
 } from '../enums';`
     );
+  });
+
+  // github issue #2211
+  it('codegen file should import model files with correct case-sensitive names', async () => {
+    const projectPath = path.join(__dirname, '../../test/schemaTest');
+    await codegen(projectPath, ['project-case-sensitive-import-entity.yaml']);
+
+    const codegenFile = await fs.promises.readFile(`${projectPath}/src/types/models/index.ts`, 'utf8');
+
+    expect(codegenFile).toContain(`export {ExampleField} from "./ExampleField"`);
   });
 });

--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -326,7 +326,7 @@ export async function generateModels(projectPath: string, schema: string): Promi
     }
     console.log(`* Schema ${className} generated !`);
   }
-  const classNames = extractEntities.models.map((entity) => entity.name);
+  const classNames = extractEntities.models.map((entity) => upperFirst(entity.name));
   if (classNames.length !== 0) {
     try {
       await renderTemplate(MODELS_INDEX_TEMPLATE_PATH, path.join(projectPath, MODEL_ROOT_DIR, `index.ts`), {

--- a/packages/cli/test/schemaTest/camelcaseEntityName.graphql
+++ b/packages/cli/test/schemaTest/camelcaseEntityName.graphql
@@ -1,0 +1,3 @@
+type exampleField @entity {
+  id: ID!
+}

--- a/packages/cli/test/schemaTest/project-case-sensitive-import-entity.yaml
+++ b/packages/cli/test/schemaTest/project-case-sensitive-import-entity.yaml
@@ -1,0 +1,23 @@
+specVersion: '1.0.0'
+description: ''
+repository: 'https://github.com/subquery/subql-starter'
+schema:
+  file: './camelcaseEntityName.graphql'
+runner:
+  node:
+    name: '@subql/node'
+    version: '>=3.0.1'
+  query:
+    name: '@subql/query'
+    version: '*'
+network:
+  endpoint: 'wss://polkadot.api.onfinality.io/public-ws'
+
+dataSources:
+  - name: main
+    kind: substrate/Runtime
+    startBlock: 1
+    mapping:
+      handlers:
+        - handler: handleBlock
+          kind: substrate/BlockHandler


### PR DESCRIPTION
# Description
fix the case sensitive import for schema entities in codegen command

Fixes #2211 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [X] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [X] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] My code is up to date with the base branch
- [X] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
