### PR TITLE
Fix getByFields including removed cache data

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Issues with setting a large block range for bypass blocks (#2566)
 - Test runner not setting lastProcessedHeight leading to data not being flushed (#2569)
 - Unable to rewind unfinalized blocks on startup (#2570)
+- Store `getByFields` returning removed cache data (#2571)
+
 ### Changed
 - Throw error when store getByField(s) options.limit exceeds queryLimit option (#2567)
 

--- a/packages/node-core/src/indexer/storeCache/cacheModel.spec.ts
+++ b/packages/node-core/src/indexer/storeCache/cacheModel.spec.ts
@@ -229,6 +229,11 @@ describe('cacheModel', () => {
       testModel = new CachedModel(sequelize.model('entity1'), true, {} as NodeConfig, () => i++);
     });
 
+    it('throws when trying to set undefined', () => {
+      expect(() => testModel.set('0x01', undefined as any, 1)).toThrow();
+      expect(() => testModel.set('0x01', null as any, 1)).toThrow();
+    });
+
     // it should keep same behavior as hook we used
     it('when get data after flushed, it should exclude block range', async () => {
       const spyDbGet = jest.spyOn(testModel.model, 'findOne');


### PR DESCRIPTION
# Description
If data in the set cache was marked as removed it was still being included in the results for `getByFields`, this now no longer happens.

It also adds a runtime check that `set` data is defined.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
