### PR TITLE
Exporter improvements

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed the issue where flags that require special handling were being overwritten.(#2612)
 
+### Changed
+- Various internal improvements to exporters (CSV exporter) (#2617)
+
 ## [15.0.3] - 2024-11-26
 ### Fixed
 - Workers crashing because of lazy monitor write (#2607)

--- a/packages/node-core/src/indexer/storeModelProvider/baseCache.service.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/baseCache.service.ts
@@ -39,7 +39,11 @@ export abstract class BaseCacheService
       if ((this.isFlushable() || forceFlush) && this.flushableRecords > 0) {
         this.pendingFlush = this._flushCache();
         // Remove reference to pending flush once it completes
-        this.pendingFlush.finally(() => (this.pendingFlush = undefined));
+        this.pendingFlush
+          .catch((e) => {
+            /* Do nothing, avoids uncaught exception */
+          })
+          .finally(() => (this.pendingFlush = undefined));
         await this.pendingFlush;
       }
     };
@@ -48,7 +52,11 @@ export abstract class BaseCacheService
     if (this.queuedFlush === undefined) {
       this.queuedFlush = flushCacheGuarded(forceFlush);
 
-      this.queuedFlush.finally(() => (this.queuedFlush = undefined));
+      this.queuedFlush
+        .catch((e) => {
+          /* Do nothing, avoids uncaught exception */
+        })
+        .finally(() => (this.queuedFlush = undefined));
     }
 
     return this.queuedFlush;

--- a/packages/node-core/src/indexer/storeModelProvider/baseStoreModel.service.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/baseStoreModel.service.ts
@@ -53,7 +53,7 @@ export abstract class BaseStoreModelService<M = IModel<any>> implements BeforeAp
 
   getAllExporters(): Exporter[] {
     return Object.values(this.cachedModels)
-      .map((m) => (m as any).exporters)
+      .map((m) => (m as any).exporters ?? [])
       .flat();
   }
 }

--- a/packages/node-core/src/indexer/storeModelProvider/baseStoreModel.service.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/baseStoreModel.service.ts
@@ -6,10 +6,10 @@ import {ModelStatic} from '@subql/x-sequelize';
 import {getLogger} from '../../logger';
 import {MetadataRepo, PoiRepo} from '../entities';
 import {HistoricalMode} from '../types';
+import {Exporter} from './exporters';
 import {METADATA_ENTITY_NAME} from './metadata/utils';
 import {BaseEntity, IModel} from './model';
 import {POI_ENTITY_NAME} from './poi';
-import {Exporter} from './types';
 
 const logger = getLogger('BaseStoreModelService');
 export abstract class BaseStoreModelService<M = IModel<any>> implements BeforeApplicationShutdown {
@@ -17,7 +17,6 @@ export abstract class BaseStoreModelService<M = IModel<any>> implements BeforeAp
   protected poiRepo?: PoiRepo;
   protected metadataRepo?: MetadataRepo;
   protected cachedModels: Record<string, M> = {};
-  protected exports: Exporter[] = [];
 
   protected abstract createModel(entity: string): M;
 
@@ -48,7 +47,13 @@ export abstract class BaseStoreModelService<M = IModel<any>> implements BeforeAp
   }
 
   async beforeApplicationShutdown(): Promise<void> {
-    await Promise.all(this.exports.map((f) => f.shutdown()));
+    await Promise.all(this.getAllExporters().map((e) => e.shutdown()));
     logger.info(`Force flush exports successful!`);
+  }
+
+  getAllExporters(): Exporter[] {
+    return Object.values(this.cachedModels)
+      .map((m) => (m as any).exporters)
+      .flat();
   }
 }

--- a/packages/node-core/src/indexer/storeModelProvider/cacheable.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/cacheable.ts
@@ -19,8 +19,7 @@ export abstract class Cacheable {
         release();
       });
 
