### PR TITLE
Remove polkadot import

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed imports of `@polkadot/util` without it being a dependency (#2592)
 
 ## [5.1.4] - 2024-10-23
 ### Fixed

--- a/packages/common/src/project/IpfsHttpClientLite/IpfsHttpClientLite.spec.ts
+++ b/packages/common/src/project/IpfsHttpClientLite/IpfsHttpClientLite.spec.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {u8aConcat} from '@polkadot/util';
 import {IPFS_NODE_ENDPOINT, IPFS_WRITE_ENDPOINT} from '../../constants';
 import {IPFSHTTPClientLite} from './IPFSHTTPClientLite';
 
@@ -43,7 +42,7 @@ describe('IPFSClient Lite', () => {
     for await (const res of req) {
       scriptBufferArray.push(res);
     }
-    const output = Buffer.from(u8aConcat(...scriptBufferArray)).toString('utf8');
+    const output = Buffer.concat(scriptBufferArray.map((u8a) => Buffer.from(u8a))).toString('utf8');
 
     expect(output).toBe(`test string to upload`);
   });
@@ -72,7 +71,7 @@ describe('IPFSClient Lite', () => {
     for await (const res of req) {
       scriptBufferArray.push(res);
     }
-    const output = Buffer.from(u8aConcat(...scriptBufferArray)).toString('utf8');
+    const output = Buffer.concat(scriptBufferArray.map((u8a) => Buffer.from(u8a))).toString('utf8');
     expect(output).toBeDefined();
     expect(output.length).toBeGreaterThan(1);
   }, 500000);

--- a/packages/common/src/project/readers/ipfs-reader.ts
+++ b/packages/common/src/project/readers/ipfs-reader.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {u8aConcat} from '@polkadot/util';
 import {Reader} from '@subql/types-core';
 import yaml from 'js-yaml';
 import type {IPackageJson} from 'package-json-type';
@@ -17,7 +16,10 @@ export class IPFSReader implements Reader {
   private ipfs: IPFSHTTPClientLite;
   private cache: Record<string, Promise<string>> = {};
 
-  constructor(readonly cid: string, gateway?: string) {
+  constructor(
+    readonly cid: string,
+    gateway?: string
+  ) {
     if (!CIDv0.test(cid) && !CIDv1.test(cid)) {
       throw new Error('IPFS project path CID is not valid');
     }
@@ -56,6 +58,6 @@ export class IPFSReader implements Reader {
     for await (const res of req) {
       scriptBufferArray.push(res);
     }
-    return Buffer.from(u8aConcat(...scriptBufferArray)).toString('utf8');
+    return Buffer.concat(scriptBufferArray.map((u8a) => Buffer.from(u8a))).toString('utf8');
   }
 }


### PR DESCRIPTION
# Description
Drop imports of `@polkadot/util`, it was not a dependency of common and broke the CLI global usage. It also was unnecessary as the same functionality can be used with built in functions.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
