### PR TITLE
Fix typos and formatting in documentation files

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -659,7 +659,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@subql/node` will recognise it and create table with additional indexes to speed querying
 - Allow query by indexed field via `global.store` (#271)
 - annotation is now supported in
-- We'll automatically generate coresponding JSON interfaces when querying this data (#275)
+- We'll automatically generate corresponding JSON interfaces when querying this data (#275)
 - Read more about how you can use this in our [updated docs](https://doc.subquery.network/create/graphql.html#json-type)
 
 ## [0.8.0] - 2021-03-11

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -413,7 +413,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.9.1]: https://github.com/subquery/subql/compare/query/2.9.0...query/2.9.1
 [2.9.0]: https://github.com/subquery/subql/compare/query/2.8.0...query/2.9.0
 [2.8.0]: https://github.com/subquery/subql/compare/query/2.7.0...query/2.8.0
-[2.7.0]: https://github.com/subquery/subql/compare/query/2.6.0...query2.7.0
+[2.7.0]: https://github.com/subquery/subql/compare/query/2.6.0...query/2.7.0
 [2.6.0]: https://github.com/subquery/subql/compare/query/2.5.0...query/2.6.0
 [2.5.0]: https://github.com/subquery/subql/compare/query/2.4.0...query/2.5.0
 [2.4.0]: https://github.com/subquery/subql/compare/query/2.3.0...query/2.4.0
@@ -421,7 +421,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.2.0]: https://github.com/subquery/subql/compare/query/2.1.0...query/2.2.0
 [2.1.0]: https://github.com/subquery/subql/compare/query/2.0.1..query/2.1.0
 [2.0.1]: https://github.com/subquery/subql/compare/query/2.0.0...query/2.0.1
-[2.0.0]: https://github.com/subquery/subql/compare/query/.1.11.2..query/2.0.0
+[2.0.0]: https://github.com/subquery/subql/compare/query/1.11.2..query/2.0.0
 [1.11.2]: https://github.com/subquery/subql/compare/query/1.11.1...query/1.11.2
 [1.11.1]: https://github.com/subquery/subql/compare/query/1.11.0...query/1.11.1
 [1.11.0]: https://github.com/subquery/subql/compare/query/1.10.2...query/1.11.0

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -15,5 +15,5 @@ DB_DATABASE=postgres
 then run the following command
 
 ```
-$ NODE_OPTIONS="-r dotenv/config" yarn start -- --name <subuqery_name> --playground
+$ NODE_OPTIONS="-r dotenv/config" yarn start -- --name <subquery_name> --playground
 ```


### PR DESCRIPTION
## Reason for Changes
1. Fixed the spelling of "corresponding" which was incorrectly written as "coresponding"
2. Fixed version link formatting by adding missing forward slash and removing extra dots
3. Corrected the typo in the example command where "subquery" was misspelled as "subuqery"

These changes improve documentation accuracy and readability, making it easier for users to follow links and execute commands correctly.

