### PR TITLE
Fixed typos

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -716,7 +716,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2021-01-15
 ### Changed
-- subql init doesn't need --starter by default (#86)
+- subql init doesn'tt need --starter by default (#86)
 - model template use bigint instead of BigInt (#82)
 
 ## [0.2.0] - 2020-12-22

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -716,7 +716,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2021-01-15
 ### Changed
-- subql init doesn' need --starter by default (#86)
+- subql init doesn't need --starter by default (#86)
 - model template use bigint instead of BigInt (#82)
 
 ## [0.2.0] - 2020-12-22

--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -585,7 +585,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.2] - 2023-07-11
 ### Fixed
-- Fix `TestingService` to run tests in seperate application contexts (#1870)
+- Fix `TestingService` to run tests in separate application contexts (#1870)
 - Cache race condition when flushing cache and getting data (#1873)
 - Various improvements for POI feature: (#1869)
   - Benchmarking mmr processing

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.17.1] - 2025-01-28
 ### Fixed
-- Graphql entitiy relations not resolving the id type from the `@dbType` directive (#2649)
+- Graphql entity relations not resolving the id type from the `@dbType` directive (#2649)
 
 ## [2.17.0] - 2024-12-11
 ### Added


### PR DESCRIPTION
### Changes

1. **File:** `/packages/node-core/CHANGELOG.md`
    - Fixed `seperate` to `separate` (Line 588)
1. **File:** `/packages/utils/CHANGELOG.md`
    - Fixed `entitiy` to `entity` (Line 19)
1. **File:** `/packages/cli/CHANGELOG.md`
    - Fixed `doesn'` to `doesn't` (Line 719)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.