### PR TITLE
Add PgOrderByRelatedPlugin to GraphQL query package

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - High CPU usage caused by interval with 0ms (#2614)
+### Added
+- Add PgOrderByRelatedPlugin to GraphQL query package
 
 ## [2.17.1] - 2024-11-28
 ### Fixed
@@ -382,8 +384,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - overwrite plugin to fix one to one unique key check
 - update query publish and docker build process
 
-[Unreleased]: https://github.com/subquery/subql/compare/query/2.17.1...HEAD
-[2.17.1]: https://github.com/subquery/subql/compare/query/2.17.0...query/2.17.1
+[Unreleased]: https://github.com/subquery/subql/compare/query/2.17.0...HEAD
 [2.17.0]: https://github.com/subquery/subql/compare/query/2.16.0...query/2.17.0
 [2.16.0]: https://github.com/subquery/subql/compare/query/2.15.2...query/2.16.0
 [2.15.2]: https://github.com/subquery/subql/compare/query/2.15.1...query/2.15.2

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "@graphile-contrib/pg-many-to-many": "^1.0.2",
+    "@graphile-contrib/pg-order-by-related": "^1.0.0",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "@graphile/pg-aggregates": "^0.1.1",
     "@graphile/pg-pubsub": "^4.13.0",

--- a/packages/query/src/graphql/plugins/index.ts
+++ b/packages/query/src/graphql/plugins/index.ts
@@ -41,6 +41,7 @@ import PgConnectionTotalCount from '@subql/x-graphile-build-pg/node8plus/plugins
 import PgSimplifyInflectorPlugin from '@graphile-contrib/pg-simplify-inflector';
 import PgManyToManyPlugin from '@graphile-contrib/pg-many-to-many';
 import ConnectionFilterPlugin from 'postgraphile-plugin-connection-filter';
+import PgOrderByRelatedPlugin from '@graphile-contrib/pg-order-by-related';
 
 // custom plugins
 import PgConnectionArgFirstLastBeforeAfter from './PgConnectionArgFirstLastBeforeAfter';
@@ -113,6 +114,7 @@ const plugins = [
   PgRowByVirtualIdPlugin,
   PgDistinctPlugin,
   PgSearchPlugin,
+  PgOrderByRelatedPlugin,
   makeAddInflectorsPlugin((inflectors) => {
     const {constantCase: oldConstantCase} = inflectors;
     const enumValues = new Set();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4050,6 +4050,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphile-contrib/pg-order-by-related@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@graphile-contrib/pg-order-by-related@npm:1.0.0"
+  checksum: e5fa3655075b6c499926cf954e809ff827d23710919662a4a1de5a342b2d9874f7b5d47e4d7924aa8da65a3e33e716c57326358ef4cb8812ea125e21abefdd31
+  languageName: node
+  linkType: hard
+
 "@graphile-contrib/pg-simplify-inflector@npm:^6.1.0":
   version: 6.1.0
   resolution: "@graphile-contrib/pg-simplify-inflector@npm:6.1.0"
@@ -6860,6 +6867,7 @@ __metadata:
   resolution: "@subql/query@workspace:packages/query"
   dependencies:
     "@graphile-contrib/pg-many-to-many": ^1.0.2
+    "@graphile-contrib/pg-order-by-related": ^1.0.0
     "@graphile-contrib/pg-simplify-inflector": ^6.1.0
     "@graphile/pg-aggregates": ^0.1.1
     "@graphile/pg-pubsub": ^4.13.0


### PR DESCRIPTION
# Description

- Incorporated the [PgOrderByRelatedPlugin](https://github.com/graphile-contrib/pg-order-by-related) to enhance querying capabilities by allowing ordering based on related entities. 
- Updated the `package.json` and `yarn.lock` files to include the new dependency, ensuring all relevant configurations are in place.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
