### PR TITLE
Always flush cache on every block when near target height

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Flushing the cache every block when the project is fully synced to reduce delay between data indexed and being queryable (#2707)
 
 ## [17.0.2] - 2025-02-26
 ### Added

--- a/packages/node-core/src/configure/NodeConfig.ts
+++ b/packages/node-core/src/configure/NodeConfig.ts
@@ -56,6 +56,7 @@ export interface IConfig {
   readonly storeGetCacheSize: number;
   readonly storeCacheAsync: boolean;
   readonly storeFlushInterval: number;
+  readonly storeCacheTarget: number;
   readonly isTest?: boolean;
   readonly root?: string;
   readonly allowSchemaMigration: boolean;
@@ -90,6 +91,7 @@ const DEFAULT_CONFIG = {
   storeGetCacheSize: 500,
   storeCacheAsync: true,
   storeFlushInterval: 5,
+  storeCacheTarget: 10,
   allowSchemaMigration: false,
   monitorOutDir: './.monitor',
   monitorObjectMaxDepth: 5,
@@ -186,6 +188,10 @@ export class NodeConfig<C extends IConfig = IConfig> implements IConfig {
 
   get storeFlushInterval(): number {
     return this._config.storeFlushInterval;
+  }
+
+  get storeCacheTarget(): number {
+    return this._config.storeCacheTarget;
   }
 
   get dictionaryRegistry(): string {

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -11,7 +11,6 @@ import {AdminEvent, IndexerEvent, PoiEvent, TargetBlockPayload} from '../../even
 import {getLogger} from '../../logger';
 import {monitorCreateBlockFork, monitorCreateBlockStart, monitorWrite} from '../../process';
 import {IQueue, mainThreadOnly} from '../../utils';
-import {MonitorServiceInterface} from '../monitor.service';
 import {PoiBlock, PoiSyncService} from '../poi';
 import {StoreService} from '../store.service';
 import {IStoreModelProvider} from '../storeModelProvider';
@@ -61,8 +60,7 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS, B> implements IB
     protected queue: Q,
     protected storeService: StoreService,
     private storeModelProvider: IStoreModelProvider,
-    private poiSyncService: PoiSyncService,
-    protected monitorService?: MonitorServiceInterface
+    private poiSyncService: PoiSyncService
   ) {}
 
   abstract enqueueBlocks(heights: (IBlock<B> | number)[], latestBufferHeight?: number): void | Promise<void>;
@@ -210,6 +208,7 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS, B> implements IB
     await this.storeModelProvider.applyPendingChanges(
       height,
       !this.projectService.hasDataSourcesAfterHeight(height),
+
       this.storeService.transaction
     );
   }

--- a/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/worker-block-dispatcher.ts
@@ -89,8 +89,7 @@ export class WorkerBlockDispatcher<
       initAutoQueue(nodeConfig.workers, nodeConfig.batchSize, nodeConfig.timeout, 'Worker'),
       storeService,
       storeModelProvider,
-      poiSyncService,
-      monitorService
+      poiSyncService
     );
 
     this.createWorker = () =>

--- a/packages/node-core/src/yargs.ts
+++ b/packages/node-core/src/yargs.ts
@@ -200,6 +200,13 @@ export function yargsBuilder<
                 type: 'number',
                 default: 5,
               },
+              'store-cache-target': {
+                demandOption: false,
+                describe:
+                  'If indexing is happening within this many blocks of the target height, then cache data will be flushed every block. This makes sure a (nearly) fully synced node is flushing data to be available ASAP to query.',
+                type: 'number',
+                default: 10,
+              },
               'subquery-name': {
                 deprecated: true,
                 demandOption: false,

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@subql/node-core` with new cache flush behaviour when fully synced (#2707)
 
 ## [5.9.1] - 2025-02-26
 ### Changed


### PR DESCRIPTION
# Description
The purpose of the cache is to group together a large number of blocks data into fewer larger DB operations. This makes sense when indexing historical data but when indexing new data this doesn't matter as much and there is a preference to make data accessible for querying ASAP. This change makes it so that every block flushes the cache to the DB when within 10 (default value, is configurable) blocks of the target height.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
