### PR TITLE
Rework bypass blocks to not expand large block ranges

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issues with setting a large block range for bypass blocks (#2566)
 
 ## [14.1.5] - 2024-09-25
 ### Changed

--- a/packages/node-core/src/indexer/fetch.service.spec.ts
+++ b/packages/node-core/src/indexer/fetch.service.spec.ts
@@ -624,9 +624,6 @@ describe('Fetch Service', () => {
 
     await fetchService.init(1);
 
-    // This doesn't work as they get removed after that height is processed
-    // expect((fetchService as any).bypassBlocks).toEqual([2, 3, 4, 5]);
-
     // Note the batch size is smaller because we exclude from the initial batch size
     expect(enqueueBlocksSpy).toHaveBeenCalledWith([1, 6, 7, 8, 9, 10], 10);
   });

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -359,7 +359,7 @@ export abstract class BaseFetchService<DS extends BaseDataSource, B extends IBlo
       const currentDS = datasources.get(currentHeight);
       // If the value for the current height is an empty array, then it's a gap
       if (currentDS?.length === 0) {
-        bypassBlocks.push(`${currentHeight}-${nextHeight}`);
+        bypassBlocks.push(`${currentHeight}-${nextHeight - 1}`);
       }
     }
     return bypassBlocks;

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -5,7 +5,7 @@ import assert from 'assert';
 import {OnApplicationShutdown} from '@nestjs/common';
 import {EventEmitter2} from '@nestjs/event-emitter';
 import {SchedulerRegistry} from '@nestjs/schedule';
-import {BaseDataSource, IProjectNetworkConfig} from '@subql/types-core';
+import {BaseDataSource} from '@subql/types-core';
 import {range} from 'lodash';
 import {NodeConfig} from '../configure';
 import {IndexerEvent} from '../events';
@@ -27,7 +27,6 @@ export abstract class BaseFetchService<DS extends BaseDataSource, B extends IBlo
   private _latestBestHeight?: number;
   private _latestFinalizedHeight?: number;
   private isShutdown = false;
-  // private bypassBlocks: number[] = [];
 
   // If the chain doesn't have a distinction between the 2 it should return the same value for finalized and best
   protected abstract getFinalizedHeader(): Promise<Header>;
@@ -47,7 +46,6 @@ export abstract class BaseFetchService<DS extends BaseDataSource, B extends IBlo
   constructor(
     private nodeConfig: NodeConfig,
     protected projectService: IProjectService<DS>,
-    protected networkConfig: IProjectNetworkConfig,
     protected blockDispatcher: B,
     protected dictionaryService: DictionaryService<DS, FB>,
     private eventEmitter: EventEmitter2,

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -2,22 +2,21 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import assert from 'assert';
-import util from 'util';
 import {OnApplicationShutdown} from '@nestjs/common';
 import {EventEmitter2} from '@nestjs/event-emitter';
 import {SchedulerRegistry} from '@nestjs/schedule';
 import {BaseDataSource, IProjectNetworkConfig} from '@subql/types-core';
-import {range, without} from 'lodash';
+import {range} from 'lodash';
 import {NodeConfig} from '../configure';
 import {IndexerEvent} from '../events';
 import {getLogger} from '../logger';
-import {cleanedBatchBlocks, delay, transformBypassBlocks, waitForBatchSize} from '../utils';
+import {delay, filterBypassBlocks, waitForBatchSize} from '../utils';
 import {IBlockDispatcher} from './blockDispatcher';
 import {mergeNumAndBlocksToNums} from './dictionary';
 import {DictionaryService} from './dictionary/dictionary.service';
-import {getBlockHeight, mergeNumAndBlocks} from './dictionary/utils';
+import {mergeNumAndBlocks} from './dictionary/utils';
 import {StoreCacheService} from './storeCache';
-import {Header, IBlock, IProjectService} from './types';
+import {BypassBlocks, Header, IBlock, IProjectService} from './types';
 import {IUnfinalizedBlocksServiceUtil} from './unfinalizedBlocks.service';
 
 const logger = getLogger('FetchService');
@@ -28,7 +27,7 @@ export abstract class BaseFetchService<DS extends BaseDataSource, B extends IBlo
   private _latestBestHeight?: number;
   private _latestFinalizedHeight?: number;
   private isShutdown = false;
-  private bypassBlocks: number[] = [];
+  // private bypassBlocks: number[] = [];
 
   // If the chain doesn't have a distinction between the 2 it should return the same value for finalized and best
   protected abstract getFinalizedHeader(): Promise<Header>;
@@ -77,31 +76,7 @@ export abstract class BaseFetchService<DS extends BaseDataSource, B extends IBlo
     this.isShutdown = true;
   }
 
