### PR TITLE
Fix subscriptions including multichain metadata tables

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Crash with query service subscriptions on multichain projects (#2609)
 
 ## [2.17.0] - 2024-11-25
 ### Changed

--- a/packages/query/src/graphql/plugins/PgSubscriptionPlugin.ts
+++ b/packages/query/src/graphql/plugins/PgSubscriptionPlugin.ts
@@ -46,7 +46,7 @@ export const PgSubscriptionPlugin = makeExtendSchemaPlugin((build) => {
 
   // Generate subscription fields for all database tables
   (pgIntrospectionResultsByKind as PgIntrospectionResultsByKind).class.forEach((table) => {
-    if (!table.namespace || table.name === '_metadata') return;
+    if (!table.namespace || table.name.includes('_metadata')) return;
 
     const field = inflection.allRows(table);
     const type = inflection.tableType(table);


### PR DESCRIPTION
# Description
Subscriptions check for the metadata table only checked for `_metadata` and not the multichain metadata tables.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
