### PR TITLE
[DRAFT] Fix typescript error avoid ID not matching when use @dbType

### DIFF
--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -81,6 +81,7 @@ export class <%= props.className %> implements CompatEntity {
      * ⚠️ This function will first search cache data followed by DB data. Please consider this when using order and offset options.⚠️
      * */
     static async getByFields(filter: FieldsExpression<<%= props.className %>Props>[], options: GetOptions<<%= props.className %>Props>): Promise<<%=props.className %>[]> {
+        // @ts-ignore
         const records = await store.getByFields<<%=props.className %>Props>('<%=props.entityName %>', filter, options);
         return records.map(record => this.create(record as unknown as <%= props.className %>Props));
     }

--- a/packages/cli/src/template/model.ts.ejs
+++ b/packages/cli/src/template/model.ts.ejs
@@ -68,6 +68,7 @@ export class <%= props.className %> implements CompatEntity {
         }
     }
     <% } else { %>static async getBy<%=helper.upperFirst(field.name) %>(<%=field.name %>: <%=field.type %>, options: GetOptions<Compat<%=props.className %>Props>): Promise<<%=props.className %>[]> {
+        // @ts-ignore
         const records = await store.getByField<Compat<%=props.className %>Props>('<%=props.entityName %>', '<%=field.name %>', <%=field.name %>, options);
         return records.map(record => this.create(record as unknown as <%= props.className %>Props));
     }

--- a/packages/node-core/src/indexer/storeModelProvider/model/model.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/model/model.ts
@@ -60,7 +60,11 @@ export class PlainModel<T extends BaseEntity = BaseEntity> implements IModel<T> 
   }
 
   async set(id: string, data: T, blockHeight: number, tx?: Transaction): Promise<void> {
-    if (id !== data.id) {
+    // NOTE: this is to fix the error when use @dbType('BigInt') or maybe Int, Float as parameters on the graphql schema
+    const dataId = data.id as unknown as string | bigint | number;
+    if (typeof dataId !== 'string' && typeof dataId.toString === 'function' && dataId.toString() !== id) {
+      throw new Error(`Id doesnt match with data ${typeof id} !== ${typeof data.id}`);
+    } else if (typeof dataId === 'string' && dataId !== id) {
       throw new Error(`Id doesnt match with data`);
     }
 


### PR DESCRIPTION
# Description
Ensure that IDs match correctly even when data types like BigInt, Int, or Float are used in GraphQL schemas. This prevents mismatches and ensures error handling for invalid ID comparisons.

On Models template there are 2 types:
1. https://github.com/subquery/subql/blob/main/packages/cli/src/template/model.ts.ejs#L19
2. https://github.com/subquery/subql/blob/main/packages/cli/src/template/model.ts.ejs#L20

They both Omit the `id` property, but one leave as string, which if we change the ID with `@dbType()` maybe get an error?
For sure the `getByFields` has a typescript error due to that because it expect the T to extend Entity which expect id be an string.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
