### PR TITLE
Subscription improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,9 @@ module.exports = {
     'plugin:jest/recommended',
   ],
   rules: {
+    // Note: you must disable the base rule as it can report incorrect errors
+    "require-await": "off",
+    "@typescript-eslint/require-await": "error",
     // rules turned off in upstream project (also required when recommended-requiring-type-checking is extended)
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-unsafe-argument': 'off',
@@ -62,11 +65,11 @@ module.exports = {
         accessibility: 'no-public',
       },
     ],
-    '@typescript-eslint/no-namespace': ['error', {allowDeclarations: true}],
+    '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }],
     // "@typescript-eslint/member-ordering": "error",
     // "@typescript-eslint/naming-convention": "error",
     // "@typescript-eslint/no-param-reassign": "error",
-    '@typescript-eslint/promise-function-async': ['error', {checkArrowFunctions: false}],
+    '@typescript-eslint/promise-function-async': ['error', { checkArrowFunctions: false }],
     // "arrow-body-style": "error",
     complexity: ['error', 20],
     curly: ['error', 'multi-line'],
@@ -87,7 +90,7 @@ module.exports = {
       'line',
       [
         //Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
-        {pattern: ' Copyright \\d{4}(-\\d{4})? SubQuery Pte Ltd authors & contributors'},
+        { pattern: ' Copyright \\d{4}(-\\d{4})? SubQuery Pte Ltd authors & contributors' },
         ' SPDX-License-Identifier: GPL-3.0',
       ],
       2,
@@ -112,7 +115,7 @@ module.exports = {
       '@typescript-eslint/parser': ['.ts', '.tsx'],
     },
   },
