### PR TITLE
Fix indexing when the finalized block is 0

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Finalized block getter when height is 0 (#2706)
 
 ## [17.0.2] - 2025-02-26
 ### Added

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -43,12 +43,13 @@ export class FetchService<DS extends BaseDataSource, B extends IBlockDispatcher<
   ) {}
 
   private get latestBestHeight(): number {
-    assert(this._latestBestHeight, new Error('Latest Best Height is not available'));
+    assert(this._latestBestHeight !== undefined, new Error('Latest Best Height is not available'));
     return this._latestBestHeight;
   }
 
   private get latestFinalizedHeight(): number {
-    assert(this._latestFinalizedHeight, new Error('Latest Finalized Height is not available'));
+    // Devnets don't always finalize blocks, in those cases we set the finalized block to be 0 and we need to specifically check for undefined here.
+    assert(this._latestFinalizedHeight !== undefined, new Error('Latest Finalized Height is not available'));
     return this._latestFinalizedHeight;
   }
 


### PR DESCRIPTION
# Description
Fixes starknet devnets where the finalized block is 0. We had a check before that checked if the finalized height was truthly which doesn't work for 0, now the check is for undefined.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
