### PR TITLE
Fix/multi endpint delay

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- When configuring multiple endpoints, poor network conditions may lead to block crawling delays. (#2572)
+
 ## [14.1.6] - 2024-10-21
 ### Fixed
 - Issues with setting a large block range for bypass blocks (#2566)

--- a/packages/node-core/src/indexer/connectionPool.service.spec.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.spec.ts
@@ -128,7 +128,7 @@ describe('ConnectionPoolService', () => {
     }, 15000);
   });
 
-  describe('Rate limit endpoint delay 20s', () => {
+  describe('Rate limit endpoint delay', () => {
     it('call delay', async () => {
       const logger = getLogger('connection-pool');
       const consoleSpy = jest.spyOn(logger, 'info');
@@ -149,7 +149,7 @@ describe('ConnectionPoolService', () => {
 
       await connectionPoolService.api.fetchBlocks([34365]);
 
-      expect(consoleSpy).toHaveBeenCalledWith('throtling on ratelimited endpoint 20s');
+      expect(consoleSpy).toHaveBeenCalledWith('throtling on ratelimited endpoint 10s');
       consoleSpy.mockRestore();
     }, 30000);
   });

--- a/packages/node-core/src/indexer/connectionPool.service.spec.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.spec.ts
@@ -127,30 +127,4 @@ describe('ConnectionPoolService', () => {
       expect(handleApiDisconnectsSpy).toHaveBeenCalledTimes(1);
     }, 15000);
   });
-
-  describe('Rate limit endpoint delay 20s', () => {
-    it('call delay', async () => {
-      const logger = getLogger('connection-pool');
-      const consoleSpy = jest.spyOn(logger, 'info');
-
-      await connectionPoolService.addToConnections(mockApiConnection, TEST_URL);
-      await connectionPoolService.addToConnections(mockApiConnection, `${TEST_URL}/2`);
-      await connectionPoolService.handleApiError(TEST_URL, {
-        name: 'timeout',
-        errorType: ApiErrorType.Timeout,
-        message: 'timeout error',
-      });
-      await connectionPoolService.handleApiError(`${TEST_URL}/2`, {
-        name: 'DefaultError',
-        errorType: ApiErrorType.Default,
-        message: 'Default error',
-      });
-      await (connectionPoolService as any).flushResultCache();
-
-      await connectionPoolService.api.fetchBlocks([34365]);
-
-      expect(consoleSpy).toHaveBeenCalledWith('throtling on ratelimited endpoint 20s');
-      consoleSpy.mockRestore();
-    }, 30000);
-  });
 });

--- a/packages/node-core/src/indexer/connectionPool.service.spec.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.spec.ts
@@ -127,4 +127,8 @@ describe('ConnectionPoolService', () => {
       expect(handleApiDisconnectsSpy).toHaveBeenCalledTimes(1);
     }, 15000);
   });
