### PR TITLE
Fix error trying to get timestamp with light blocks

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Crash with iterating extrinsics when skipTransactions is enabled (#2656)
 
 ## [5.7.0] - 2025-01-28
 ### Changed

--- a/packages/node/src/utils/substrate.ts
+++ b/packages/node/src/utils/substrate.ts
@@ -69,16 +69,19 @@ export function wrapBlock(
 export function getTimestamp({
   block: { extrinsics },
 }: SignedBlock): Date | undefined {
-  for (const e of extrinsics) {
-    const {
-      method: { method, section },
-    } = e;
-    if (section === 'timestamp' && method === 'set') {
-      const date = new Date(e.args[0].toJSON() as number);
-      if (isNaN(date.getTime())) {
-        throw new Error('timestamp args type wrong');
+  // extrinsics can be undefined when fetching light blocks
+  if (extrinsics) {
+    for (const e of extrinsics) {
+      const {
+        method: { method, section },
+      } = e;
+      if (section === 'timestamp' && method === 'set') {
+        const date = new Date(e.args[0].toJSON() as number);
+        if (isNaN(date.getTime())) {
+          throw new Error('timestamp args type wrong');
+        }
+        return date;
       }
-      return date;
     }
   }
   // For network that doesn't use timestamp-set, return undefined


### PR DESCRIPTION
# Description
When using light blocks its not possible to resolve the timestamp because we don't have the extrinsics, which include the block timestamp information. This PR adds a check that the extrinsics exist before trying to find the timestamp.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