-  private updateBypassBlocksFromDatasources(): void {
-    const datasources = this.projectService.getDataSourcesMap().getAll();
-
-    const heights = Array.from(datasources.keys());
-
-    for (let i = 0; i < heights.length - 1; i++) {
-      const currentHeight = heights[i];
-      const nextHeight = heights[i + 1];
-
-      const currentDS = datasources.get(currentHeight);
-      // If the value for the current height is an empty array, then it's a gap
-      if (currentDS && currentDS.length === 0) {
-        this.bypassBlocks.push(...range(currentHeight, nextHeight));
-      }
-    }
-  }
-
   async init(startHeight: number): Promise<void> {
-    this.bypassBlocks = [];
-
-    if (this.networkConfig?.bypassBlocks !== undefined) {
-      this.bypassBlocks = transformBypassBlocks(this.networkConfig.bypassBlocks).filter((blk) => blk >= startHeight);
-    }
-
-    this.updateBypassBlocksFromDatasources();
     const interval = await this.getChainInterval();
 
     await Promise.all([this.getFinalizedBlockHead(), this.getBestBlockHead()]);
@@ -344,49 +319,52 @@ export abstract class BaseFetchService<DS extends BaseDataSource, B extends IBlo
   }
 
   private async enqueueBlocks(enqueuingBlocks: (IBlock<FB> | number)[], latestHeight: number): Promise<void> {
-    const cleanedBatchBlocks = this.filteredBlockBatch(enqueuingBlocks);
+    const cleanedBatchBlocks = filterBypassBlocks<FB>(enqueuingBlocks, [
+      ...this.projectService.bypassBlocks,
+      ...this.getDatasourceBypassBlocks(),
+    ]);
     await this.blockDispatcher.enqueueBlocks(
       cleanedBatchBlocks,
-      this.getLatestBufferHeight(cleanedBatchBlocks, enqueuingBlocks, latestHeight)
+      this.getLatestBufferHeight(enqueuingBlocks, latestHeight)
     );
   }
 
   /**
    *
-   * @param cleanedBatchBlocks
    * @param rawBatchBlocks
    * @param latestHeight
    * @private
    */
