### PR TITLE
error in word in the CHANGELOG.md

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -649,7 +649,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for block hashes with base64 format for POI (#1761)
 
 ### Changed
-- Update vm2 past problimatic version (#1770)
+- Update vm2 past problematic version (#1770)
 - Add optional root option to config (#1771)
 
 ## [2.3.1] - 2023-05-26


### PR DESCRIPTION
### **Title**
Error in word in the CHANGELOG.md

---

### **Description**
This pull request corrects a typo in the `CHANGELOG.md` file. The word "problimatic" has been updated to "problematic" in the description of the vm2
