### PR TITLE
Fix monitor oom

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `TextEncoder` in sandbox, some network package util method is depended on it
+- Added the `--monitor-object-max-depth` flag to mitigate OOM issues when encountering large chunks.(#2644)
+
+### Fixed
+- Fixed the inconsistency between the `monitor-file-size` flag and the expected behavior.(#2644)
 
 ## [16.1.0] - 2024-12-11
 ### Changed

--- a/packages/node-core/src/configure/NodeConfig.spec.ts
+++ b/packages/node-core/src/configure/NodeConfig.spec.ts
@@ -44,4 +44,20 @@ describe('NodeConfig', () => {
     expect(() => NodeConfig.fromFile(path.join(__dirname, '../../test/config.toml'))).toThrow();
     expect(() => NodeConfig.fromFile(path.join(__dirname, '../../test/con.toml'))).toThrow(/Load config from file/);
   });
+
+  it('Monitor configs default value', () => {
+    const fileConfig = NodeConfig.fromFile(path.join(__dirname, '../../test/config.yml'));
+    expect(fileConfig.monitorFileSize).toEqual(0);
+    expect(fileConfig.monitorObjectMaxDepth).toEqual(0);
+
+    const config2 = NodeConfig.rebaseWithArgs(fileConfig, {
+      monitorObjectMaxDepth: 10,
+    });
+    expect(config2.monitorObjectMaxDepth).toEqual(10);
+
+    const config3 = NodeConfig.rebaseWithArgs(fileConfig, {
+      proofOfIndex: true,
+    });
+    expect(config3.monitorFileSize).toEqual(200);
+  });
 });

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -57,6 +57,7 @@ export interface IConfig {
   readonly csvOutDir?: string;
   readonly monitorOutDir: string;
   readonly monitorFileSize?: number;
+  readonly monitorObjectMaxDepth: number;
   readonly enableCache?: boolean;
 }
 
@@ -86,6 +87,7 @@ const DEFAULT_CONFIG = {
   storeFlushInterval: 5,
   allowSchemaMigration: false,
   monitorOutDir: './.monitor',
+  monitorObjectMaxDepth: 0,
 };
 
 export class NodeConfig<C extends IConfig = IConfig> implements IConfig {
@@ -335,6 +337,10 @@ export class NodeConfig<C extends IConfig = IConfig> implements IConfig {
     // If user passed though yarg, we will record monitor file by this size, no matter poi or not
     // if user didn't pass through yarg, we will record monitor file by this default size only when poi is enabled
     return this._config.monitorFileSize ?? (this._config.proofOfIndex ? defaultMonitorFileSize : 0);
+  }
+
+  get monitorObjectMaxDepth(): number {
+    return this._config.monitorObjectMaxDepth;
   }
 
   get enableCache(): boolean {

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -334,7 +334,7 @@ export class NodeConfig<C extends IConfig = IConfig> implements IConfig {
     const defaultMonitorFileSize = 200;
     // If user passed though yarg, we will record monitor file by this size, no matter poi or not
     // if user didn't pass through yarg, we will record monitor file by this default size only when poi is enabled
-    return (this._config.monitorFileSize ?? this._config.proofOfIndex) ? defaultMonitorFileSize : 0;
+    return this._config.monitorFileSize ?? (this._config.proofOfIndex ? defaultMonitorFileSize : 0);
   }
 
   get enableCache(): boolean {

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -87,7 +87,7 @@ const DEFAULT_CONFIG = {
   storeFlushInterval: 5,
   allowSchemaMigration: false,
   monitorOutDir: './.monitor',
-  monitorObjectMaxDepth: 0,
+  monitorObjectMaxDepth: 5,
 };
 
 export class NodeConfig<C extends IConfig = IConfig> implements IConfig {

--- a/packages/node-core/src/indexer/indexer.manager.ts
+++ b/packages/node-core/src/indexer/indexer.manager.ts
@@ -190,7 +190,9 @@ export abstract class BaseIndexerManager<
 
         const parsedData = await this.prepareFilteredData(kind, data, ds);
 
-        monitorWrite(() => `- Handler: ${handler.handler}, args:${handledStringify(data)}`);
+        monitorWrite(
+          () => `- Handler: ${handler.handler}, args:${handledStringify(data, this.nodeConfig.monitorObjectMaxDepth)}`
+        );
         this.nodeConfig.profiler
           ? await profilerWrap(
               vm.securedExec.bind(vm),
@@ -209,7 +211,9 @@ export abstract class BaseIndexerManager<
       for (const handler of handlers) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         vm ??= await getVM(ds);
-        monitorWrite(() => `- Handler: ${handler.handler}, args:${handledStringify(data)}`);
+        monitorWrite(
+          () => `- Handler: ${handler.handler}, args:${handledStringify(data, this.nodeConfig.monitorObjectMaxDepth)}`
+        );
         await this.transformAndExecuteCustomDs(ds, vm, handler, data);
       }
     }

--- a/packages/node-core/src/utils/string.spec.ts
+++ b/packages/node-core/src/utils/string.spec.ts
@@ -79,4 +79,22 @@ describe('handledStringify depth', () => {
     );
     expect(handledStringify(obj, 1)).toEqual('{"key":"value","child":"[Object(3)]"}');
   });
+
+  it('Undefined values', () => {
+    expect(handledStringify(undefined, 3)).toBeUndefined();
+  });
+
+  it('Null values', () => {
+    expect(handledStringify(null, 3)).toEqual('null');
+    expect(handledStringify({a: null}, 3)).toEqual('{"a":null}');
+  });
+
+  it('A circular reference', () => {
+    const obj: any = {};
+    const obj2: any = {};
+    obj.reference = obj2;
+    obj2.reference = obj;
+    expect(handledStringify(obj, 0)).toMatch(/Converting circular structure to JSON/);
+    expect(handledStringify(obj, 3)).toMatch(/Converting circular structure to JSON/);
+  });
 });

