### PR TITLE
Fix test runner not setting last processed height

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Issues with setting a large block range for bypass blocks (#2566)
+- Test runner not setting lastProcessedHeight leading to data not being flushed (#2569)
 
 ## [14.1.5] - 2024-09-25
 ### Changed

--- a/packages/node-core/src/indexer/fetch.service.spec.ts
+++ b/packages/node-core/src/indexer/fetch.service.spec.ts
@@ -326,7 +326,7 @@ describe('Fetch Service', () => {
 
     await fetchService.init(1);
 
-    expect((fetchService as any).getDatasourceBypassBlocks()).toEqual([`301-500`]);
+    expect((fetchService as any).getDatasourceBypassBlocks()).toEqual([`301-499`]);
   });
 
   it('checks chain heads at an interval', async () => {

--- a/packages/node-core/src/indexer/storeCache/cacheModel.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.ts
@@ -45,7 +45,7 @@ export class CachedModel<
     T extends {id: string; __block_range?: (number | null)[] | Fn} = {
       id: string;
       __block_range?: (number | null)[] | Fn;
-    },
+    }
   >
   extends Cacheable
   implements ICachedModel<T>, ICachedModelControl
@@ -352,16 +352,13 @@ export class CachedModel<
   }
 
   private filterRemoveRecordByHeight(blockHeight: number, lessEqt: boolean): Record<string, RemoveValue> {
-    return Object.entries(this.removeCache).reduce(
-      (acc, [key, value]) => {
-        if (lessEqt ? value.removedAtBlock <= blockHeight : value.removedAtBlock > blockHeight) {
-          acc[key] = value;
-        }
+    return Object.entries(this.removeCache).reduce((acc, [key, value]) => {
+      if (lessEqt ? value.removedAtBlock <= blockHeight : value.removedAtBlock > blockHeight) {
+        acc[key] = value;
+      }
 
-        return acc;
-      },
-      {} as Record<string, RemoveValue>
-    );
+      return acc;
+    }, {} as Record<string, RemoveValue>);
   }
 
   private filterRecordsWithHeight(blockHeight: number): FilteredHeightRecords<T> {

--- a/packages/node-core/src/indexer/storeCache/storeCache.service.ts
+++ b/packages/node-core/src/indexer/storeCache/storeCache.service.ts
@@ -173,6 +173,7 @@ export class StoreCacheService extends BaseCacheService {
     try {
       // Get the block height of all data we want to flush up to
       const blockHeight = await this.metadata.find('lastProcessedHeight');
+      assert(blockHeight !== undefined, 'Cannot flush cache without lastProcessedHeight');
       // Get models that have data to flush
       const updatableModels = Object.values(this.cachedModels).filter((m) => m.isFlushable);
       if (this._useCockroachDb) {

--- a/packages/node-core/src/indexer/storeCache/types.ts
+++ b/packages/node-core/src/indexer/storeCache/types.ts
@@ -24,7 +24,7 @@ export interface ICachedModelControl {
   isFlushable: boolean;
   hasAssociations?: boolean;
   flushableRecordCounter: number;
-  flush(tx: Transaction, blockHeight?: number): Promise<void>;
+  flush(tx: Transaction, blockHeight: number): Promise<void>;
   flushOperation?(i: number, tx: Transaction): Promise<void>;
   /**
    *

--- a/packages/node-core/src/indexer/test.runner.spec.ts
+++ b/packages/node-core/src/indexer/test.runner.spec.ts
@@ -6,6 +6,11 @@ import {TestRunner} from './test.runner';
 
 jest.mock('@subql/x-sequelize');
 
+const mockStoreCache = {
+  flushCache: jest.fn().mockResolvedValue(undefined),
+  metadata: {set: jest.fn()},
+};
+
 describe('TestRunner', () => {
   let testRunner: TestRunner<any, any, any, any>;
   let sequelizeMock: jest.Mocked<Sequelize>;
@@ -22,7 +27,7 @@ describe('TestRunner', () => {
     storeServiceMock = {
       setBlockHeight: jest.fn(),
       getStore: jest.fn().mockReturnValue({}),
-      storeCache: {flushCache: jest.fn().mockResolvedValue(undefined)},
+      storeCache: mockStoreCache,
     };
 
     sandboxMock = {
@@ -83,7 +88,7 @@ describe('TestRunner', () => {
     (testRunner as any).storeService = {
       getStore: () => storeMock,
       setBlockHeight: jest.fn(),
-      storeCache: {flushCache: jest.fn().mockResolvedValue(undefined)},
+      storeCache: mockStoreCache,
     } as any;
 
     await testRunner.runTest(testMock, sandboxMock, indexBlock);
@@ -118,7 +123,7 @@ describe('TestRunner', () => {
     (testRunner as any).storeService = {
       getStore: () => storeMock,
       setBlockHeight: jest.fn(),
-      storeCache: {flushCache: jest.fn().mockResolvedValue(undefined)},
+      storeCache: mockStoreCache,
     } as any;
 
     await testRunner.runTest(testMock, sandboxMock, indexBlock);
@@ -175,7 +180,7 @@ describe('TestRunner', () => {
     (testRunner as any).storeService = {
       getStore: () => storeMock,
       setBlockHeight: jest.fn(),
-      storeCache: {flushCache: jest.fn().mockResolvedValue(undefined)},
+      storeCache: mockStoreCache,
     } as any;
 
     await testRunner.runTest(testMock, sandboxMock, indexBlock);

--- a/packages/node-core/src/indexer/test.runner.ts
+++ b/packages/node-core/src/indexer/test.runner.ts
@@ -57,6 +57,7 @@ export class TestRunner<A, SA, B, DS> {
       const [block] = await this.apiService.fetchBlocks([test.blockHeight]);
 
       this.storeService.setBlockHeight(test.blockHeight);
+      this.storeService.storeCache.metadata.set('lastProcessedHeight', test.blockHeight - 1);
       const store = this.storeService.getStore();
       sandbox.freeze(store, 'store');
 
@@ -67,6 +68,8 @@ export class TestRunner<A, SA, B, DS> {
       logger.debug('Running handler');
 
       try {
+        // Ensure a block height is set so that
+
         await indexBlock(block, test.handler, this.indexerManager, this.apiService);
         await this.storeService.storeCache.flushCache(true);
       } catch (e: any) {
@@ -110,7 +113,9 @@ export class TestRunner<A, SA, B, DS> {
                 return value;
               };
               failedAttributes.push(
-                `\t\tattribute: "${attr}":\n\t\t\texpected: "${fmtValue(expectedAttr)}"\n\t\t\tactual:   "${fmtValue(actualAttr)}"\n`
+                `\t\tattribute: "${attr}":\n\t\t\texpected: "${fmtValue(expectedAttr)}"\n\t\t\tactual:   "${fmtValue(
+                  actualAttr
+                )}"\n`
               );
             }
           });

--- a/packages/node-core/src/indexer/test.runner.ts
+++ b/packages/node-core/src/indexer/test.runner.ts
@@ -57,6 +57,7 @@ export class TestRunner<A, SA, B, DS> {
       const [block] = await this.apiService.fetchBlocks([test.blockHeight]);
 
       this.storeService.setBlockHeight(test.blockHeight);
+      // Ensure a block height is set so that data is flushed correctly
       this.storeService.storeCache.metadata.set('lastProcessedHeight', test.blockHeight - 1);
       const store = this.storeService.getStore();
       sandbox.freeze(store, 'store');
@@ -68,8 +69,6 @@ export class TestRunner<A, SA, B, DS> {
       logger.debug('Running handler');
 
       try {
-        // Ensure a block height is set so that
-
         await indexBlock(block, test.handler, this.indexerManager, this.apiService);
         await this.storeService.storeCache.flushCache(true);
       } catch (e: any) {


### PR DESCRIPTION
# Description
A while ago there was a change to the store cache service to require block height. This was not tested with the testing framework and its caused an issue where the lastProcessedHeight was not set so no data would be flushed for tests.

This PR updates the types to catch this issue and adds an assertion to ensure a clear error. It also sets the lastProcessed height to the previous block in the test runner.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
