### PR TITLE
Fixes codegen when `@dbType` directive is used

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add some constants for Starknet
-
 ### Changed
 - Added internal note relating to some tests
+### Fixed
+- Codegen: getByFields being invalid code
 
 ## [5.4.0] - 2024-12-11
 ### Changed

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added internal note relating to some tests
 ### Fixed
-- Codegen: getByFields being invalid code
+- Codegen: getByFields being invalid code (#2649)
 
 ## [5.4.0] - 2024-12-11
 ### Changed

--- a/packages/cli/src/controller/codegen-controller.test.ts
+++ b/packages/cli/src/controller/codegen-controller.test.ts
@@ -101,4 +101,17 @@ describe('Codegen can generate schema', () => {
 
     expect(codegenFile).toContain(`export {ExampleField} from "./ExampleField"`);
   });
+
+  it('correctly generates relations with different dbTypes', async () => {
+    const projectPath = path.join(__dirname, '../../test/schemaTest');
+    await codegen(projectPath, ['project-id-type.yaml']);
+
+    const blockEntity = await fs.promises.readFile(`${projectPath}/src/types/models/Block.ts`, 'utf8');
+
+    expect(blockEntity).toContain('        metaId: bigint,');
+    expect(blockEntity).toContain('public metaId: bigint;');
+    expect(blockEntity).toContain(
+      'static async getByMetaId(metaId: bigint, options: GetOptions<CompatBlockProps>): Promise<Block[]> {'
+    );
+  });
 });

--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -161,9 +161,6 @@ export function processFields(
       switch (field.type) {
         default: {
           const typeClass = getTypeByScalarName(field.type);
-          if (field.name === 'metaId') {
-            console.log(field, injectField, typeClass);
-          }
 
           assert(
             typeClass && typeClass.tsType,

--- a/packages/cli/src/controller/codegen-controller.ts
+++ b/packages/cli/src/controller/codegen-controller.ts
@@ -161,6 +161,10 @@ export function processFields(
       switch (field.type) {
         default: {
           const typeClass = getTypeByScalarName(field.type);
+          if (field.name === 'metaId') {
+            console.log(field, injectField, typeClass);
+          }
+
           assert(
             typeClass && typeClass.tsType,
             `Schema: undefined type "${field.type.toString()}" on field "${field.name}" in "type ${className} @${type}"`

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -79,8 +79,8 @@ export class <%= props.className %> implements CompatEntity {
      *
      * ⚠️ This function will first search cache data followed by DB data. Please consider this when using order and offset options.⚠️
      * */
-    static async getByFields(filter: FieldsExpression<<%= props.className %>Props>[], options: GetOptions<Compat<%= props.className %>Props>): Promise<<%=props.className %>[]> {
-        const records = await store.getByFields<Compat<%=props.className %>Props>('<%=props.entityName %>', filter, options);
+    static async getByFields(filter: FieldsExpression<<%= props.className %>Props>[], options: GetOptions<<%= props.className %>Props>): Promise<<%=props.className %>[]> {
+        const records = await store.getByFields<<%=props.className %>Props>('<%=props.entityName %>', filter, options);
         return records.map(record => this.create(record as unknown as <%= props.className %>Props));
     }
 

--- a/packages/cli/test/schemaTest/dbTypeSchema.graphql
+++ b/packages/cli/test/schemaTest/dbTypeSchema.graphql
@@ -1,0 +1,11 @@
+type BlockMeta @entity {
+  id: ID! @dbType(type: "BigInt")
+
+  height: Int!
+}
+
+type Block @entity {
+  id: ID!
+
+  meta: BlockMeta!
+}

--- a/packages/cli/test/schemaTest/project-id-type.yaml
+++ b/packages/cli/test/schemaTest/project-id-type.yaml
@@ -1,0 +1,24 @@
+specVersion: '1.0.0'
+name: 'example'
+
+schema:
+  file: './dbTypeSchema.graphql'
+runner:
+  node:
+    name: '@subql/node'
+    version: '>=3.0.1'
+  query:
+    name: '@subql/query'
+    version: '*'
+customDs:
+  kind: substrate/FrontierEvm
+  assets:
+    erc721:
+      file: ./abis/erc721.json
+dataSources:
+  - kind: ethereum/Runtime
+    startBlock: 1
+    mapping:
+      handlers:
+        - handler: handleTransaction
+          kind: ethereum/BlockHandler

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Graphql entitiy relations not resolving the id type from the `@dbType` directive (#2649)
 
 ## [2.17.0] - 2024-12-11
 ### Added

--- a/packages/utils/src/graphql/entities.ts
+++ b/packages/utils/src/graphql/entities.ts
@@ -359,7 +359,7 @@ function packEntityField(
 ): GraphQLEntityField {
   return {
     name: isForeignKey ? `${field.name}Id` : field.name,
-    type: /*isForeignKey ? FieldScalar.String : */ typeString,
+    type: typeString,
     description: field.description ?? undefined,
     isArray: isListType(isNonNullType(field.type) ? getNullableType(field.type) : field.type),
     nullable: !isNonNullType(field.type),

--- a/packages/utils/src/graphql/entities.ts
+++ b/packages/utils/src/graphql/entities.ts
@@ -133,7 +133,16 @@ export function getAllEntitiesRelations(_schema: GraphQLSchema | string | null):
       }
       // If is a foreign key
       else if (entityNameSet.includes(typeString) && !derivedFromDirectValues) {
-        newModel.fields.push(packEntityField(typeString, field, true));
+        let relatedTypeString = FieldScalar.String;
+
+        // Check to see if the relation ID type is modified with the @dbType directive
+        const relatedIdField = entities.find((e) => e.name === typeString)?.getFields().id;
+        const dbIdType = relatedIdField?.astNode ? getDirectiveValues(idDbType, relatedIdField.astNode) : undefined;
+        if (dbIdType) {
+          relatedTypeString = dbIdType.type;
+        }
+
+        newModel.fields.push(packEntityField(relatedTypeString, field, true));
         modelRelations.relations.push({
           from: entity.name,
           type: 'belongsTo',
@@ -350,7 +359,7 @@ function packEntityField(
 ): GraphQLEntityField {
   return {
     name: isForeignKey ? `${field.name}Id` : field.name,
-    type: isForeignKey ? FieldScalar.String : typeString,
+    type: /*isForeignKey ? FieldScalar.String : */ typeString,
     description: field.description ?? undefined,
     isArray: isListType(isNonNullType(field.type) ? getNullableType(field.type) : field.type),
     nullable: !isNonNullType(field.type),


### PR DESCRIPTION
# Description
https://github.com/subquery/subql/pull/2622 added support for alternative ID types. This introduced a bug where the entities generated code would lead to an invalid `getByFields` function that wouldn't compile.

It also did not have the correct type for related entities id. This has also been fixed.

## TODO:
- [x] Test the change on entities.ts that it doesn't brake code elsewhere.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