-      const pendingFlush = this.runFlush(tx, historicalUnit);
-      await pendingFlush;
+      await this.runFlush(tx, historicalUnit);
     } catch (e) {
       release();
       throw e;

--- a/packages/node-core/src/indexer/storeModelProvider/exporters/csvStore.spec.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/exporters/csvStore.spec.ts
@@ -3,11 +3,12 @@
 
 import fs from 'fs';
 import path from 'path';
+import type {Fn} from '@subql/x-sequelize/types/utils';
 import {rimraf} from 'rimraf';
-import {CsvStoreService} from './csvStore.service';
+import {CsvExporter} from './csvStore';
 
-describe('csv Store Service', () => {
-  const csvDirPath = path.join(__dirname, '../../../test/csv-test');
+describe('CSV Exporter', () => {
+  const csvDirPath = path.join(__dirname, '../../../../test/csv-test');
 
   beforeAll(async () => {
     await fs.promises.mkdir(csvDirPath);
@@ -16,34 +17,24 @@ describe('csv Store Service', () => {
   afterAll(async () => {
     await rimraf(csvDirPath);
   });
+
   it('Able to export to csv with correct output, No duplicated headers', async () => {
     const csvFilePath1 = path.join(csvDirPath, 'Test.csv');
 
-    const csvStore = new CsvStoreService('Test', csvDirPath);
+    const data = {
+      id: '1463-6',
+      amount: 98746560n,
+      blockNumber: 1463,
+      date: new Date('2020-05-26T18:03:24.000Z'),
+      fromId: '13gkdcmf2pxlw1mdctksezqf541ksy6mszfaehw5vftdpsxe',
+      toId: '15zf7zvduiy2eycgn6kwbv2sjpdbsp6vdhs1ytzdgjrcsmhn',
+      __block_range: {fn: 'int8range', args: [1463, null]} as unknown as Fn,
+    };
 
-    await csvStore.export([
-      {
-        id: '1463-6',
-        amount: 98746560n,
-        blockNumber: 1463,
-        date: new Date('2020-05-26T18:03:24.000Z'),
-        fromId: '13gkdcmf2pxlw1mdctksezqf541ksy6mszfaehw5vftdpsxe',
-        toId: '15zf7zvduiy2eycgn6kwbv2sjpdbsp6vdhs1ytzdgjrcsmhn',
-        __block_range: {fn: 'int8range', args: [1463, null]},
-      },
-    ]);
+    const csvStore = new CsvExporter<typeof data>('Test', csvDirPath);
 
-    await csvStore.export([
-      {
-        id: '1463-6',
-        amount: 98746560n,
-        blockNumber: 1463,
-        date: new Date('2020-05-26T18:03:24.000Z'),
-        fromId: '13gkdcmf2pxlw1mdctksezqf541ksy6mszfaehw5vftdpsxe',
-        toId: '15zf7zvduiy2eycgn6kwbv2sjpdbsp6vdhs1ytzdgjrcsmhn',
-        __block_range: {fn: 'int8range', args: [1463, null]},
-      },
-    ]);
+    await csvStore.export([data]);
+    await csvStore.export([data]);
 
     await csvStore.shutdown();
 
@@ -57,19 +48,20 @@ describe('csv Store Service', () => {
 `
     );
   });
+
   it('JSON serialisation', async () => {
     const csvFilePath2 = path.join(csvDirPath, 'JsonTest.csv');
 
-    const csvStore = new CsvStoreService('JsonTest', csvDirPath);
+    const data = {
+      id: '1463-6',
+      amount: 98746560n,
+      blockNumber: 1463,
+      jsonField: {field1: 'string', field2: 2, nestedJson: {foo: 'bar'}},
+    };
 
-    await csvStore.export([
-      {
-        id: '1463-6',
-        amount: 98746560n,
-        blockNumber: 1463,
-        jsonField: {field1: 'string', field2: 2, nestedJson: {foo: 'bar'}},
-      },
-    ]);
+    const csvStore = new CsvExporter<typeof data>('JsonTest', csvDirPath);
+
+    await csvStore.export([data]);
 
     await csvStore.shutdown();
     const csv = await fs.promises.readFile(csvFilePath2, 'utf-8');

--- a/packages/node-core/src/indexer/storeModelProvider/exporters/csvStore.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/exporters/csvStore.ts
@@ -4,12 +4,13 @@
 import fs from 'fs';
 import path from 'path';
 import {Stringifier, stringify} from 'csv-stringify';
-import {getLogger} from '../../logger';
-import {exitWithError} from '../../process';
-import {Exporter} from './types';
+import {getLogger} from '../../../logger';
+import {exitWithError} from '../../../process';
+import {BaseEntity} from '../model';
+import {Exporter} from './exporter';
 
 const logger = getLogger('CsvStore');
-export class CsvStoreService implements Exporter {
+export class CsvExporter<T extends BaseEntity = BaseEntity> implements Exporter<T> {
   private fileExist?: boolean;
   private stringifyStream: Stringifier;
   private readonly writeStream: fs.WriteStream;
@@ -39,31 +40,45 @@ export class CsvStoreService implements Exporter {
     this.fileExist = fs.existsSync(filePath);
     return filePath;
   }
-  async export(records: any[]): Promise<void> {
+
+  private async write(r: Omit<T, '__block_range'> & {blockNumber?: number}): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.stringifyStream.write(r, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(undefined);
+        }
+      });
+    });
+  }
+
+  private blockRangeToBlockNumber(input: T['__block_range']): number | undefined {
+    if (!input) return undefined;
+
+    if (Array.isArray(input)) {
+      return input[0] ?? undefined;
+    }
+
+    if ((input as any).fn === 'int8range') {
+      return (input as any).args[0];
+    }
+  }
+
+  async export(records: T[]): Promise<void> {
     await Promise.all(
       records
-        .map((r: any) => {
-          // remove store
-          const {__block_range, store, ...orgRecord} = r;
+        .map((r) => {
+          const {__block_range, ...orgRecord} = r;
           if (__block_range !== undefined) {
             return {
               ...orgRecord,
-              __block_number: r.blockNumber,
+              __block_number: this.blockRangeToBlockNumber(__block_range),
             };
           }
           return orgRecord;
         })
-        .map((r) => {
-          return new Promise((resolve, reject) => {
-            this.stringifyStream.write(r, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve(undefined);
-              }
-            });
-          });
-        })
+        .map((r) => this.write(r))
     );
   }
 

--- a/packages/node-core/src/indexer/storeModelProvider/exporters/exporter.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/exporters/exporter.ts
@@ -1,0 +1,60 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {BaseEntity} from '../model';
+
+export interface Exporter<T extends BaseEntity = BaseEntity> {
+  /**
+   * Exports an array of records.
+   * This method should handle the processing of the provided records.
+   *
+   * @param records An array of records to be exported.
+   *                These records are of the same type as the database entries
+   */
+  export: (record: T[]) => Promise<void>;
+  /**
+   * Shuts down the export operation.
+   * This method should ensure that all ongoing export operations are
+   * completed and any resources used are properly released or closed.
+   *
+   * @returns A promise that resolves when the shutdown process is complete.
+   */
+  shutdown: () => Promise<void>;
+}
+
+export type TransactionedExporter<T extends BaseEntity = BaseEntity> = Exporter<T> & {commit: () => Promise<void>};
+
+export function isTxExporter<T extends BaseEntity = BaseEntity>(
+  exporter: Exporter<T>
+): exporter is TransactionedExporter<T> {
+  return typeof (exporter as TransactionedExporter).commit === 'function';
+}
+
+export function asTxExporter<T extends BaseEntity = BaseEntity>(exporter: Exporter<T>): TransactionedExporter<T> {
+  if (isTxExporter(exporter)) return exporter;
+  return new TxExporter(exporter);
+}
+
+export class TxExporter<T extends BaseEntity = BaseEntity> implements TransactionedExporter<T> {
+  #pendingData: T[] = [];
+  #exporter: Exporter<T>;
+
+  constructor(exporter: Exporter<T>) {
+    this.#exporter = exporter;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async export(data: T[]): Promise<void> {
+    this.#pendingData.push(...data);
+  }
+
+  async shutdown(): Promise<void> {
+    await this.commit();
+    await this.#exporter.shutdown();
+  }
+
+  async commit(): Promise<void> {
+    await this.#exporter.export(this.#pendingData);
+    this.#pendingData = [];
+  }
+}

--- a/packages/node-core/src/indexer/storeModelProvider/exporters/index.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/exporters/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+export * from './exporter';
+export * from './csvStore';

--- a/packages/node-core/src/indexer/storeModelProvider/model/cacheModel.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/model/cacheModel.ts
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import assert from 'assert';
-import { FieldsExpression, GetOptions } from '@subql/types-core';
-import { CreationAttributes, Model, ModelStatic, Op, Sequelize, Transaction } from '@subql/x-sequelize';
-import { flatten, uniq, cloneDeep, orderBy, unionBy } from 'lodash';
-import { NodeConfig } from '../../../configure';
-import { HistoricalMode } from '../../types';
-import { Cacheable } from '../cacheable';
-import { CsvStoreService } from '../csvStore.service';
-import { SetValueModel } from '../setValueModel';
-import { ICachedModelControl, RemoveValue, SetData, GetData, FilteredHeightRecords, SetValue, Exporter } from '../types';
-import { BaseEntity, IModel } from './model';
-import { getFullOptions, operatorsMap } from './utils';
+import {FieldsExpression, GetOptions} from '@subql/types-core';
+import {CreationAttributes, Model, ModelStatic, Op, Sequelize, Transaction} from '@subql/x-sequelize';
+import {flatten, uniq, cloneDeep, orderBy, unionBy} from 'lodash';
+import {NodeConfig} from '../../../configure';
+import {HistoricalMode} from '../../types';
+import {Cacheable} from '../cacheable';
+import {Exporter} from '../exporters';
+import {SetValueModel} from '../setValueModel';
+import {ICachedModelControl, RemoveValue, SetData, GetData, FilteredHeightRecords, SetValue} from '../types';
+import {BaseEntity, IModel} from './model';
+import {getFullOptions, operatorsMap} from './utils';
 
 const getCacheOptions = {
   max: 500, // default value
@@ -22,13 +22,14 @@ const getCacheOptions = {
 
 export class CachedModel<T extends BaseEntity = BaseEntity>
   extends Cacheable
-  implements IModel<T>, ICachedModelControl {
+  implements IModel<T>, ICachedModelControl
+{
   // Null value indicates its not defined in the db
   private getCache: GetData<T>;
   private setCache: SetData<T> = {};
   private removeCache: Record<string, RemoveValue> = {};
   readonly hasAssociations: boolean = false;
-  private exporters: Exporter[] = [];
+  exporters: Exporter[] = [];
 
   flushableRecordCounter = 0;
 
@@ -82,7 +83,7 @@ export class CachedModel<T extends BaseEntity = BaseEntity>
         record = (
           await this.model.findOne({
             // https://github.com/sequelize/sequelize/issues/15179
-            where: { id } as any,
+            where: {id} as any,
           })
         )?.toJSON();
         if (record) {
@@ -96,7 +97,7 @@ export class CachedModel<T extends BaseEntity = BaseEntity>
     return cloneDeep(this.getCache.get(id));
   }
 
-  addExporterStore(cacheState: CsvStoreService): void {
+  addExporter(cacheState: Exporter): void {
     this.exporters.push(cacheState);
   }
 
@@ -152,8 +153,8 @@ export class CachedModel<T extends BaseEntity = BaseEntity>
     const records = await this.model.findAll({
       where: {
         [Op.and]: [
-          ...filters.map(([field, operator, value]) => ({ [field]: { [operatorsMap[operator]]: value } })),
-          { id: { [Op.notIn]: this.allCachedIds() } },
+          ...filters.map(([field, operator, value]) => ({[field]: {[operatorsMap[operator]]: value}})),
+          {id: {[Op.notIn]: this.allCachedIds()}},
         ] as any, // Types not working properly
       },
       limit: fullOptions.limit - offsetCacheData.length, // Only get enough to fill the limit
@@ -234,7 +235,7 @@ export class CachedModel<T extends BaseEntity = BaseEntity>
 
   async runFlush(tx: Transaction, blockHeight: number): Promise<void> {
     // Get records relevant to the block height
-    const { removeRecords, setRecords } = this.filterRecordsWithHeight(blockHeight);
+    const {removeRecords, setRecords} = this.filterRecordsWithHeight(blockHeight);
     // Filter non-historical could return undefined due to it been removed
     let records = this.applyBlockRange(setRecords).filter((r) => !!r);
     let dbOperation: Promise<unknown>;
@@ -272,20 +273,20 @@ export class CachedModel<T extends BaseEntity = BaseEntity>
 
       dbOperation = Promise.all([
         records.length &&
-        this.model.bulkCreate(records, {
-          transaction: tx,
-          updateOnDuplicate: Object.keys(records[0]) as unknown as (keyof T)[],
-        }),
+          this.model.bulkCreate(records, {
+            transaction: tx,
+            updateOnDuplicate: Object.keys(records[0]) as unknown as (keyof T)[],
+          }),
         Object.keys(removeRecords).length &&
-        this.model.destroy({ where: { id: Object.keys(removeRecords) } as any, transaction: tx }),
+          this.model.destroy({where: {id: Object.keys(removeRecords)} as any, transaction: tx}),
       ]);
     }
-    this.exporters.forEach((store: Exporter) => {
-      tx.afterCommit(async () => {
-        await store.export(records);
-      });
-    });
+
     await dbOperation;
+    // If this throws the transaction should be aborted
+    for (const exporter of this.exporters) {
+      await exporter.export(records);
+    }
   }
 
   // Flush relation model in operationIndex order with non-historical db
@@ -294,7 +295,7 @@ export class CachedModel<T extends BaseEntity = BaseEntity>
       (key) => this.removeCache[key].operationIndex === operationIndex
     );
     if (removeRecordKey !== undefined) {
-      await this.model.destroy({ where: { id: removeRecordKey } as any, transaction: tx });
+      await this.model.destroy({where: {id: removeRecordKey} as any, transaction: tx});
       delete this.removeCache[removeRecordKey];
     } else {
       let setRecord: SetValue<T> | undefined;
@@ -303,7 +304,7 @@ export class CachedModel<T extends BaseEntity = BaseEntity>
         if (setRecord) break;
       }
       if (setRecord) {
-        await this.model.upsert(setRecord.data as unknown as CreationAttributes<Model<T, T>>, { transaction: tx });
+        await this.model.upsert(setRecord.data as unknown as CreationAttributes<Model<T, T>>, {transaction: tx});
       }
       return;
     }
@@ -401,15 +402,15 @@ export class CachedModel<T extends BaseEntity = BaseEntity>
     setRecords: SetData<T>,
     removeRecords: Record<string, RemoveValue>
   ): Promise<void> {
-    const closeSetRecords: { id: string; blockHeight: number }[] = [];
+    const closeSetRecords: {id: string; blockHeight: number}[] = [];
     for (const [id, value] of Object.entries(setRecords)) {
       const firstValue = value.getFirst();
       if (firstValue !== undefined) {
-        closeSetRecords.push({ id, blockHeight: firstValue.startHeight });
+        closeSetRecords.push({id, blockHeight: firstValue.startHeight});
       }
     }
     const closeRemoveRecords = Object.entries(removeRecords).map(([id, value]) => {
-      return { id, blockHeight: value.removedAtBlock };
+      return {id, blockHeight: value.removedAtBlock};
     });
     const mergedRecords = closeSetRecords.concat(closeRemoveRecords);
 
@@ -420,10 +421,10 @@ export class CachedModel<T extends BaseEntity = BaseEntity>
     await this.sequelize.query(
       `UPDATE ${this.model.getTableName()} table1 SET _block_range = int8range(lower("_block_range"), table2._block_end)
             from (SELECT UNNEST(array[${mergedRecords.map((r) =>
-        this.sequelize.escape(r.id)
-      )}]) AS id, UNNEST(array[${mergedRecords.map((r) => r.blockHeight)}]) AS _block_end) AS table2
+              this.sequelize.escape(r.id)
+            )}]) AS id, UNNEST(array[${mergedRecords.map((r) => r.blockHeight)}]) AS _block_end) AS table2
             WHERE table1.id = table2.id and "_block_range" @> _block_end-1::int8;`,
-      { transaction: tx }
+      {transaction: tx}
     );
   }
 

--- a/packages/node-core/src/indexer/storeModelProvider/storeModel.service.spec.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/storeModel.service.spec.ts
@@ -1,0 +1,94 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {delay} from '@subql/common';
+import {NodeConfig} from '@subql/node-core/configure';
+import {Sequelize} from '@subql/x-sequelize';
+import {Exporter} from './exporters';
+import {BaseEntity} from './model';
+import {PlainStoreModelService} from './storeModel.service';
+
+type TestEntity = BaseEntity & {field1: string};
+
+jest.mock('@subql/x-sequelize', () => {
+  const mSequelize = {
+    authenticate: jest.fn(),
+    Op: {
+      in: jest.fn(),
+      notIn: jest.fn(),
+    },
+    define: () => ({
+      findOne: jest.fn(),
+      create: (input: any) => input,
+    }),
+    query: () => [{nextval: 1}],
+    showAllSchemas: () => ['subquery_1'],
+    model: (entity: string) => ({
+      upsert: jest.fn(),
+      associations: [{}, {}],
+      count: 5,
+      findAll: jest.fn(() => [
+        {
+          toJSON: () => ({
+            id: 'apple-05-sequelize',
+            field1: 'set apple at block 5 with sequelize',
+          }),
+        },
+      ]),
+      bulkCreate: jest.fn(),
+      destroy: jest.fn(),
+    }),
+    sync: jest.fn(),
+    transaction: () => ({
+      commit: jest.fn(() => delay(1)), // Delay of 1s is used to test whether we wait for cache to flush
+      rollback: jest.fn(),
+      afterCommit: jest.fn(),
+    }),
+    // createSchema: jest.fn(),
+  };
+  const actualSequelize = jest.requireActual('@subql/x-sequelize');
+  return {
+    ...actualSequelize,
+    Sequelize: jest.fn(() => mSequelize),
+  };
+});
+
+const errorExporter = {
+  export: () => {
+    return Promise.reject(new Error('Cant export'));
+  },
+  shutdown: () => Promise.resolve(),
+} satisfies Exporter;
+
+describe('StoreModelService', () => {
+  let modelService: PlainStoreModelService;
+
+  const sequelize = new Sequelize();
+  const nodeConfig = {} as NodeConfig;
+
+  beforeEach(() => {
+    modelService = new PlainStoreModelService(sequelize, nodeConfig);
+    modelService.init(false, {findByPk: () => Promise.resolve({toJSON: () => 1})} as any, undefined);
+  });
+
+  it('aborts the transaction if an exporter fails', async () => {
+    const entity1Model = modelService.getModel<TestEntity>('entity1');
+    const tx = await sequelize.transaction();
+
+    (modelService as any).addExporter(entity1Model, errorExporter);
+
+    for (let i = 0; i < 5; i++) {
+      await entity1Model.set(
+        `entity1_id_0x0${i}`,
+        {
+          id: `entity1_id_0x0${i}`,
+          field1: 'set at block 1',
+        },
+        1,
+        tx
+      );
+    }
+
+    await expect(() => modelService.applyPendingChanges(1, false, tx)).rejects.toThrow('Cant export');
+  });
+});

--- a/packages/node-core/src/indexer/storeModelProvider/types.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/types.ts
@@ -1,16 +1,16 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import { ModelStatic, Transaction } from '@subql/x-sequelize';
-import { LRUCache } from 'lru-cache';
-import { MetadataRepo, PoiRepo } from '../entities';
-import { HistoricalMode } from '../types';
-import { IMetadata } from './metadata';
-import { BaseEntity, IModel } from './model';
-import { IPoi } from './poi';
-import { SetValueModel } from './setValueModel';
+import {ModelStatic, Transaction} from '@subql/x-sequelize';
+import {LRUCache} from 'lru-cache';
+import {MetadataRepo, PoiRepo} from '../entities';
+import {HistoricalMode} from '../types';
+import {IMetadata} from './metadata';
+import {BaseEntity, IModel} from './model';
+import {IPoi} from './poi';
+import {SetValueModel} from './setValueModel';
 
-export type HistoricalModel = { __block_range: any };
+export type HistoricalModel = {__block_range: any};
 
 export interface IStoreModelProvider {
   poi: IPoi | null;
@@ -20,11 +20,9 @@ export interface IStoreModelProvider {
 
   getModel<T extends BaseEntity>(entity: string): IModel<T>;
 
-  // addExporter(entity: string, exporterStore: CsvStoreService): void;
-
   applyPendingChanges(height: number, dataSourcesCompleted: boolean, tx?: Transaction): Promise<void>;
 
-  updateModels({ modifiedModels, removedModels }: { modifiedModels: ModelStatic<any>[]; removedModels: string[] }): void;
+  updateModels({modifiedModels, removedModels}: {modifiedModels: ModelStatic<any>[]; removedModels: string[]}): void;
 }
 
 export interface ICachedModelControl {
@@ -69,22 +67,3 @@ export type SetValue<T> = {
 export type SetData<T> = Record<string, SetValueModel<T>>;
 
 export class GetData<T extends {}> extends LRUCache<string, T, unknown> {}
-
-export interface Exporter {
-  /**
-   * Exports an array of records.
-   * This method should handle the processing of the provided records.
-   *
-   * @param records An array of records to be exported.
-   *                These records are of the same type as the database entries
-   */
-  export: (record: any[]) => Promise<void>;
-  /**
-   * Shuts down the export operation.
-   * This method should ensure that all ongoing export operations are
-   * completed and any resources used are properly released or closed.
-   *
-   * @returns A promise that resolves when the shutdown process is complete.
-   */
-  shutdown: () => Promise<void>;
-}

--- a/packages/node-core/src/indexer/storeModelProvider/utils.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/utils.ts
@@ -9,12 +9,12 @@ import {StoreCacheService} from './storeCache.service';
 import {PlainStoreModelService} from './storeModel.service';
 import {IStoreModelProvider} from './types';
 
-export async function cacheProviderFlushData(modelProvider: IStoreModelProvider, forceFlush?: boolean) {
+export async function cacheProviderFlushData(modelProvider: IStoreModelProvider, forceFlush?: boolean): Promise<void> {
   if (modelProvider instanceof StoreCacheService) {
     await modelProvider.flushData(forceFlush);
   }
 }
-export async function cacheProviderResetData(modelProvider: IStoreModelProvider) {
+export async function cacheProviderResetData(modelProvider: IStoreModelProvider): Promise<void> {
   if (modelProvider instanceof StoreCacheService) {
     await modelProvider.resetData();
   }


### PR DESCRIPTION
# Description
Fixes some issues with exporters:
* Operation not being atomic with store cache disabled
* Class types instead of interface types
* Unexplained `store` being extracted
* Incorrect `__block_height` calculation that assumed a field called `blockHeight`
* Improve consistency naming things relating to exporters, there was a mix of store and exporter.
* Restructure locations to prepare for support for other exporters

Other
* Catch uncaught promise exceptions, these were already handled but `finalize` without a `catch` leads to an uncaught exception

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
