### PR TITLE
Fix the issue that may occur when using a dictionary to crawl blocks.

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed the inconsistency between the `monitor-file-size` flag and the expected behavior.(#2644)
 - Improved block range validation in POI endpoint with custom class-validator decorator
+- When setting a smaller batch size and the current processing height reaches latestFinalizedHeight, it causes the program to exit unexpectedly.
 
 ## [16.1.0] - 2024-12-11
 ### Changed

--- a/packages/node-core/src/configure/NodeConfig.spec.ts
+++ b/packages/node-core/src/configure/NodeConfig.spec.ts
@@ -48,7 +48,7 @@ describe('NodeConfig', () => {
   it('Monitor configs default value', () => {
     const fileConfig = NodeConfig.fromFile(path.join(__dirname, '../../test/config.yml'));
     expect(fileConfig.monitorFileSize).toEqual(0);
-    expect(fileConfig.monitorObjectMaxDepth).toEqual(0);
+    expect(fileConfig.monitorObjectMaxDepth).toEqual(5);
 
     const config2 = NodeConfig.rebaseWithArgs(fileConfig, {
       monitorObjectMaxDepth: 10,

--- a/packages/node-core/src/indexer/dictionary/v1/dictionaryV1.spec.ts
+++ b/packages/node-core/src/indexer/dictionary/v1/dictionaryV1.spec.ts
@@ -10,7 +10,7 @@ import {BlockHeightMap} from '../../../utils/blockHeightMap';
 import {dsMap, mockDS, TestDictionaryV1, HAPPY_PATH_CONDITIONS} from '../dictionary.fixtures';
 import {getGqlType} from './utils';
 
-const DICTIONARY_ENDPOINT = `https://gateway.subquery.network/query/QmUGBdhQKnzE8q6x6MPqP6LNZGa8gzXf5gkdmhzWjdFGfL`;
+const DICTIONARY_ENDPOINT = `https://gateway.subquery.network/query/QmSxAgGGpaMrYzooWpydmwzutREwomL5nupLZqxURzuJTo`;
 const DICTIONARY_CHAINID = `0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3`;
 
 const nodeConfig = new NodeConfig({


### PR DESCRIPTION
# Description
When setting a smaller batch size and the current processing height reaches latestFinalizedHeight, it causes the program to exit unexpectedly. Will cause the following error.
```
2025-01-21T07:09:18.745Z <BlockDispatcherService> INFO Enqueueing blocks 21671197...21671197, total 1 blocks 
2025-01-21T07:09:19.661Z <BlockDispatcherService> INFO Enqueueing blocks 21671197...21671197, total 1 blocks 
2025-01-21T07:09:19.932Z <BlockDispatcherService> ERROR Failed to index block at height 21671197  AssertionError: Block processed out of order. Height: 21671197. Latest: 21671197
2025-01-21T07:09:19.933Z <BlockDispatcherService> ERROR undefined Error: Failed to enqueue fetched block to process
Cause: AssertionError: Block processed out of order. Height: 21671197. Latest: 21671197
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