+
+  // describe('The endpoint with rate limiting.', () => {
+  //   it('should handle all nodes being rate limited', async () => {});
+  // });
 });

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -102,13 +102,6 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
         if (prop === 'fetchBlocks') {
           return async (heights: number[], ...args: any): Promise<any> => {
             try {
-              // Check if the endpoint is rate-limited
-              if (await this.poolStateManager.getFieldValue(endpoint, 'rateLimited')) {
-                const rateLimitDelay = await this.poolStateManager.getFieldValue(endpoint, 'rateLimitDelay');
-                logger.info(`throtling on ratelimited endpoint ${rateLimitDelay / 1000}s`);
-                await delay(rateLimitDelay / 1000);
-              }
-
               const start = Date.now();
               const result = await target.fetchBlocks(heights, ...args);
               const end = Date.now();

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -102,6 +102,13 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
         if (prop === 'fetchBlocks') {
           return async (heights: number[], ...args: any): Promise<any> => {
             try {
+              // Check if the endpoint is rate-limited
+              if (await this.poolStateManager.getFieldValue(endpoint, 'rateLimited')) {
+                const rateLimitDelay = await this.poolStateManager.getFieldValue(endpoint, 'rateLimitDelay');
+                logger.info(`throtling on ratelimited endpoint ${rateLimitDelay / 1000}s`);
+                await delay(rateLimitDelay / 1000);
+              }
+
               const start = Date.now();
               const result = await target.fetchBlocks(heights, ...args);
               const end = Date.now();

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -104,9 +104,9 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
             try {
               // Check if the endpoint is rate-limited
               if (await this.poolStateManager.getFieldValue(endpoint, 'rateLimited')) {
-                logger.info('throtling on ratelimited endpoint');
-                const backoffDelay = await this.poolStateManager.getFieldValue(endpoint, 'backoffDelay');
-                await delay(backoffDelay / 1000);
+                const rateLimitDelay = await this.poolStateManager.getFieldValue(endpoint, 'rateLimitDelay');
+                logger.info(`throtling on ratelimited endpoint ${rateLimitDelay / 1000}s`);
+                await delay(rateLimitDelay / 1000);
               }
 
               const start = Date.now();

--- a/packages/node-core/src/indexer/connectionPool.service.ts
+++ b/packages/node-core/src/indexer/connectionPool.service.ts
@@ -104,9 +104,8 @@ export class ConnectionPoolService<T extends IApiConnectionSpecific<any, any, an
             try {
               // Check if the endpoint is rate-limited
               if (await this.poolStateManager.getFieldValue(endpoint, 'rateLimited')) {
-                const rateLimitDelay = await this.poolStateManager.getFieldValue(endpoint, 'rateLimitDelay');
-                logger.info(`throtling on ratelimited endpoint ${rateLimitDelay / 1000}s`);
-                await delay(rateLimitDelay / 1000);
+                logger.info(`throtling on ratelimited endpoint 10s`);
+                await delay(10);
               }
 
               const start = Date.now();

--- a/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
@@ -1,7 +1,8 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {ConnectionPoolStateManager} from './connectionPoolState.manager';
+import {ApiErrorType} from '../api.connection.error';
+import {ConnectionPoolItem, ConnectionPoolStateManager} from './connectionPoolState.manager';
 
 describe('ConnectionPoolStateManager', function () {
   let connectionPoolStateManager: ConnectionPoolStateManager<any>;
@@ -12,60 +13,52 @@ describe('ConnectionPoolStateManager', function () {
     connectionPoolStateManager = new ConnectionPoolStateManager();
   });
 
-  it('chooses primary endpoint first', async function () {
-    (connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT1] = {
-      primary: true,
-      performanceScore: 100,
-      failureCount: 0,
-      endpoint: '',
-      backoffDelay: 0,
-      rateLimited: false,
-      failed: false,
-      connected: true,
-      lastRequestTime: 0,
-    };
+  afterEach(async function () {
+    await connectionPoolStateManager.onApplicationShutdown();
+  });
 
-    (connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2] = {
-      primary: false,
-      performanceScore: 100,
-      failureCount: 0,
-      endpoint: '',
-      backoffDelay: 0,
-      rateLimited: false,
-      failed: false,
-      connected: true,
-      lastRequestTime: 0,
-    };
+  it('chooses primary endpoint first', async function () {
+    await connectionPoolStateManager.addToConnections(EXAMPLE_ENDPOINT1, true);
+    await connectionPoolStateManager.addToConnections(EXAMPLE_ENDPOINT2, false);
 
     expect(await connectionPoolStateManager.getNextConnectedEndpoint()).toEqual(EXAMPLE_ENDPOINT1);
   });
 
   it('does not choose primary endpoint if failed', async function () {
-    (connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT1] = {
-      primary: true,
-      performanceScore: 100,
-      failureCount: 0,
-      endpoint: '',
-      backoffDelay: 0,
-      rateLimited: false,
-      failed: false,
-      connected: false,
-      lastRequestTime: 0,
-    };
+    await connectionPoolStateManager.addToConnections(EXAMPLE_ENDPOINT1, true);
+    await connectionPoolStateManager.addToConnections(EXAMPLE_ENDPOINT2, false);
 
-    (connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2] = {
-      primary: false,
-      performanceScore: 100,
-      failureCount: 0,
-      endpoint: '',
-      backoffDelay: 0,
-      rateLimited: false,
-      failed: false,
-      connected: true,
-      lastRequestTime: 0,
-    };
+    await connectionPoolStateManager.handleApiError(EXAMPLE_ENDPOINT1, ApiErrorType.Default);
 
     expect(await connectionPoolStateManager.getNextConnectedEndpoint()).toEqual(EXAMPLE_ENDPOINT2);
+  });
+
+  it('All endpoints backoff; select a rateLimited endpoint. reason: ApiErrorType.Timeout', async function () {
+    await connectionPoolStateManager.addToConnections(EXAMPLE_ENDPOINT1, false);
+    await connectionPoolStateManager.addToConnections(EXAMPLE_ENDPOINT2, false);
+
+    await connectionPoolStateManager.handleApiError(EXAMPLE_ENDPOINT1, ApiErrorType.Default);
+    await connectionPoolStateManager.handleApiError(EXAMPLE_ENDPOINT2, ApiErrorType.Timeout);
+
+    const nextEndpoint = await connectionPoolStateManager.getNextConnectedEndpoint();
+    const endpointInfo = (connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2] as ConnectionPoolItem<any>;
+    expect(nextEndpoint).toEqual(EXAMPLE_ENDPOINT2);
+    expect(endpointInfo.rateLimited).toBe(true);
+    expect((connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2].rateLimitDelay).toBe(20 * 1000);
+  });
+
+  it('All endpoints backoff; select a rateLimited endpoint. reason: ApiErrorType.RateLimit', async function () {
+    await connectionPoolStateManager.addToConnections(EXAMPLE_ENDPOINT1, false);
+    await connectionPoolStateManager.addToConnections(EXAMPLE_ENDPOINT2, false);
+
+    await connectionPoolStateManager.handleApiError(EXAMPLE_ENDPOINT1, ApiErrorType.Default);
+    await connectionPoolStateManager.handleApiError(EXAMPLE_ENDPOINT2, ApiErrorType.RateLimit);
+
+    const nextEndpoint = await connectionPoolStateManager.getNextConnectedEndpoint();
+    const endpointInfo = (connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2] as ConnectionPoolItem<any>;
+    expect(nextEndpoint).toEqual(EXAMPLE_ENDPOINT2);
+    expect(endpointInfo.rateLimited).toBe(true);
+    expect((connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2].rateLimitDelay).toBe(20 * 1000);
   });
 
   it('can calculate performance score for response time of zero', function () {
@@ -78,6 +71,4 @@ describe('ConnectionPoolStateManager', function () {
     const score2 = (connectionPoolStateManager as any).calculatePerformanceScore(2, 0);
     expect(score1).toBeGreaterThan(score2);
   });
-
-  // it('handleApiError', async function () {});
 });

--- a/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
@@ -78,4 +78,6 @@ describe('ConnectionPoolStateManager', function () {
     const score2 = (connectionPoolStateManager as any).calculatePerformanceScore(2, 0);
     expect(score1).toBeGreaterThan(score2);
   });
+
+  // it('handleApiError', async function () {});
 });

--- a/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
@@ -71,30 +71,4 @@ describe('ConnectionPoolStateManager', function () {
     const score2 = (connectionPoolStateManager as any).calculatePerformanceScore(2, 0);
     expect(score1).toBeGreaterThan(score2);
   });
-
-  it('backoff delay rule', function () {
-    const delay1 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 0});
-    expect(delay1).toBe(0);
-
-    const delay2 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 1});
-    expect(delay2).toBe(10000);
-
-    const delay3 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 2});
-    expect(delay3).toBe(20000);
-
-    const delay4 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 3});
-    expect(delay4).toBe(40000);
-
-    const delay5 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 4});
-    expect(delay5).toBe(80000);
-
-    const delay6 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 5});
-    expect(delay6).toBe(160000);
-
-    const delay7 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 6});
-    expect(delay7).toBe(320000);
-
-    const delayMax = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 7});
-    expect(delayMax).toBe(320000);
-  });
 });

