### PR TITLE
Update store interface so limit is required on getByField(s) methods

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Improve codegen error messages (#2567)
+- Update codegen to match changes to store interface making options.limit required on getByField(s) methods (#2567)
 
 ## [5.2.8] - 2024-09-25
 ### Changed

--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -91,7 +91,7 @@ export async function generateJsonInterfaces(projectPath: string, schema: string
       await renderTemplate(INTERFACE_TEMPLATE_PATH, path.join(typesDir, `interfaces.ts`), interfaceTemplate);
       exportTypes.interfaces = true;
     } catch (e) {
-      throw new Error(`When render json interfaces having problems.`);
+      throw new Error(`Codegen failed for json interface.`, {cause: e});
     }
   }
 }
@@ -116,7 +116,7 @@ export async function generateEnums(projectPath: string, schema: string): Promis
       await renderTemplate(ENUM_TEMPLATE_PATH, path.join(typesDir, `enums.ts`), enumsTemplate);
       exportTypes.enums = true;
     } catch (e) {
-      throw new Error(`When render enums having problems.`);
+      throw new Error(`Codegen failed for enums.`, {cause: e});
     }
   }
 }
@@ -262,7 +262,7 @@ export async function codegen(projectPath: string, fileNames: string[] = [DEFAUL
         },
       });
     } catch (e) {
-      throw new Error(`When render index in types having problems.`);
+      throw new Error(`Codegen failed for indexes.`, {cause: e});
     }
     console.log(`* Types index generated !`);
   }
@@ -322,7 +322,7 @@ export async function generateModels(projectPath: string, schema: string): Promi
       );
     } catch (e) {
       console.error(e);
-      throw new Error(`When render entity ${className} to schema having problems.`);
+      throw new Error(`Codegen failed for entity ${className}.`, {cause: e});
     }
     console.log(`* Schema ${className} generated !`);
   }
