### PR TITLE
fix: typos in documentation files

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -179,7 +179,7 @@ spec:
       terminationGracePeriodSeconds: 300
 ```
 
-To gain further security, an archieve node should be used in the same k8s cluster, and a NetworkPolicy be added to limit all network communication within the internal network.
+To gain further security, an archive node should be used in the same k8s cluster, and a NetworkPolicy be added to limit all network communication within the internal network.
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/packages/cli/src/commands/migrate.test.ts
+++ b/packages/cli/src/commands/migrate.test.ts
@@ -9,7 +9,7 @@ import {DEFAULT_SUBQL_MANIFEST} from '../constants';
 import Migrate from './migrate';
 
 jest.setTimeout(300_000); // 300s
-describe('Intergration test - Migrate', () => {
+describe('Integration test - Migrate', () => {
   let projectDir: string;
 
   beforeAll(async () => {

--- a/packages/cli/src/commands/publish.test.ts
+++ b/packages/cli/src/commands/publish.test.ts
@@ -8,7 +8,7 @@ import {createTestProject} from '../createProject.fixtures';
 import Publish from './publish';
 
 jest.setTimeout(300_000); // 300s
-describe('Intergration test - Publish', () => {
+describe('Integration test - Publish', () => {
   let projectDir: string;
 
   beforeAll(async () => {


### PR DESCRIPTION
Corrected `archieve` to `archive`
Corrected `Intergration` to `Integration`