--- a/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
@@ -44,7 +44,6 @@ describe('ConnectionPoolStateManager', function () {
     const endpointInfo = (connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2] as ConnectionPoolItem<any>;
     expect(nextEndpoint).toEqual(EXAMPLE_ENDPOINT2);
     expect(endpointInfo.rateLimited).toBe(true);
-    expect((connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2].rateLimitDelay).toBe(20 * 1000);
   });
 
   it('All endpoints backoff; select a rateLimited endpoint. reason: ApiErrorType.RateLimit', async function () {
@@ -58,7 +57,6 @@ describe('ConnectionPoolStateManager', function () {
     const endpointInfo = (connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2] as ConnectionPoolItem<any>;
     expect(nextEndpoint).toEqual(EXAMPLE_ENDPOINT2);
     expect(endpointInfo.rateLimited).toBe(true);
-    expect((connectionPoolStateManager as any).pool[EXAMPLE_ENDPOINT2].rateLimitDelay).toBe(20 * 1000);
   });
 
   it('can calculate performance score for response time of zero', function () {

--- a/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.spec.ts
@@ -71,4 +71,30 @@ describe('ConnectionPoolStateManager', function () {
     const score2 = (connectionPoolStateManager as any).calculatePerformanceScore(2, 0);
     expect(score1).toBeGreaterThan(score2);
   });
+
+  it('backoff delay rule', function () {
+    const delay1 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 0});
+    expect(delay1).toBe(0);
+
+    const delay2 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 1});
+    expect(delay2).toBe(10000);
+
+    const delay3 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 2});
+    expect(delay3).toBe(20000);
+
+    const delay4 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 3});
+    expect(delay4).toBe(40000);
+
+    const delay5 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 4});
+    expect(delay5).toBe(80000);
+
+    const delay6 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 5});
+    expect(delay6).toBe(160000);
+
+    const delay7 = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 6});
+    expect(delay7).toBe(320000);
+
+    const delayMax = (connectionPoolStateManager as any).calculateNextDelay({failureCount: 7});
+    expect(delayMax).toBe(320000);
+  });
 });

