### PR TITLE
Comments

### DIFF
--- a/packages/node-core/src/indexer/ds-processor.service.ts
+++ b/packages/node-core/src/indexer/ds-processor.service.ts
@@ -33,7 +33,7 @@ function isSecondLayerHandlerProcessor_0_0_0<
     | SecondLayerHandlerProcessor_0_0_0<InputKinds, HandlerInput, BaseHandlerFilters, F, E, DS, API>
     | SecondLayerHandlerProcessor_1_0_0<InputKinds, HandlerInput, BaseHandlerFilters, F, E, DS, API>
 ): processor is SecondLayerHandlerProcessor_0_0_0<InputKinds, HandlerInput, BaseHandlerFilters, F, E, DS, API> {
-  // Exisiting datasource processors had no concept of specVersion, therefore undefined is equivalent to 0.0.0
+  // Existing datasource processors had no concept of specVersion, therefore undefined is equivalent to 0.0.0
   return processor.specVersion === undefined;
 }
 

--- a/packages/node/src/indexer/runtime/workerRuntimeService.ts
+++ b/packages/node/src/indexer/runtime/workerRuntimeService.ts
@@ -22,7 +22,7 @@ export class WorkerRuntimeService extends BaseRuntimeService {
     }
   }
 
-  // Worker runtime does not syncDictionary by its self
+  // Worker runtime does not syncDictionary by itself
   // syncDictionary is done by main runtime
   async getSpecVersion(
     blockHeight: number,


### PR DESCRIPTION




## Changes

1. packages/node-core/src/indexer/ds-processor.service.ts:
- // Exisiting datasource processors
+ // Existing datasource processors

2. packages/node/src/indexer/runtime/workerRuntimeService.ts:
- // Worker runtime does not syncDictionary by its self
+ // Worker runtime does not syncDictionary by itself

## Why
- Fix misspelling of "Existing" (was "Exisiting")
- Use correct reflexive pronoun "itself" (was "its self")

- [x] Bug fix (documentation only)
- [x] No code changes
- [x] Improves readability
