### PR TITLE
Testing, exit with non-zero code if tests fail

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- If any tests fail with the `test` subcommand the exit code will now be 1 instead of 0 (#2624)
 
 ## [16.0.0] - 2024-12-04
 ### Removed

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -32,7 +32,10 @@ export abstract class TestingService<A, SA, B, DS extends BaseDataSource> {
   private totalPassedTests = 0;
   private totalFailedTests = 0;
 
-  constructor(protected nodeConfig: NodeConfig, protected project: ISubqueryProject<IProjectNetworkConfig, DS>) {
+  constructor(
+    protected nodeConfig: NodeConfig,
+    protected project: ISubqueryProject<IProjectNetworkConfig, DS>
+  ) {
     const projectPath = this.project.root;
     // find all paths to test files
     const testFiles = this.findAllTestFiles(path.join(projectPath, 'dist'));
@@ -64,7 +67,7 @@ export abstract class TestingService<A, SA, B, DS extends BaseDataSource> {
     await indexerManager.indexBlock(block, this.getDsWithHandler(handler));
   }
 
-  async run() {
+  async run(): Promise<void> {
     if (Object.keys(this.tests).length !== 0) {
       for (const sandboxIndex in this.tests) {
         const tests = this.tests[sandboxIndex];
@@ -171,5 +174,9 @@ export abstract class TestingService<A, SA, B, DS extends BaseDataSource> {
     logger.info(chalk.bold.white(`Total tests: ${this.totalTests}`));
     logger.info(chalk.bold.green(`Passing tests: ${this.totalPassedTests}`));
     logger.info(chalk.bold.red(`Failing tests: ${this.totalFailedTests}`));
+
+    if (this.totalFailedTests > 0) {
+      process.exit(1);
+    }
   }
 }


### PR DESCRIPTION
# Description
If there are failing tests when running the `test` subcommand, it will now exit with code 1 rather than 0.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