--- a/packages/node-core/src/indexer/connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.ts
@@ -22,7 +22,6 @@ export interface ConnectionPoolItem<T> {
   backoffDelay: number;
   failureCount: number;
   rateLimited: boolean;
-  rateLimitDelay: number;
   failed: boolean;
   lastRequestTime: number;
   connected: boolean;
@@ -73,7 +72,6 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
       endpoint,
       backoffDelay: 0,
       rateLimited: false,
-      rateLimitDelay: 0,
       failed: false,
       connected: true,
       lastRequestTime: 0,
@@ -200,7 +198,6 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
     this.pool[endpoint].timeoutId = setTimeout(() => {
       this.pool[endpoint].backoffDelay = 0; // Reset backoff delay only if there are no consecutive errors
       this.pool[endpoint].rateLimited = false;
-      this.pool[endpoint].rateLimitDelay = 0;
       this.pool[endpoint].failed = false;
       this.pool[endpoint].timeoutId = undefined; // Clear the timeout ID
 
@@ -259,7 +256,6 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
       case ApiErrorType.RateLimit: {
         // The “rateLimited” status will be selected when no endpoints are available, so we should avoid setting a large delay.
         this.pool[endpoint].rateLimited = true;
-        this.pool[endpoint].rateLimitDelay = RATE_LIMIT_DELAY;
         break;
       }
       case ApiErrorType.Default: {

--- a/packages/node-core/src/indexer/connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.ts
@@ -24,6 +24,7 @@ export interface ConnectionPoolItem<T> {
   backoffDelay: number;
   failureCount: number;
   rateLimited: boolean;
+  rateLimitDelay: number;
   failed: boolean;
   lastRequestTime: number;
   connected: boolean;
@@ -74,6 +75,7 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
       endpoint,
       backoffDelay: 0,
       rateLimited: false,
+      rateLimitDelay: 0,
       failed: false,
       connected: true,
       lastRequestTime: 0,
@@ -200,6 +202,7 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
     this.pool[endpoint].timeoutId = setTimeout(() => {
       this.pool[endpoint].backoffDelay = 0; // Reset backoff delay only if there are no consecutive errors
       this.pool[endpoint].rateLimited = false;
+      this.pool[endpoint].rateLimitDelay = 0;
       this.pool[endpoint].failed = false;
       this.pool[endpoint].timeoutId = undefined; // Clear the timeout ID
 
@@ -258,6 +261,7 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
       case ApiErrorType.RateLimit: {
         // The “rateLimited” status will be selected when no endpoints are available, so we should avoid setting a large delay.
         this.pool[endpoint].rateLimited = true;
+        this.pool[endpoint].rateLimitDelay = RATE_LIMIT_DELAY;
         break;
       }
       case ApiErrorType.Default: {

--- a/packages/node-core/src/indexer/connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.ts
@@ -10,6 +10,8 @@ import {getLogger} from '../logger';
 import {exitWithError} from '../process';
 import {errorTypeToScoreAdjustment} from './connectionPool.service';
 
+const RETRY_DELAY = 60 * 1000;
+const MAX_RETRY_DELAY = 60 * RETRY_DELAY;
 const MAX_FAILURES = 5;
 const RESPONSE_TIME_WEIGHT = 0.7;
 const FAILURE_WEIGHT = 0.3;
@@ -280,16 +282,8 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
   }
 
   private calculateNextDelay(poolItem: ConnectionPoolItem<T>): number {
-    const delayRule = [10, 20, 40, 80, 160, 320];
-    let delayTime = 0;
-    if (poolItem.failureCount < 1) {
-      delayTime = 0;
-    } else if (poolItem.failureCount >= 1 && poolItem.failureCount <= delayRule.length) {
-      delayTime = delayRule[poolItem.failureCount - 1];
-    } else {
-      delayTime = delayRule[delayRule.length - 1];
-    }
-    return delayTime * 1000;
+    // Exponential backoff using failure count, Start with RETRY_DELAY and double on each failure, MAX_RETRY_DELAY is the maximum delay
+    return Math.min(RETRY_DELAY * Math.pow(2, poolItem.failureCount - 1), MAX_RETRY_DELAY);
   }
 
   private calculatePerformanceScore(responseTime: number, failureCount: number): number {

--- a/packages/node-core/src/indexer/connectionPoolState.manager.ts
+++ b/packages/node-core/src/indexer/connectionPoolState.manager.ts
@@ -11,9 +11,11 @@ import {exitWithError} from '../process';
 import {errorTypeToScoreAdjustment} from './connectionPool.service';
 
 const RETRY_DELAY = 60 * 1000;
+const MAX_RETRY_DELAY = 60 * RETRY_DELAY;
 const MAX_FAILURES = 5;
 const RESPONSE_TIME_WEIGHT = 0.7;
 const FAILURE_WEIGHT = 0.3;
+const RATE_LIMIT_DELAY = 20 * 1000;
 
 export interface ConnectionPoolItem<T> {
   endpoint: string;
@@ -22,6 +24,7 @@ export interface ConnectionPoolItem<T> {
   backoffDelay: number;
   failureCount: number;
   rateLimited: boolean;
+  rateLimitDelay: number;
   failed: boolean;
   lastRequestTime: number;
   connected: boolean;
@@ -72,6 +75,7 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
       endpoint,
       backoffDelay: 0,
       rateLimited: false,
+      rateLimitDelay: 0,
       failed: false,
       connected: true,
       lastRequestTime: 0,
@@ -191,13 +195,14 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
   }
 
   //eslint-disable-next-line @typescript-eslint/require-await
-  async setTimeout(endpoint: string, delay: number): Promise<void> {
+  async setRecoverTimeout(endpoint: string, delay: number): Promise<void> {
     // Make sure there is no existing timeout
     await this.clearTimeout(endpoint);
 
     this.pool[endpoint].timeoutId = setTimeout(() => {
       this.pool[endpoint].backoffDelay = 0; // Reset backoff delay only if there are no consecutive errors
       this.pool[endpoint].rateLimited = false;
+      this.pool[endpoint].rateLimitDelay = 0;
       this.pool[endpoint].failed = false;
       this.pool[endpoint].timeoutId = undefined; // Clear the timeout ID
 
@@ -247,35 +252,42 @@ export class ConnectionPoolStateManager<T extends IApiConnectionSpecific<any, an
     switch (errorType) {
       case ApiErrorType.Connection: {
         if (this.pool[endpoint].connected) {
-          //handleApiDisconnects was already called if this is false
-          //this.handleApiDisconnects(endpoint);
+          // The connected status does not provide service. handleApiDisconnects() will be called to handle this.
           this.pool[endpoint].connected = false;
         }
         return;
       }
+      case ApiErrorType.Timeout:
+      case ApiErrorType.RateLimit: {
+        // The “rateLimited” status will be selected when no endpoints are available, so we should avoid setting a large delay.
+        this.pool[endpoint].rateLimited = true;
+        this.pool[endpoint].rateLimitDelay = RATE_LIMIT_DELAY;
+        break;
+      }
       case ApiErrorType.Default: {
-        const nextDelay = RETRY_DELAY * Math.pow(2, this.pool[endpoint].failureCount - 1); // Exponential backoff using failure count // Start with RETRY_DELAY and double on each failure
-        this.pool[endpoint].backoffDelay = nextDelay;
-
-        if (ApiErrorType.Timeout || ApiErrorType.RateLimit) {
-          this.pool[endpoint].rateLimited = true;
-        } else {
-          this.pool[endpoint].failed = true;
-        }
-
-        await this.setTimeout(endpoint, nextDelay);
-
-        logger.warn(
-          `Endpoint ${this.pool[endpoint].endpoint} experienced an error (${errorType}). Suspending for ${
-            nextDelay / 1000
-          }s.`
-        );
-        return;
+        // The “failed” status does not provide service.
+        this.pool[endpoint].failed = true;
+        break;
       }
       default: {
         throw new Error(`Unknown error type ${errorType}`);
       }
     }
+
+    const nextDelay = this.calculateNextDelay(this.pool[endpoint]);
+    this.pool[endpoint].backoffDelay = nextDelay;
+    await this.setRecoverTimeout(endpoint, nextDelay);
+
+    logger.warn(
+      `Endpoint ${this.pool[endpoint].endpoint} experienced an error (${errorType}). Suspending for ${
+        nextDelay / 1000
+      }s.`
+    );
+  }
+
+  private calculateNextDelay(poolItem: ConnectionPoolItem<T>): number {
+    // Exponential backoff using failure count, Start with RETRY_DELAY and double on each failure, MAX_RETRY_DELAY is the maximum delay
+    return Math.min(RETRY_DELAY * Math.pow(2, poolItem.failureCount - 1), MAX_RETRY_DELAY);
   }
 
   private calculatePerformanceScore(responseTime: number, failureCount: number): number {


### PR DESCRIPTION
# Description
Multi-endpoint indexing logic delay and other related issues

Fixes https://github.com/subquery/subql/issues/2572

- Fix the issue where the backoff delay increases excessively after multiple failures.
- Correctly handle timeout and rate limit errors.
- Resolve the issue where default errors are treated as rate limit errors on the endpoint.
- Add control logic for rateLimitDelay, default to 20 seconds.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
