### PR TITLE
Fixed the issue where flags that require special handling were being overwritten.

### DIFF
--- a/packages/cli/src/controller/deploy-controller.test.ts
+++ b/packages/cli/src/controller/deploy-controller.test.ts
@@ -153,7 +153,7 @@ describe('CLI deploy, delete, promote', () => {
 
   it('reDeploy to Hosted Service', async () => {
     const {ipfs, org, projectName, type} = projectSpec;
-    const newIPFS = 'QmbKvrzwSmzTZi5jrhEpa6yDDHQXRURi5S4ztLgJLpBxAi';
+    const newIPFS = 'Qmdr4yg98Fv8Yif3anjKVHhjuAKR665j6ekhWsfYUdkaCu';
     const validator = await ipfsCID_validate(projectSpec.ipfs, testAuth, ROOT_API_URL_PROD);
 
     const deployOutput = await deployTestProject(validator, ipfs, org, projectName, testAuth, ROOT_API_URL_PROD);

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- When the `primary-network-endpoint` flag exists, it will report an "Invalid endpoint" error.
+- When the `primary-network-endpoint` flag exists, it will report an "Invalid endpoint" error.(#2612)
 
 ## [15.0.3] - 2024-11-26
 ### Fixed

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- When the `primary-network-endpoint` flag exists, it will report an "Invalid endpoint" error.(#2612)
+- Fixed the issue where flags that require special handling were being overwritten.(#2612)
 
 ## [15.0.3] - 2024-11-26
 ### Fixed

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- When the `primary-network-endpoint` flag exists, it will report an "Invalid endpoint" error.
+
 ## [15.0.3] - 2024-11-26
 ### Fixed
 - Workers crashing because of lazy monitor write (#2607)

--- a/packages/node-core/src/configure/configure.module.spec.ts
+++ b/packages/node-core/src/configure/configure.module.spec.ts
@@ -93,7 +93,9 @@ describe('Configure', () => {
       const option = {headers: {'api-key': '<your-api-key>'}};
       const {primaryNetworkEndpoint} = yargsToIConfig({
         'primary-network-endpoint': 'https://example.com',
+        primaryNetworkEndpoint: 'https://example.com',
         'primary-network-endpoint-config': JSON.stringify(option),
+        primaryNetworkEndpointConfig: JSON.stringify(option),
       });
 
       expect(primaryNetworkEndpoint).toEqual(['https://example.com', option]);

--- a/packages/node-core/src/configure/configure.module.ts
+++ b/packages/node-core/src/configure/configure.module.ts
@@ -52,7 +52,7 @@ export function yargsToIConfig(yargs: Args, nameMapping: Record<string, string> 
   return Object.entries(yargs).reduce((acc, [key, value]) => {
     if (['_', '$0'].includes(key)) return acc;
 
-    if (key === 'network-registry') {
+    if (isMatchFlag(key, ['network-registry'])) {
       try {
         value = JSON.parse(value as string);
       } catch (e) {
@@ -61,7 +61,7 @@ export function yargsToIConfig(yargs: Args, nameMapping: Record<string, string> 
     }
 
     // Merge network endpoints and possible endpoint configs
-    if (key === 'network-endpoint') {
+    if (isMatchFlag(key, ['network-endpoint'])) {
       const endpointConfig = processEndpointConfig(yargs['network-endpoint-config']);
       if (typeof value === 'string') {
         value = [value];
@@ -76,22 +76,26 @@ export function yargsToIConfig(yargs: Args, nameMapping: Record<string, string> 
         );
       }
     }
-    if (key === 'primary-network-endpoint') {
+    if (isMatchFlag(key, ['primary-network-endpoint'])) {
       const endpointConfig = processEndpointConfig(yargs['primary-network-endpoint-config']);
       value = [value, endpointConfig[0] ?? {}];
     }
-    if (['network-endpoint-config', 'primary-network-endpoint-config'].includes(key)) return acc;
+    if (isMatchFlag(key, ['network-endpoint-config', 'primary-network-endpoint-config'])) return acc;
 
-    if (key === 'disable-historical' && value) {
+    if (isMatchFlag(key, ['disable-historical']) && value) {
       acc.historical = false;
     }
-    if (key === 'historical' && value === 'false') {
+    if (isMatchFlag(key, ['historical']) && value === 'false') {
       value = false;
     }
 
     acc[nameMapping[key] ?? camelCase(key)] = value;
     return acc;
   }, {} as any);
+}
+
+function isMatchFlag(key: string, targets: string[]): boolean {
+  return targets.some((target) => key === target || key === camelCase(target));
 }
 
 function warnDeprecations(argv: Args) {

--- a/packages/node-core/src/configure/configure.module.ts
+++ b/packages/node-core/src/configure/configure.module.ts
@@ -52,7 +52,9 @@ export function yargsToIConfig(yargs: Args, nameMapping: Record<string, string> 
   return Object.entries(yargs).reduce((acc, [key, value]) => {
     if (['_', '$0'].includes(key)) return acc;
 
-    if (isMatchFlag(key, ['network-registry'])) {
+    const outputKey = nameMapping[key] ?? camelCase(key);
+
+    if (outputKey === 'networkRegistry') {
       try {
         value = JSON.parse(value as string);
       } catch (e) {
@@ -61,7 +63,7 @@ export function yargsToIConfig(yargs: Args, nameMapping: Record<string, string> 
     }
 
     // Merge network endpoints and possible endpoint configs
-    if (isMatchFlag(key, ['network-endpoint'])) {
+    if (outputKey === 'networkEndpoint') {
       const endpointConfig = processEndpointConfig(yargs['network-endpoint-config']);
       if (typeof value === 'string') {
         value = [value];
@@ -76,26 +78,22 @@ export function yargsToIConfig(yargs: Args, nameMapping: Record<string, string> 
         );
       }
     }
-    if (isMatchFlag(key, ['primary-network-endpoint'])) {
+    if (outputKey === 'primaryNetworkEndpoint') {
       const endpointConfig = processEndpointConfig(yargs['primary-network-endpoint-config']);
       value = [value, endpointConfig[0] ?? {}];
     }
-    if (isMatchFlag(key, ['network-endpoint-config', 'primary-network-endpoint-config'])) return acc;
+    if (['networkEndpointConfig', 'primaryNetworkEndpointConfig'].includes(outputKey)) return acc;
 
-    if (isMatchFlag(key, ['disable-historical']) && value) {
+    if (outputKey === 'disableHistorical' && value) {
       acc.historical = false;
     }
-    if (isMatchFlag(key, ['historical']) && value === 'false') {
+    if (outputKey === 'historical' && value === 'false') {
       value = false;
     }
 
-    acc[nameMapping[key] ?? camelCase(key)] = value;
+    acc[outputKey] = value;
     return acc;
   }, {} as any);
-}
-
-function isMatchFlag(key: string, targets: string[]): boolean {
-  return targets.some((target) => key === target || key === camelCase(target));
 }
 
 function warnDeprecations(argv: Args) {

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- When the `primary-network-endpoint` flag exists, it will report an "Invalid endpoint" error.
+- When the `primary-network-endpoint` flag exists, it will report an "Invalid endpoint" error.(#2612)
 
 ## [5.4.2] - 2024-11-26
 ### Fixed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- When the `primary-network-endpoint` flag exists, it will report an "Invalid endpoint" error.
+
 ## [5.4.2] - 2024-11-26
 ### Fixed
 - Not using grouped events (#2607)


### PR DESCRIPTION
# Description
When the `primary-network-endpoint` flag exists, it will report an "Invalid endpoint" error.

After yargs parses the flags, there will be two types of fields: snake_case and camelCase. Therefore, we currently need to optimize the logic for handling camelCase fields.

Fixes #2612

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