--- a/packages/node-core/src/utils/string.spec.ts
+++ b/packages/node-core/src/utils/string.spec.ts
@@ -58,3 +58,25 @@ describe('handledStringify', () => {
     expect(result).toBe('Error without stack');
   });
 });
+
+describe('handledStringify depth', () => {
+  it('Different truncation situations at various depths', () => {
+    const obj = {
+      key: 'value',
+      child: {
+        key: 'value',
+        child: {
+          key: 'value',
+        },
+        arr: [1, 2, 3],
+      },
+    };
+    expect(handledStringify(obj, 0)).toEqual(
+      '{"key":"value","child":{"key":"value","child":{"key":"value"},"arr":[1,2,3]}}'
+    );
+    expect(handledStringify(obj, 2)).toEqual(
+      '{"key":"value","child":{"key":"value","child":"[Object(1)]","arr":"[Array(3)]"}}'
+    );
+    expect(handledStringify(obj, 1)).toEqual('{"key":"value","child":"[Object(3)]"}');
+  });
+});

--- a/packages/node-core/src/utils/string.ts
+++ b/packages/node-core/src/utils/string.ts
@@ -1,8 +1,32 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-export function handledStringify(obj: any): string {
+function truncateObject(value: any, currentDepth: number, maxDepth: number): any {
+  if (currentDepth >= maxDepth) {
+    if (Array.isArray(value)) return `[Array(${value.length})]`;
+    if (value && typeof value === 'object') return `[Object(${Object.keys(value).length})]`;
+  }
+
+  if (value && typeof value === 'object') {
+    const truncated: any = Array.isArray(value) ? [] : {};
+    for (const key in value) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
+        truncated[key] = truncateObject(value[key], currentDepth + 1, maxDepth);
+      }
+    }
+    return truncated;
+  }
+
+  return value;
+}
+
+export function handledStringify(obj: any, depth = 0): string {
   try {
+    if (depth > 0) {
+      const limitedObj = truncateObject(obj, 0, depth);
+      return JSON.stringify(limitedObj);
+    }
+
     return JSON.stringify(obj);
   } catch (error) {
     if (error instanceof Error) {

--- a/packages/node-core/src/utils/string.ts
+++ b/packages/node-core/src/utils/string.ts
@@ -1,19 +1,25 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-function truncateObject(value: any, currentDepth: number, maxDepth: number): any {
+function truncateObject(value: any, currentDepth: number, maxDepth: number, seen: Set<any> = new Set()): any {
   if (currentDepth >= maxDepth) {
     if (Array.isArray(value)) return `[Array(${value.length})]`;
     if (value && typeof value === 'object') return `[Object(${Object.keys(value).length})]`;
   }
 
   if (value && typeof value === 'object') {
+    if (seen.has(value)) {
+      throw new Error('Converting circular structure to JSON');
+    }
+    seen.add(value);
+
     const truncated: any = Array.isArray(value) ? [] : {};
     for (const key in value) {
       if (Object.prototype.hasOwnProperty.call(value, key)) {
-        truncated[key] = truncateObject(value[key], currentDepth + 1, maxDepth);
+        truncated[key] = truncateObject(value[key], currentDepth + 1, maxDepth, seen);
       }
     }
+    seen.delete(value);
     return truncated;
   }
 

--- a/packages/node-core/src/yargs.ts
+++ b/packages/node-core/src/yargs.ts
@@ -267,7 +267,7 @@ export function yargsBuilder<
                 type: 'number',
               },
               'monitor-object-max-depth': {
-                describe: 'The maximum depth of an object recorded by a monitor. Default is 0, no limit',
+                describe: 'The maximum depth of an object recorded by a monitor. Default is 5, 0 is no limit',
                 type: 'number',
               },
               'enable-cache': {

--- a/packages/node-core/src/yargs.ts
+++ b/packages/node-core/src/yargs.ts
@@ -269,7 +269,6 @@ export function yargsBuilder<
               'monitor-object-max-depth': {
                 describe: 'The maximum depth of an object recorded by a monitor. Default is 0, no limit',
                 type: 'number',
-                default: 0,
               },
               'enable-cache': {
                 describe: 'cache enable or disable',

--- a/packages/node-core/src/yargs.ts
+++ b/packages/node-core/src/yargs.ts
@@ -266,6 +266,11 @@ export function yargsBuilder<
                 describe: 'monitor file size limit in MB ',
                 type: 'number',
               },
+              'monitor-object-max-depth': {
+                describe: 'The maximum depth of an object recorded by a monitor. Default is 0, no limit',
+                type: 'number',
+                default: 0,
+              },
               'enable-cache': {
                 describe: 'cache enable or disable',
                 type: 'boolean',

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Bump `@subql/node-core` dependency (#2644)
+
 ## [5.6.0] - 2024-12-11
 ### Changed
 - Update `@subql/node-core` with bug fixes and support for alternative ID types


### PR DESCRIPTION
# Description
When encountering large blocks and using multiple workers, the monitor will experience memory overflow and thread blocking due to the need for thread communication and large object parsing. The main cause is that JSON parsing takes a long time, during which the main thread is still sending messages, leading to an OOM error.

The following optimizations were made:
 - Added the `--monitor-object-max-depth` flag to mitigate OOM issues when encountering large chunks.

Fixes # (issue)
 - Fixed the inconsistency between the `monitor-file-size` flag and the expected behavior.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