-  overrides:[
+  overrides: [
     {
       files: ['*.test.ts', '*.spec.ts'],
       rules: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -175,7 +175,7 @@ module.exports = {
   ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
-  testRegex: '.*\\.spec\\.ts$',
+  testRegex: '.*\\.(spec|test)\\.ts$',
 
   // This option allows the use of a custom results processor
   // testResultsProcessor: undefined,

--- a/jest.config.js
+++ b/jest.config.js
@@ -175,7 +175,7 @@ module.exports = {
   ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
-  testRegex: '.*\\.(spec|test)\\.ts$',
+  testRegex: '.*\\.(spec)\\.ts$',
 
   // This option allows the use of a custom results processor
   // testResultsProcessor: undefined,

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - When using a GET query to retrieve an entity, it will include a “store” field.
 - Support for historical indexing by timestamp as well as block height (#2584)
+- Subscriptions not emitting deleted mutation type with historical (#2600)
 
 ### Removed
 - Support for cockroach DB (#2584)

--- a/packages/node-core/src/db/sync-helper.test.ts
+++ b/packages/node-core/src/db/sync-helper.test.ts
@@ -168,9 +168,11 @@ describe('sync helper test', () => {
       await tx2.commit();
 
       await delay(1);
+      // There is a limitation with our historical implementation where with the order or queries means we cant easily determine the difference between insert and update.
+      // For that reason the behaviour is kept the same as before delete was fixed.
       expect(listener).toHaveBeenNthCalledWith(
         1,
-        `{"id": "1", "_entity": {"id": "1", "block_number": 1}, "mutation_type": "INSERT"}`
+        `{"id": "1", "_entity": {"id": "1", "block_number": 1}, "mutation_type": "UPDATE"}`
       );
       expect(listener).toHaveBeenNthCalledWith(
         2,

--- a/packages/node-core/src/db/sync-helper.test.ts
+++ b/packages/node-core/src/db/sync-helper.test.ts
@@ -3,10 +3,11 @@
 
 import {INestApplication} from '@nestjs/common';
 import {Test} from '@nestjs/testing';
-import {getDbSizeAndUpdateMetadata} from '@subql/node-core';
+import {delay} from '@subql/common';
 import {Sequelize} from '@subql/x-sequelize';
 import {NodeConfig} from '../configure/NodeConfig';
 import {DbModule} from './db.module';
+import {createSendNotificationTriggerFunction, createNotifyTrigger, getDbSizeAndUpdateMetadata} from './sync-helper';
 
 const nodeConfig = new NodeConfig({subquery: 'packages/node-core/test/v1.0.0', subqueryName: 'test'});
 
@@ -42,4 +43,143 @@ describe('sync helper test', () => {
     const dbSize = await getDbSizeAndUpdateMetadata(sequelize, schema);
     expect(dbSize).not.toBeUndefined();
   }, 50000);
+
+  describe('has the correct notification trigger payload', () => {
+    let client: unknown;
+
+    afterEach(async () => {
+      if (client) {
+        await (client as any).query('UNLISTEN "0xc4e66f9e1358fa3c"');
+        (client as any).removeAllListeners('notification');
+        sequelize.connectionManager.releaseConnection(client);
+      }
+    });
+
+    it('without historical', async () => {
+      const module = await Test.createTestingModule({
+        imports: [DbModule.forRootWithConfig(nodeConfig)],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+      sequelize = app.get(Sequelize);
+      schema = 'trigger-test';
+      const tableName = 'test';
+      await sequelize.createSchema(schema, {});
+      // mock create metadata table
+      await sequelize.query(`
+        CREATE TABLE IF NOT EXISTS "${schema}".${tableName} (
+          id text NOT NULL,
+          block_number int4 NOT NULL
+      )`);
+
+      await sequelize.query(createSendNotificationTriggerFunction(schema));
+      await sequelize.query(createNotifyTrigger(schema, tableName));
+
+      client = await sequelize.connectionManager.getConnection({
+        type: 'read',
+      });
+
+      await (client as any).query('LISTEN "0xc4e66f9e1358fa3c"');
+
+      const listener = jest.fn();
+      (client as any).on('notification', (msg: any) => {
+        console.log('Payload:', msg.payload);
+        listener(msg.payload);
+      });
+
+      await sequelize.query(`INSERT INTO "${schema}".${tableName} (id, block_number) VALUES ('1', 1);`);
+      await sequelize.query(`UPDATE "${schema}".${tableName} SET block_number = 2 WHERE id = '1';`);
+      await sequelize.query(`DELETE FROM "${schema}".${tableName} WHERE id = '1';`);
+      await delay(1);
+      expect(listener).toHaveBeenNthCalledWith(
+        1,
+        `{"id": "1", "_entity": {"id": "1", "block_number": 1}, "mutation_type": "INSERT"}`
+      );
+      expect(listener).toHaveBeenNthCalledWith(
+        2,
+        `{"id": "1", "_entity": {"id": "1", "block_number": 2}, "mutation_type": "UPDATE"}`
+      );
+      expect(listener).toHaveBeenNthCalledWith(
+        3,
+        `{"id": "1", "_entity": {"id": "1", "block_number": 2}, "mutation_type": "DELETE"}`
+      );
+    }, 10_000);
+
+    it('with historical', async () => {
+      const module = await Test.createTestingModule({
+        imports: [DbModule.forRootWithConfig(nodeConfig)],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+      sequelize = app.get(Sequelize);
+      schema = 'trigger-test';
+      const tableName = 'test';
+      await sequelize.createSchema(schema, {});
+      // mock create metadata table
+      await sequelize.query(`
+        CREATE TABLE IF NOT EXISTS "${schema}".${tableName} (
+          id text NOT NULL,
+          block_number int4 NOT NULL,
+          "_id" uuid NOT NULL,
+          "_block_range" int8range NOT NULL,
+          CONSTRAINT test_pk PRIMARY KEY (_id)
+      )`);
+
+      await sequelize.query(createSendNotificationTriggerFunction(schema));
+      await sequelize.query(createNotifyTrigger(schema, tableName));
+
+      client = await sequelize.connectionManager.getConnection({
+        type: 'read',
+      });
+
+      await (client as any).query('LISTEN "0xc4e66f9e1358fa3c"');
+
+      const listener = jest.fn();
+
+      (client as any).on('notification', (msg: any) => {
+        console.log('Payload:', msg.payload);
+        listener(msg.payload);
+      });
+
+      // Insert
+      await sequelize.query(
+        `INSERT INTO "${schema}".${tableName} (id, block_number, _id, _block_range) VALUES ('1', 1, 'adde2f8c-cb87-4e84-9600-77f434556e6d', int8range(1, NULL));`
+      );
+
+      // Simulate Update
+      const tx1 = await sequelize.transaction();
+      await sequelize.query(
+        `INSERT INTO "${schema}".${tableName} (id, block_number, _id, _block_range) VALUES ('1', 2, '9396aca4-cef2-4b52-98a7-c5f1ed3edb81', int8range(2, NULL));`
+      );
+      await sequelize.query(
+        `UPDATE "${schema}".${tableName} SET block_number = 2, _block_range = int8range(1, 2) WHERE _id = 'adde2f8c-cb87-4e84-9600-77f434556e6d';`,
+        {transaction: tx1}
+      );
+      await tx1.commit();
+
+      // Simulate delete
+      const tx2 = await sequelize.transaction();
+      await sequelize.query(
+        `UPDATE "${schema}".${tableName} SET _block_range = int8range(2, 3) WHERE _id = '9396aca4-cef2-4b52-98a7-c5f1ed3edb81';`,
+        {transaction: tx2}
+      );
+      await tx2.commit();
+
+      await delay(1);
+      expect(listener).toHaveBeenNthCalledWith(
+        1,
+        `{"id": "1", "_entity": {"id": "1", "block_number": 1}, "mutation_type": "INSERT"}`
+      );
+      expect(listener).toHaveBeenNthCalledWith(
+        2,
+        `{"id": "1", "_entity": {"id": "1", "block_number": 2}, "mutation_type": "UPDATE"}`
+      );
+      expect(listener).toHaveBeenNthCalledWith(
+        3,
+        `{"id": "1", "_entity": {"id": "1", "block_number": 2}, "mutation_type": "DELETE"}`
+      );
+    }, 10_000);
+  });
 });

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - WS libarary with support for graphiql (#2600)
+- Subscription type from JSON to the correct entity type (#2600)
 
 ## [2.16.0] - 2024-11-22
 ### Changed

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update the playground to the latest GraphiQL (#2588)
+- WS libarary with support for graphiql (#2600)
+
 ### Added
 - Support for historical indexing by timestamp as well as block height (#2584)
 

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -48,13 +48,14 @@
     "graphile-utils": "^4.12.2",
     "graphql": "^15.8.0",
     "graphql-query-complexity": "^0.11.0",
+    "graphql-ws": "^5.16.0",
     "lodash": "^4.17.21",
     "pg": "^8.12.0",
     "pg-tsquery": "^8.4.2",
     "postgraphile": "^4.13.0",
     "postgraphile-plugin-connection-filter": "^2.2.2",
     "rxjs": "^7.1.0",
-    "subscriptions-transport-ws": "^0.11.0",
+    "ws": "^8.18.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {
@@ -65,6 +66,7 @@
     "@types/express-pino-logger": "^4.0.5",
     "@types/jest": "^27.5.2",
     "@types/lodash": "^4.17.7",
+    "@types/ws": "^8",
     "@types/yargs": "^16.0.9",
     "nodemon": "^3.1.4"
   },

--- a/packages/query/src/graphql/plugins/PlaygroundPlugin.ts
+++ b/packages/query/src/graphql/plugins/PlaygroundPlugin.ts
@@ -3,7 +3,7 @@
 
 import type {ApolloServerPlugin, GraphQLServerListener} from 'apollo-server-plugin-base';
 
-export function playgroundPlugin(options: {url: string}): ApolloServerPlugin {
+export function playgroundPlugin(options: {url: string; subscriptionUrl?: string}): ApolloServerPlugin {
   return {
     // eslint-disable-next-line @typescript-eslint/require-await
     async serverWillStart(): Promise<GraphQLServerListener> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6883,6 +6883,7 @@ __metadata:
     "@types/express-pino-logger": ^4.0.5
     "@types/jest": ^27.5.2
     "@types/lodash": ^4.17.7
+    "@types/ws": ^8
     "@types/yargs": ^16.0.9
     apollo-server-express: ^3.12.0
     compression: ^1.7.4
@@ -6891,6 +6892,7 @@ __metadata:
     graphile-utils: ^4.12.2
     graphql: ^15.8.0
     graphql-query-complexity: ^0.11.0
+    graphql-ws: ^5.16.0
     lodash: ^4.17.21
     nodemon: ^3.1.4
     pg: ^8.12.0
@@ -6898,7 +6900,7 @@ __metadata:
     postgraphile: ^4.13.0
     postgraphile-plugin-connection-filter: ^2.2.2
     rxjs: ^7.1.0
-    subscriptions-transport-ws: ^0.11.0
+    ws: ^8.18.0
     yargs: ^16.2.0
   bin:
     subql-query: ./bin/run
@@ -8071,6 +8073,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: b4c9b8ad209620c9b21e78314ce4ff07515c0cadab9af101c1651e7bfb992d7fd933bd8b9c99d110738fd6db523ed15f82f29f50b45510288da72e964dedb1a3
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8":
+  version: 8.5.13
+  resolution: "@types/ws@npm:8.5.13"
+  dependencies:
+    "@types/node": "*"
+  checksum: f17023ce7b89c6124249c90211803a4aaa02886e12bc2d0d2cd47fa665eeb058db4d871ce4397d8e423f6beea97dd56835dd3fdbb921030fe4d887601e37d609
   languageName: node
   linkType: hard
 
@@ -13584,6 +13595,15 @@ __metadata:
   peerDependencies:
     graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
   checksum: b15162a3d62f17b9b79302445b9ee330e041582f1c7faca74b9dec5daa74272c906ec1c34e1c50592bb6215e5c3eba80a309103f6ba9e4c1cddc350c46f010df
+  languageName: node
+  linkType: hard
+
+"graphql-ws@npm:^5.16.0":
+  version: 5.16.0
+  resolution: "graphql-ws@npm:5.16.0"
+  peerDependencies:
+    graphql: ">=0.11 <=16"
+  checksum: e3e077ec187a92be3fd5dfae49e23af11a82711d3537064384f6861c2b5ceb339f60dc1871d0026b47ff05e4ed3c941404812a8086347e454688e0e6ef0e69f3
   languageName: node
   linkType: hard
 
@@ -20593,21 +20613,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"subscriptions-transport-ws@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "subscriptions-transport-ws@npm:0.11.0"
-  dependencies:
-    backo2: ^1.0.2
-    eventemitter3: ^3.1.0
-    iterall: ^1.2.1
-    symbol-observable: ^1.0.4
-    ws: ^5.2.0 || ^6.0.0 || ^7.0.0
-  peerDependencies:
-    graphql: ^15.7.2 || ^16.0.0
-  checksum: cc2e98d5c9d89c44d2e15eca188781c6ebae13d1661c42a99cee9d2897aebe2a22bc118eefff83244a79c88ee4ea24d46973ebf26ae7cb47ac1857fb8ee2c947
-  languageName: node
-  linkType: hard
-
 "subscriptions-transport-ws@npm:^0.9.18":
   version: 0.9.19
   resolution: "subscriptions-transport-ws@npm:0.9.19"
@@ -22497,7 +22502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.16.0":
+"ws@npm:^8.16.0, ws@npm:^8.18.0":
   version: 8.18.0
   resolution: "ws@npm:8.18.0"
   peerDependencies:


### PR DESCRIPTION
# Description
This somewhat improves what is mentioned in https://github.com/subquery/subql/issues/2590. It will now emit the `UPDATE` and `DELETE` mutation types rather than just `UPDATE`. Its still not possible to distinguish between `UPDATE` and insert with historical enabled.

Changes the subscription type of the entity from JSON to the correct entity type

Also updates the ws socket lib on the query service, this allow support for subscriptions in the playground.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update https://github.com/subquery/documentation/pull/573

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/573
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