@@ -339,7 +339,7 @@ export async function generateModels(projectPath: string, schema: string): Promi
       });
       exportTypes.models = true;
     } catch (e) {
-      throw new Error(`When render index in models having problems.`);
+      throw new Error(`Failed to codgen for model indexes.`, {cause: e});
     }
     console.log(`* Models index generated !`);
   }

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -2,16 +2,16 @@
 import {Entity, FunctionPropertyNames, FieldsExpression, GetOptions } from "@subql/types-core";
 import assert from 'assert';
 <%if (props.importJsonInterfaces.length !== 0) { %>
-import {<% props.importJsonInterfaces.forEach(function(interface){ %>
+import { <% props.importJsonInterfaces.forEach(function(interface){ %>
     <%= interface %>,
 <% }); %>} from '../interfaces';
 <% } %>
 <%if (props.importEnums.length !== 0) { %>
-import {<% props.importEnums.forEach(function(e){ %>
+import { <% props.importEnums.forEach(function(e){ %>
     <%= e %>,
 <% }); %>} from '../enums';<% } %>
 
-export type <%= props.className %>Props = Omit<<%=props.className %>, NonNullable<FunctionPropertyNames<<%=props.className %>>>| '_name'>;
+export type <%= props.className %>Props = Omit<<%=props.className %>, NonNullable<FunctionPropertyNames<<%=props.className %>>> | '_name'>;
 
 export class <%= props.className %> implements Entity {
 
@@ -30,18 +30,18 @@ export class <%= props.className %> implements Entity {
         return '<%=props.entityName %>';
     }
 
-    async save(): Promise<void>{
+    async save(): Promise<void> {
         let id = this.id;
         assert(id !== null, "Cannot save <%=props.className %> entity without an ID");
         await store.set('<%=props.entityName %>', id.toString(), this);
     }
 
-    static async remove(id:string): Promise<void>{
+    static async remove(id: string): Promise<void> {
         assert(id !== null, "Cannot remove <%=props.className %> entity without an ID");
         await store.remove('<%=props.entityName %>', id.toString());
     }
 
-    static async get(id:string): Promise<<%=props.className %> | undefined>{
+    static async get(id: string): Promise<<%=props.className %> | undefined> {
         assert((id !== null && id !== undefined), "Cannot get <%=props.className %> entity without an ID");
         const record = await store.get('<%=props.entityName %>', id.toString());
         if (record) {
@@ -51,17 +51,21 @@ export class <%= props.className %> implements Entity {
         }
     }
 <% props.indexedFields.forEach(function(field){ %>
-    static async getBy<%=helper.upperFirst(field.name) %>(<%=field.name %>: <%=field.type %>): Promise<<%=props.className %><%=field.unique ? '' : '[]' %> | undefined>{
-      <% if (field.unique) {%>
-      const record = await store.getOneByField('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>);
-      if (record) {
-          return this.create(record as <%= props.className %>Props);
-      } else {
-          return;
-      }
-      <% } else { %>const records = await store.getByField('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>);
-      return records.map(record => this.create(record as <%= props.className %>Props));<% }%>
+    <% if (field.unique) {%>
+
+    static async getBy<%=helper.upperFirst(field.name) %>(<%=field.name %>: <%=field.type %>): Promise<<%=props.className %> | undefined> {
+        const record = await store.getOneByField('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>);
+        if (record) {
+            return this.create(record as <%= props.className %>Props);
+        } else {
+            return;
+        }
     }
+    <% } else { %>static async getBy<%=helper.upperFirst(field.name) %>(<%=field.name %>: <%=field.type %>, options: GetOptions<<%=props.className %>>): Promise<<%=props.className %>[]> {
+        const records = await store.getByField<<%=props.className %>>('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>, options);
+        return records.map(record => this.create(record as <%= props.className %>Props));
+    }
+    <% }%>
 <% }); %>
 
     /**
@@ -69,8 +73,8 @@ export class <%= props.className %> implements Entity {
      *
      * ⚠️ This function will first search cache data followed by DB data. Please consider this when using order and offset options.⚠️
      * */
-    static async getByFields(filter: FieldsExpression<<%= props.className %>Props>[], options?: GetOptions<<%= props.className %>Props>): Promise<<%=props.className %>[]> {
-        const records = await store.getByFields('<%=props.entityName %>', filter, options);
+    static async getByFields(filter: FieldsExpression<<%= props.className %>Props>[], options: GetOptions<<%= props.className %>Props>): Promise<<%=props.className %>[]> {
+        const records = await store.getByFields<<%=props.className %>>('<%=props.entityName %>', filter, options);
         return records.map(record => this.create(record as <%= props.className %>Props));
     }
 

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -7,7 +7,7 @@ import { <% props.importJsonInterfaces.forEach(function(interface){ %>
 <% }); %>} from '../interfaces';
 <% } %>
 <%if (props.importEnums.length !== 0) { %>
-import { <% props.importEnums.forEach(function(e){ %>
+import {<% props.importEnums.forEach(function(e){ %>
     <%= e %>,
 <% }); %>} from '../enums';<% } %>
 

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Issues with setting a large block range for bypass blocks (#2566)
 - Test runner not setting lastProcessedHeight leading to data not being flushed (#2569)
+### Changed
+- Throw error when store getByField(s) options.limit exceeds queryLimit option (#2567)
 
 ## [14.1.5] - 2024-09-25
 ### Changed

--- a/packages/node-core/src/indexer/store/store.ts
+++ b/packages/node-core/src/indexer/store/store.ts
@@ -4,15 +4,12 @@
 import assert from 'assert';
 import {Store as IStore, Entity, FieldsExpression, GetOptions} from '@subql/types-core';
 import {NodeConfig} from '../../configure';
-import {getLogger} from '../../logger';
 import {monitorWrite} from '../../process';
 import {handledStringify} from '../../utils';
 import {StoreCacheService} from '../storeCache';
 import {StoreOperations} from '../StoreOperations';
 import {OperationType} from '../types';
 import {EntityClass} from './entity';
-
-const logger = getLogger('Store');
 
 /* A context is provided to allow it to be updated by the owner of the class instance */
 type Context = {
@@ -34,17 +31,9 @@ export class Store implements IStore {
     this.#context = context;
   }
 
-  #queryLimitCheck(storeMethod: string, entity: string, options?: GetOptions<any>) {
-    if (options) {
-      if (options.limit && this.#config.queryLimit < options.limit) {
-        logger.warn(
-          `store ${storeMethod} for entity ${entity} with ${options.limit} records exceeds config limit ${
-            this.#config.queryLimit
-          }. Will use ${this.#config.queryLimit} as the limit.`
-        );
-      }
-
-      options.limit = options.limit ? Math.min(options.limit, this.#config.queryLimit) : this.#config.queryLimit;
+  #queryLimitCheck(storeMethod: string, entity: string, options: GetOptions<any>) {
+    if (options.limit > this.#config.queryLimit) {
+      throw new Error(`Query limit exceeds the maximum allowed value of ${this.#config.queryLimit}`);
     }
   }
 
@@ -62,7 +51,7 @@ export class Store implements IStore {
     entity: string,
     field: keyof T,
     value: T[keyof T] | T[keyof T][],
-    options: GetOptions<T> = {}
+    options: GetOptions<T>
   ): Promise<T[]> {
     try {
       const indexed = this.#context.isIndexed(entity, String(field));
@@ -81,7 +70,7 @@ export class Store implements IStore {
   async getByFields<T extends Entity>(
     entity: string,
     filter: FieldsExpression<T>[],
-    options?: GetOptions<T>
+    options: GetOptions<T>
   ): Promise<T[]> {
     try {
       // Check that the fields are indexed

--- a/packages/node-core/src/indexer/worker/worker.store.service.ts
+++ b/packages/node-core/src/indexer/worker/worker.store.service.ts
@@ -1,14 +1,23 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {Store, FieldsExpression, GetOptions} from '@subql/types-core';
+import {Store, FieldsExpression, GetOptions, Entity} from '@subql/types-core';
 import {unwrapProxyArgs} from './utils';
 
 export type HostStore = {
   // This matches the store interface
   storeGet: (entity: string, id: string) => Promise<any | null>;
-  storeGetByField: (entity: string, field: string, value: any, options?: GetOptions<any>) => Promise<any[]>;
-  storeGetByFields: (entity: string, filter: FieldsExpression<any>[], options?: GetOptions<any>) => Promise<any[]>;
+  storeGetByField: <T extends Entity>(
+    entity: string,
+    field: keyof T,
+    value: any,
+    options: GetOptions<T>
+  ) => Promise<T[]>;
+  storeGetByFields: <T extends Entity>(
+    entity: string,
+    filter: FieldsExpression<T>[],
+    options: GetOptions<T>
+  ) => Promise<T[]>;
   storeGetOneByField: (entity: string, field: string, value: any) => Promise<any | null>;
   storeSet: (entity: string, id: string, data: any) => Promise<void>;
   storeBulkCreate: (entity: string, data: any[]) => Promise<void>;
@@ -48,8 +57,8 @@ export const hostStoreToStore = (host: HostStore): Store => {
 export function storeHostFunctions(store: Store): HostStore {
   return {
     storeGet: store.get.bind(store),
-    storeGetByField: store.getByField.bind(store),
-    storeGetByFields: store.getByFields.bind(store),
+    storeGetByField: store.getByField.bind<any>(store),
+    storeGetByFields: store.getByFields.bind<any>(store),
     storeGetOneByField: store.getOneByField.bind(store),
     storeSet: store.set.bind(store),
     storeBulkCreate: store.bulkCreate.bind(store),

--- a/packages/types-core/CHANGELOG.md
+++ b/packages/types-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update store interface making options.limit required on getByField(s) methods (#2567)
 
 ## [1.1.1] - 2024-08-12
 ### Fixed

--- a/packages/types-core/src/store.ts
+++ b/packages/types-core/src/store.ts
@@ -20,8 +20,11 @@ export interface Entity {
 }
 
 export type GetOptions<T> = {
+  /**
+   * The number of items to return, if this exceeds the query-limit flag it will throw
+   * */
+  limit: number;
   offset?: number;
-  limit?: number;
   orderBy?: keyof T;
   orderDirection?: 'ASC' | 'DESC';
 };
@@ -33,11 +36,11 @@ export interface Store {
    *
    * ⚠️ This function will first search cache data followed by DB data. Please consider this when using order and offset options.⚠️
    * */
-  getByFields<T extends Entity>(entity: string, filter: FieldsExpression<T>[], options?: GetOptions<T>): Promise<T[]>;
+  getByFields<T extends Entity>(entity: string, filter: FieldsExpression<T>[], options: GetOptions<T>): Promise<T[]>;
   /**
    * This is an alias for getByFields with a single filter
    * */
-  getByField(entity: string, field: string, value: any, options?: GetOptions<Entity>): Promise<Entity[]>;
+  getByField<T extends Entity>(entity: string, field: keyof T, value: any, options: GetOptions<T>): Promise<T[]>;
   /**
    * This is an alias for getByField with limit set to 1
    * */


### PR DESCRIPTION
# Description
Updates codegen and store interfaces to make getByField(s) methods require specifying the limit. This is a breaking change at the type level only.

NOTE some tests are failing because they are testing projects that have an older version of the types interface. They will start working again after these changes have been released

Fixes https://github.com/subquery/subql/issues/2558

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/558
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