-  private getLatestBufferHeight(
-    cleanedBatchBlocks: (IBlock<FB> | number)[],
-    rawBatchBlocks: (IBlock<FB> | number)[],
-    latestHeight: number
-  ): number {
+  private getLatestBufferHeight(rawBatchBlocks: (IBlock<FB> | number)[], latestHeight: number): number {
     // When both BatchBlocks are empty, mean no blocks to enqueue and full synced,
     // we are safe to update latestBufferHeight to this number
-    if (cleanedBatchBlocks.length === 0 && rawBatchBlocks.length === 0) {
+    if (rawBatchBlocks.length === 0) {
       return latestHeight;
     }
-    return Math.max(...mergeNumAndBlocksToNums(cleanedBatchBlocks, rawBatchBlocks));
+    return Math.max(...mergeNumAndBlocksToNums([], rawBatchBlocks));
   }
 
-  private filteredBlockBatch(currentBatchBlocks: (number | IBlock<FB>)[]): (number | IBlock<FB>)[] {
-    if (!this.bypassBlocks.length || !currentBatchBlocks) {
-      return currentBatchBlocks;
-    }
+  /**
+   * If a projects datasources are not continuious we can add add them to the bypass blocks
+   * */
+  private getDatasourceBypassBlocks(): BypassBlocks {
+    const datasources = this.projectService.getDataSourcesMap().getAll();
 
-    const cleanedBatch = cleanedBatchBlocks(this.bypassBlocks, currentBatchBlocks);
+    const heights = Array.from(datasources.keys());
 
-    const pollutedBlocks = this.bypassBlocks.filter(
-      (b) => b < Math.max(...currentBatchBlocks.map((b) => getBlockHeight(b)))
-    );
-    if (pollutedBlocks.length) {
-      // inspect limits the number of logged blocks to 100
-      logger.info(`Bypassing blocks: ${util.inspect(pollutedBlocks, {maxArrayLength: 100})}`);
+    const bypassBlocks: BypassBlocks = [];
+
+    for (let i = 0; i < heights.length - 1; i++) {
+      const currentHeight = heights[i];
+      const nextHeight = heights[i + 1];
+
+      const currentDS = datasources.get(currentHeight);
+      // If the value for the current height is an empty array, then it's a gap
+      if (currentDS?.length === 0) {
+        bypassBlocks.push(`${currentHeight}-${nextHeight}`);
+      }
     }
-    this.bypassBlocks = without(this.bypassBlocks, ...pollutedBlocks);
-    return cleanedBatch;
+    return bypassBlocks;
   }
 
   private nextEndBlockHeight(startBlockHeight: number, scaledBatchSize: number): number {

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -19,7 +19,7 @@ import {MetadataKeys} from './entities';
 import {PoiSyncService} from './poi';
 import {PoiService} from './poi/poi.service';
 import {StoreService} from './store.service';
-import {ISubqueryProject, IProjectService} from './types';
+import {ISubqueryProject, IProjectService, BypassBlocks} from './types';
 import {IUnfinalizedBlocksService} from './unfinalizedBlocks.service';
 
 const logger = getLogger('Project');
@@ -33,7 +33,7 @@ class NotInitError extends Error {
 export abstract class BaseProjectService<
   API extends IApi,
   DS extends BaseDataSource,
-  UnfinalizedBlocksService extends IUnfinalizedBlocksService<any> = IUnfinalizedBlocksService<any>,
+  UnfinalizedBlocksService extends IUnfinalizedBlocksService<any> = IUnfinalizedBlocksService<any>
 > implements IProjectService<DS>
 {
   private _schema?: string;
@@ -81,6 +81,10 @@ export abstract class BaseProjectService<
 
   get blockOffset(): number | undefined {
     return this._blockOffset;
+  }
+
+  get bypassBlocks(): BypassBlocks {
+    return this.project.network.bypassBlocks ?? [];
   }
 
   protected get isHistorical(): boolean {

--- a/packages/node-core/src/indexer/types.ts
+++ b/packages/node-core/src/indexer/types.ts
@@ -16,7 +16,7 @@ export interface ISubqueryProject<
   N extends IProjectNetworkConfig = IProjectNetworkConfig,
   DS extends BaseDataSource = BaseDataSource,
   T extends BaseTemplateDataSource<DS> = BaseTemplateDataSource<DS>,
-  C = unknown,
+  C = unknown
 > extends Omit<CommonSubqueryProject<N, DS, T>, 'schema' | 'version' | 'name' | 'specVersion' | 'description'> {
   readonly schema: GraphQLSchema;
   applyCronTimestamps: (getBlockTimestamp: (height: number) => Promise<Date | undefined>) => Promise<void>;
@@ -43,6 +43,7 @@ export interface IIndexerManager<B, DS> {
 export interface IProjectService<DS> {
   blockOffset: number | undefined;
   startHeight: number;
+  bypassBlocks: BypassBlocks;
   reindex(lastCorrectHeight: number): Promise<void>;
   /**
    * This is used everywhere but within indexing blocks, see comment on getDataSources for more info
@@ -68,3 +69,5 @@ export type Header = {
   blockHash: string;
   parentHash: string | undefined;
 };
+
+export type BypassBlocks = (number | `${number}-${number}`)[];

--- a/packages/node-core/src/utils/blocks.spec.ts
+++ b/packages/node-core/src/utils/blocks.spec.ts
@@ -2,28 +2,28 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {range} from 'lodash';
-import {transformBypassBlocks, cleanedBatchBlocks} from './blocks';
+import {BypassBlocks} from '../indexer';
+import {filterBypassBlocks} from './blocks';
 
 describe('bypass logic', () => {
   it('process bypassBlocks with ranges', () => {
-    let bypassBlocks = transformBypassBlocks([20, 40, '5-10', 20, 140]);
-    expect(bypassBlocks).toEqual([20, 40, 5, 6, 7, 8, 9, 10, 140]);
+    let bypassBlocks: BypassBlocks = [20, 40, '5-10', 20, 140];
     let currentBlockBatch = [1, 5, 7, 8, 20, 40, 100, 120];
-    const case_1 = cleanedBatchBlocks(bypassBlocks, currentBlockBatch);
+    const case_1 = filterBypassBlocks(currentBlockBatch, bypassBlocks);
 
     expect(case_1).toEqual([1, 100, 120]);
 
-    bypassBlocks = transformBypassBlocks([' 5 - 10 ', 20, 140]);
+    bypassBlocks = [' 5 - 10 ', 20, 140];
     currentBlockBatch = [1, 5, 7, 8, 20, 40, 100, 120];
-    const case_2 = cleanedBatchBlocks(bypassBlocks, currentBlockBatch);
+    const case_2 = filterBypassBlocks(currentBlockBatch, bypassBlocks);
 
     expect(case_2).toEqual([1, 40, 100, 120]);
   });
 
   it('cleanedBatchBlocks with large amount blocks should not throw error Maximum call stack size exceeded', () => {
-    const bypassBlocks = transformBypassBlocks(['50051722-54939220']);
+    const bypassBlocks: BypassBlocks = ['50051722-54939220'];
     const currentBlockBatch = range(34312396, 34312495);
-    const case_1 = cleanedBatchBlocks(bypassBlocks, currentBlockBatch);
+    const case_1 = filterBypassBlocks(currentBlockBatch, bypassBlocks);
     expect(case_1).toEqual(currentBlockBatch);
   });
 });

--- a/packages/node-core/src/utils/blocks.ts
+++ b/packages/node-core/src/utils/blocks.ts
@@ -2,41 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {Schedule} from 'cron-converter';
-import {chunk, flatten, isNumber, range, uniq, without} from 'lodash';
 import {getBlockHeight} from '../indexer/dictionary';
-import {IBlock} from '../indexer/types';
+import {BypassBlocks, IBlock} from '../indexer/types';
 import {getLogger} from '../logger';
-
-export function cleanedBatchBlocks<FB>(
-  bypassBlocks: number[],
-  currentBlockBatch: (IBlock<FB> | number)[]
-): (IBlock<FB> | number)[] {
-  // Use suggested work around to avoid Maximum call stack size exceeded issue when large numbers of transformedBlocks
-  // https://github.com/lodash/lodash/issues/5552
-  const transformedBlocks = transformBypassBlocks(bypassBlocks);
-  let result = currentBlockBatch;
-  chunk(transformedBlocks, 10000).forEach((chunk) => {
-    result = without(
-      result.map((r) => getBlockHeight(r)),
-      ...chunk
-    );
-  });
-  return result;
-}
-
-export function transformBypassBlocks(bypassBlocks: (number | string)[]): number[] {
-  if (!bypassBlocks?.length) return [];
-
-  return uniq(
-    flatten(
-      bypassBlocks.map((bypassEntry) => {
-        if (isNumber(bypassEntry)) return [bypassEntry];
-        const splitRange = bypassEntry.split('-').map((val) => parseInt(val.trim(), 10));
-        return range(splitRange[0], splitRange[1] + 1);
-      })
-    )
-  );
-}
 
 const logger = getLogger('timestamp-filter');
 
@@ -60,4 +28,27 @@ export function filterBlockTimestamp(blockTimestamp: number, filter: CronFilter)
     filter.cronSchedule.schedule.prev();
     return false;
   }
+}
+
+/**
+ * Takes a list of blocks or block numbers to be enqueued and indexed and removes any based on the bypassBlocks
+ * */
+export function filterBypassBlocks<B = any>(
+  enqueuedBlocks: (IBlock<B> | number)[],
+  bypassBlocks?: BypassBlocks
+): (IBlock<B> | number)[] {
+  if (!bypassBlocks?.length) return enqueuedBlocks;
+
+  return enqueuedBlocks.filter((b) => {
+    if (typeof b === 'number') !inBypassBlocks(bypassBlocks, b);
+    return !inBypassBlocks(bypassBlocks, getBlockHeight(b));
+  });
+}
+
+function inBypassBlocks(bypassBlocks: BypassBlocks, blockNum: number): boolean {
+  return bypassBlocks.some((bypassEntry) => {
+    if (typeof bypassEntry === 'number') return bypassEntry === blockNum;
+    const splitRange = bypassEntry.split('-').map((val) => parseInt(val.trim(), 10));
+    return blockNum >= splitRange[0] && blockNum <= splitRange[1];
+  });
 }

--- a/packages/node-core/src/utils/blocks.ts
+++ b/packages/node-core/src/utils/blocks.ts
@@ -32,6 +32,7 @@ export function filterBlockTimestamp(blockTimestamp: number, filter: CronFilter)
 
 /**
  * Takes a list of blocks or block numbers to be enqueued and indexed and removes any based on the bypassBlocks
+ * TODO this could further be optimised by returning the end of a block range to fast forward to.
  * */
 export function filterBypassBlocks<B = any>(
   enqueuedBlocks: (IBlock<B> | number)[],
@@ -48,7 +49,7 @@ export function filterBypassBlocks<B = any>(
 function inBypassBlocks(bypassBlocks: BypassBlocks, blockNum: number): boolean {
   return bypassBlocks.some((bypassEntry) => {
     if (typeof bypassEntry === 'number') return bypassEntry === blockNum;
-    const splitRange = bypassEntry.split('-').map((val) => parseInt(val.trim(), 10));
-    return blockNum >= splitRange[0] && blockNum <= splitRange[1];
+    const [start, end] = bypassEntry.split('-').map((val) => parseInt(val.trim(), 10));
+    return blockNum >= start && blockNum <= end;
   });
 }

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issues with setting a large block range for bypass blocks (#2566)
 
 ## [5.2.6] - 2024-09-25
 ### Changed

--- a/packages/node/src/indexer/fetch.service.spec.ts
+++ b/packages/node/src/indexer/fetch.service.spec.ts
@@ -63,7 +63,6 @@ describe('FetchSevice', () => {
       null as any, // ApiService
       null as any, // NodeConfig
       projectService, // ProjectService
-      {} as any, // Project
       null as any, // BlockDispatcher,
       null as any, // DictionaryService
       null as any, // UnfinalizedBlocks

--- a/packages/node/src/indexer/fetch.service.test.ts
+++ b/packages/node/src/indexer/fetch.service.test.ts
@@ -26,7 +26,6 @@ describe('FetchService', () => {
       apiService, // ApiService
       null as any, // NodeConfig
       null as any, // ProjectService
-      {} as any, // Project
       null as any, // BlockDispatcher,
       null as any, // DictionaryService
       {

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -15,7 +15,6 @@ import {
   StoreCacheService,
 } from '@subql/node-core';
 import { SubstrateDatasource, SubstrateBlock } from '@subql/types';
-import { SubqueryProject } from '../configure/SubqueryProject';
 import { calcInterval, substrateHeaderToHeader } from '../utils/substrate';
 import { ApiService } from './api.service';
 import { ISubstrateBlockDispatcher } from './blockDispatcher/substrate-block-dispatcher';
@@ -37,7 +36,6 @@ export class FetchService extends BaseFetchService<
     private apiService: ApiService,
     nodeConfig: NodeConfig,
     @Inject('IProjectService') projectService: ProjectService,
-    @Inject('ISubqueryProject') project: SubqueryProject,
     @Inject('IBlockDispatcher')
     blockDispatcher: ISubstrateBlockDispatcher,
     dictionaryService: SubstrateDictionaryService,
@@ -50,7 +48,6 @@ export class FetchService extends BaseFetchService<
     super(
       nodeConfig,
       projectService,
-      project.network,
       blockDispatcher,
       dictionaryService,
       eventEmitter,


### PR DESCRIPTION
# Description
If a large range of blocks was specified to be bypassed, then it could result in array/map size limits. This change simplifies the logic to calculate bypass blocks, as well as no longer expanding block ranges to individual blocks. 

Fixes https://github.com/subquery/subql/issues/2565

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
