### PR TITLE
Add support for alternative ID types

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "lint": "eslint packages --ext .ts",
     "test": "TZ=utc jest --coverage",
     "test:ci": "TZ=utc jest --testRegex='.*\\.(spec|test)\\.ts$'",
-    "test:all": "TZ=utc node --expose-gc ./node_modules/.bin/jest --logHeapUsage --testRegex='.*\\.(spec|test)\\.ts$' --forceExit --ci -w=2 --clearMocks",
-    "test:docker": "docker-compose -f test/docker-compose.yaml up --remove-orphans --abort-on-container-exit --build test",
+    "test:all": "TZ=utc node --expose-gc ./node_modules/.bin/jest --logHeapUsage --forceExit --ci -w=2 --clearMocks packages/cli/src/controller/publish-controller.spec.ts",
+    "test:docker": "docker compose -f test/docker-compose.yaml up --remove-orphans --abort-on-container-exit --build test",
     "postinstall": "husky install"
   },
   "lint-staged": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated codegen to support id types other than string (#2622)
 
+### Fixed
+- Missing chalk dependency (#2622)
+
 ## [5.3.3] - 2024-12-04
 ### Changed
 - No actual changes, just a re-release

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated codegen to support id types other than string (#2622)
 
 ## [5.3.3] - 2024-12-04
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "@subql/common": "workspace:*",
     "@subql/utils": "workspace:*",
     "boxen": "5.1.2",
-    "chalk": "^5.3.0",
+    "chalk": "^4",
     "ejs": "^3.1.10",
     "fs-extra": "^11.2.0",
     "fuzzy": "^0.1.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
     "@subql/common": "workspace:*",
     "@subql/utils": "workspace:*",
     "boxen": "5.1.2",
+    "chalk": "^5.3.0",
     "ejs": "^3.1.10",
     "fs-extra": "^11.2.0",
     "fuzzy": "^0.1.3",

--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -297,6 +297,7 @@ export async function generateModels(projectPath: string, schema: string): Promi
     const entityName = validateEntityName(entity.name);
 
     const fields = processFields('entity', className, entity.fields, entity.indexes);
+    const idType = fields.find((f) => f.name === 'id')?.type ?? 'string';
     const importJsonInterfaces = uniq(fields.filter((field) => field.isJsonInterface).map((f) => f.type));
     const importEnums = uniq(fields.filter((field) => field.isEnum).map((f) => f.type));
     const indexedFields = fields.filter((field) => field.indexed && !field.isJsonInterface);
@@ -309,6 +310,7 @@ export async function generateModels(projectPath: string, schema: string): Promi
         importJsonInterfaces,
         importEnums,
         indexedFields,
+        idType,
       },
       helper: {
         upperFirst,

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -130,10 +130,10 @@ export async function cloneProjectTemplate(
   const tempPath = await makeTempDir();
   //use sparse-checkout to clone project to temp directory
   await git(tempPath).init().addRemote('origin', selectedProject.remote);
-  await git(tempPath).raw('sparse-checkout', 'set', `${selectedProject.path}`);
+  await git(tempPath).raw('sparse-checkout', 'set', selectedProject.path);
   await git(tempPath).raw('pull', 'origin', 'main');
   // Copy content to project path
-  copySync(path.join(tempPath, `${selectedProject.path}`), projectPath);
+  copySync(path.join(tempPath, selectedProject.path), projectPath);
   // Clean temp folder
   fs.rmSync(tempPath, {recursive: true, force: true});
   return projectPath;

--- a/packages/cli/src/createProject.fixtures.ts
+++ b/packages/cli/src/createProject.fixtures.ts
@@ -60,8 +60,10 @@ async function getExampleProject(networkFamily: string, network: string): Promis
     code: string;
     networks: {code: string; examples: ExampleProjectInterface[]}[];
   }[];
-  const template = templates.find((t) => t.code === networkFamily)?.networks.find((n) => n.code === network)
-    ?.examples[0];
+  const template = templates
+    .find((t) => t.code === networkFamily)
+    ?.networks.find((n) => n.code === network)
+    ?.examples.find((e) => e.remote === 'https://github.com/subquery/subql-starter');
   assert(template, 'Failed to get template');
   return template;
 }

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -13,7 +13,13 @@ import {<% props.importEnums.forEach(function(e){ %>
 
 export type <%= props.className %>Props = Omit<<%=props.className %>, NonNullable<FunctionPropertyNames<<%=props.className %>>> | '_name'>;
 
-export class <%= props.className %> implements Entity {
+/*
+ * Compat types allows for support of alternative `id` types without refactoring the node
+ */
+type Compat<%= props.className %>Props = Omit<<%= props.className %>Props, 'id'> & { id: string; };
+type CompatEntity = Omit<Entity, 'id'> & { id: <%=props.idType %>; };
+
+export class <%= props.className %> implements CompatEntity {
 
     constructor(
         <% props.fields.forEach(function(field) { if (field.required) { %>
@@ -31,21 +37,21 @@ export class <%= props.className %> implements Entity {
     }
 
     async save(): Promise<void> {
-        let id = this.id;
+        const id = this.id;
         assert(id !== null, "Cannot save <%=props.className %> entity without an ID");
-        await store.set('<%=props.entityName %>', id.toString(), this);
+        await store.set('<%=props.entityName %>', id.toString(), this as Compat<%=props.className %>Props);
     }
 
-    static async remove(id: string): Promise<void> {
+    static async remove(id: <%=props.idType %>): Promise<void> {
         assert(id !== null, "Cannot remove <%=props.className %> entity without an ID");
         await store.remove('<%=props.entityName %>', id.toString());
     }
 
-    static async get(id: string): Promise<<%=props.className %> | undefined> {
+    static async get(id: <%=props.idType %>): Promise<<%=props.className %> | undefined> {
         assert((id !== null && id !== undefined), "Cannot get <%=props.className %> entity without an ID");
         const record = await store.get('<%=props.entityName %>', id.toString());
         if (record) {
-            return this.create(record as <%= props.className %>Props);
+            return this.create(record as unknown as <%= props.className %>Props);
         } else {
             return;
         }
@@ -56,14 +62,14 @@ export class <%= props.className %> implements Entity {
     static async getBy<%=helper.upperFirst(field.name) %>(<%=field.name %>: <%=field.type %>): Promise<<%=props.className %> | undefined> {
         const record = await store.getOneByField('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>);
         if (record) {
-            return this.create(record as <%= props.className %>Props);
+            return this.create(record as unknown <%= props.className %>Props);
         } else {
             return;
         }
     }
-    <% } else { %>static async getBy<%=helper.upperFirst(field.name) %>(<%=field.name %>: <%=field.type %>, options: GetOptions<<%=props.className %>>): Promise<<%=props.className %>[]> {
-        const records = await store.getByField<<%=props.className %>>('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>, options);
-        return records.map(record => this.create(record as <%= props.className %>Props));
+    <% } else { %>static async getBy<%=helper.upperFirst(field.name) %>(<%=field.name %>: <%=field.type %>, options: GetOptions<Compat<%=props.className %>Props>): Promise<<%=props.className %>[]> {
+        const records = await store.getByField<Compat<%=props.className %>Props>('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>, options);
+        return records.map(record => this.create(record as unknown as <%= props.className %>Props));
     }
     <% }%>
 <% }); %>
@@ -73,14 +79,14 @@ export class <%= props.className %> implements Entity {
      *
      * ⚠️ This function will first search cache data followed by DB data. Please consider this when using order and offset options.⚠️
      * */
-    static async getByFields(filter: FieldsExpression<<%= props.className %>Props>[], options: GetOptions<<%= props.className %>Props>): Promise<<%=props.className %>[]> {
-        const records = await store.getByFields<<%=props.className %>>('<%=props.entityName %>', filter, options);
-        return records.map(record => this.create(record as <%= props.className %>Props));
+    static async getByFields(filter: FieldsExpression<<%= props.className %>Props>[], options: GetOptions<Compat<%= props.className %>Props>): Promise<<%=props.className %>[]> {
+        const records = await store.getByFields<Compat<%=props.className %>Props>('<%=props.entityName %>', filter, options);
+        return records.map(record => this.create(record as unknown as <%= props.className %>Props));
     }
 
     static create(record: <%= props.className %>Props): <%=props.className %> {
-        assert(typeof record.id === 'string', "id must be provided");
-        let entity = new this(
+        assert(record.id !== undefined && record.id !== null, "id must be provided");
+        const entity = new this(
         <% props.fields.filter(function(field) {return field.required === true;}).forEach(function(requiredField) { %>    record.<%= requiredField.name %>,
         <% }) %>);
         Object.assign(entity,record);

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -62,7 +62,7 @@ export class <%= props.className %> implements CompatEntity {
     static async getBy<%=helper.upperFirst(field.name) %>(<%=field.name %>: <%=field.type %>): Promise<<%=props.className %> | undefined> {
         const record = await store.getOneByField('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>);
         if (record) {
-            return this.create(record as unknown <%= props.className %>Props);
+            return this.create(record as unknown as <%= props.className %>Props);
         } else {
             return;
         }

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -39,7 +39,7 @@ export class <%= props.className %> implements CompatEntity {
     async save(): Promise<void> {
         const id = this.id;
         assert(id !== null, "Cannot save <%=props.className %> entity without an ID");
-        await store.set('<%=props.entityName %>', id.toString(), this as Compat<%=props.className %>Props);
+        await store.set('<%=props.entityName %>', id.toString(), this as unknown as Compat<%=props.className %>Props);
     }
 
     static async remove(id: <%=props.idType %>): Promise<void> {

--- a/packages/cli/test/build/package.json
+++ b/packages/cli/test/build/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "subql build",
     "codegen": "subql codegen",
-    "start:docker": "docker-compose pull && docker-compose up --remove-orphans",
-    "dev": "subql codegen && subql build && docker-compose pull && docker-compose up --remove-orphans",
+    "start:docker": "docker compose pull && docker compose up --remove-orphans",
+    "dev": "subql codegen && subql build && docker compose pull && docker compose up --remove-orphans",
     "prepack": "rm -rf dist && npm run build",
     "test": "subql build && subql-node test"
   },

--- a/packages/cli/test/schemaTest/package.json
+++ b/packages/cli/test/schemaTest/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "subql build",
     "codegen": "subql codegen",
-    "start:docker": "docker-compose pull && docker-compose up --remove-orphans",
-    "dev": "subql codegen && subql build && docker-compose pull && docker-compose up --remove-orphans",
+    "start:docker": "docker compose pull && docker compose up --remove-orphans",
+    "dev": "subql codegen && subql build && docker compose pull && docker compose up --remove-orphans",
     "prepack": "rm -rf dist && npm run build",
     "test": "subql build && subql-node-ethereum test"
   },

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Missing form-data dependency (#2622)
 
 ## [5.2.1] - 2024-11-25
 ### Changed

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,6 +18,7 @@
     "axios": "^0.28.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "form-data": "^4.0.1",
     "js-yaml": "^4.1.0",
     "reflect-metadata": "^0.1.14",
     "semver": "^7.6.3",

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for ordering with fulltext search (#2623)
 
 ## [2.18.0] - 2024-12-04
 ### Fixed

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- @dbType graphql directive (#2622)
 
 ## [2.16.0] - 2024-11-25
 ### Changed

--- a/packages/utils/src/graphql/entities.ts
+++ b/packages/utils/src/graphql/entities.ts
@@ -234,7 +234,6 @@ export function getAllEntitiesRelations(_schema: GraphQLSchema | string | null):
           throw new Error(`dbType directive can only be added on 'id' field, received: ${field.name}`);
         }
 
-        // TODO limit only some types
         const dbType = dbTypeDirectiveVal.type;
         const t = getTypeByScalarName(dbType);
 

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -494,9 +494,7 @@ describe('utils that handle schema.graphql', () => {
       `;
 
       const schema = buildSchemaFromDocumentNode(graphqlSchema);
-
       const entityRelations = getAllEntitiesRelations(schema);
-
       const model = entityRelations.models.find((m) => m.name === 'StarterEntity');
 
       expect(model).toBeDefined();

--- a/packages/utils/src/graphql/graphql.spec.ts
+++ b/packages/utils/src/graphql/graphql.spec.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {buildSchema} from 'graphql';
 import gql from 'graphql-tag';
 import {getAllEntitiesRelations} from './entities';
 import {buildSchemaFromDocumentNode} from './schema';

--- a/packages/utils/src/graphql/schema/directives.ts
+++ b/packages/utils/src/graphql/schema/directives.ts
@@ -10,4 +10,5 @@ export const directives = gql`
   directive @index(unique: Boolean) on FIELD_DEFINITION
   directive @compositeIndexes(fields: [[String]]!) on OBJECT
   directive @fullText(fields: [String!], language: String) on OBJECT
+  directive @dbType(type: String!) on FIELD_DEFINITION
 `;

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   postgres:
@@ -31,4 +31,3 @@ services:
     command:
       - yarn
       - test:all
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -6610,6 +6610,7 @@ __metadata:
     "@types/update-notifier": ^6
     "@types/websocket": ^1
     boxen: 5.1.2
+    chalk: ^5.3.0
     ejs: ^3.1.10
     eslint: ^8.8.0
     eslint-config-oclif: ^4.0.0
@@ -6773,6 +6774,7 @@ __metadata:
     axios: ^0.28.0
     class-transformer: ^0.5.1
     class-validator: ^0.14.1
+    form-data: ^4.0.1
     js-yaml: ^4.1.0
     reflect-metadata: ^0.1.14
     semver: ^7.6.3
@@ -10243,7 +10245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.2.0, chalk@npm:~5.3.0":
+"chalk@npm:^5.2.0, chalk@npm:^5.3.0, chalk@npm:~5.3.0":
   version: 5.3.0
   resolution: "chalk@npm:5.3.0"
   checksum: 623922e077b7d1e9dedaea6f8b9e9352921f8ae3afe739132e0e00c275971bdd331268183b2628cf4ab1727c45ea1f28d7e24ac23ce1db1eb653c414ca8a5a80
@@ -12835,6 +12837,17 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "form-data@npm:4.0.1"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: ccee458cd5baf234d6b57f349fe9cc5f9a2ea8fd1af5ecda501a18fd1572a6dd3bf08a49f00568afd995b6a65af34cb8dec083cf9d582c4e621836499498dd84
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6610,7 +6610,7 @@ __metadata:
     "@types/update-notifier": ^6
     "@types/websocket": ^1
     boxen: 5.1.2
-    chalk: ^5.3.0
+    chalk: ^4
     ejs: ^3.1.10
     eslint: ^8.8.0
     eslint-config-oclif: ^4.0.0
@@ -10245,7 +10245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.2.0, chalk@npm:^5.3.0, chalk@npm:~5.3.0":
+"chalk@npm:^5.2.0, chalk@npm:~5.3.0":
   version: 5.3.0
   resolution: "chalk@npm:5.3.0"
   checksum: 623922e077b7d1e9dedaea6f8b9e9352921f8ae3afe739132e0e00c275971bdd331268183b2628cf4ab1727c45ea1f28d7e24ac23ce1db1eb653c414ca8a5a80


### PR DESCRIPTION
# Description
Allows specifying a different ID type other than text. It can be 'BigInt', 'Int', 'Float', 'ID' or 'String'. This is useful when you want to order by ID but not in a lexicographical order. 

In order to avoid growing this PR and the complexity of types, codegen has been updated to generate some `Compat` types to work with internal types that expect the `id` to be a string.

Fixes https://github.com/subquery/subql/issues/2562
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update https://github.com/subquery/documentation/pull/577

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/577
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
