### PR TITLE
Prevent the use of latestFinalizedHeight when unfinalizedBlock is enable (return latestBestHeight instead)

### DIFF
--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -60,8 +60,11 @@ export abstract class BaseFetchService<DS extends BaseDataSource, B extends IBlo
   }
 
   private get latestFinalizedHeight(): number {
-    assert(this._latestFinalizedHeight, new Error('Latest Finalized Height is not available'));
-    return this._latestFinalizedHeight;
+    if (!this.nodeConfig.unfinalizedBlocks) {
+      assert(this._latestFinalizedHeight, new Error('Latest Finalized Height is not available'));
+      return this._latestFinalizedHeight;
+    }
+    return this.latestBestHeight;
   }
 
   onApplicationShutdown(): void {


### PR DESCRIPTION
# Description
When using unfinalized-blocks and not having a working dictionary, the code still try to use `latestFinalizedHeight` resulting in an error `Error: Latest Finalized Height is not available`.

This quick patch, use the `latestBestHeight` if unfinalized-blocks mode is enable and we try to access `latestFinalizedHeight`

Fixes #2593 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
