### PR TITLE
Reuse tmp dir for ipfs based projects

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Expose CID on IPFS Reader (#2551)
 
 ## [5.1.1] - 2024-08-14
 ### Added

--- a/packages/common/src/project/readers/ipfs-reader.ts
+++ b/packages/common/src/project/readers/ipfs-reader.ts
@@ -17,7 +17,7 @@ export class IPFSReader implements Reader {
   private ipfs: IPFSHTTPClientLite;
   private cache: Record<string, Promise<string>> = {};
 
-  constructor(private readonly cid: string, gateway?: string) {
+  constructor(readonly cid: string, gateway?: string) {
     if (!CIDv0.test(cid) && !CIDv1.test(cid)) {
       throw new Error('IPFS project path CID is not valid');
     }

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Reuse the same temp dir when project is from IPFS (#2551)
 
 ## [14.1.3] - 2024-08-30
 ### Fixed


### PR DESCRIPTION
# Description
If a project is from IPFS we will reuse the same temp dir now. This can save disk space if there are restarts and new temp dirs are created each time and not cleaned up

Fixes https://github.com/subquery/subql/issues/2545

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
