### PR TITLE
add tsconfig-paths-webpack-plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "terser-webpack-plugin": "^5.3.10",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
+    "tsconfig-paths-webpack-plugin": "^4.2.0",
     "tslib": "^2.6.3",
     "typescript": "^5.7.3",
     "update-notifier": "^5.1.0",

--- a/packages/cli/src/controller/build-controller.ts
+++ b/packages/cli/src/controller/build-controller.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import assert from 'assert';
-import { readFileSync } from 'fs';
+import {readFileSync} from 'fs';
 import path from 'path';
-import { globSync } from 'glob';
+import {globSync} from 'glob';
 import TerserPlugin from 'terser-webpack-plugin';
-import webpack, { Configuration } from 'webpack';
-import { merge } from 'webpack-merge';
+import {TsconfigPathsPlugin} from 'tsconfig-paths-webpack-plugin';
+import webpack, {Configuration} from 'webpack';
+import {merge} from 'webpack-merge';
 
 const getBaseConfig = (
   buildEntries: Configuration['entry'],
@@ -54,6 +55,7 @@ const getBaseConfig = (
 
   resolve: {
     extensions: ['.tsx', '.ts', '.js', '.json'],
+    plugins: [new TsconfigPathsPlugin()],
   },
 
   output: {
@@ -72,7 +74,7 @@ export async function runWebpack(
 ): Promise<void> {
   const config = merge(
     getBaseConfig(buildEntries, projectDir, outputDir, isDev),
-    { output: { clean } }
+    {output: {clean}}
     // Can allow projects to override webpack config here
   );
 
@@ -121,7 +123,7 @@ export function getBuildEntries(directory: string): Record<string, string> {
         acc[key] = path.resolve(directory, value);
         return acc;
       },
-      { ...buildEntries }
+      {...buildEntries}
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7008,6 +7008,7 @@ __metadata:
     terser-webpack-plugin: ^5.3.10
     ts-loader: ^9.5.1
     ts-node: ^10.9.2
+    tsconfig-paths-webpack-plugin: ^4.2.0
     tslib: ^2.6.3
     typescript: ^5.7.3
     update-notifier: ^5.1.0
@@ -12163,6 +12164,16 @@ __metadata:
     graceful-fs: ^4.2.4
     tapable: ^2.2.0
   checksum: 4bc38cf1cea96456f97503db7280394177d1bc46f8f87c267297d04f795ac5efa81e48115a2f5b6273c781027b5b6bfc5f62b54df629e4d25fa7001a86624f59
+  languageName: node
+  linkType: hard
+
+"enhanced-resolve@npm:^5.7.0":
+  version: 5.18.1
+  resolution: "enhanced-resolve@npm:5.18.1"
+  dependencies:
+    graceful-fs: ^4.2.4
+    tapable: ^2.2.0
+  checksum: de5bea7debe3576e78173bcc409c4aee7fcb56580c602d5c47c533b92952e55d7da3d9f53b864846ba62c8bd3efb0f9ecfe5f865e57de2f3e9b6e5cda03b4e7e
   languageName: node
   linkType: hard
 
@@ -21680,7 +21691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.1.1, tapable@npm:^2.2.0":
+"tapable@npm:^2.1.1, tapable@npm:^2.2.0, tapable@npm:^2.2.1":
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
   checksum: 3b7a1b4d86fa940aad46d9e73d1e8739335efd4c48322cb37d073eb6f80f5281889bf0320c6d8ffcfa1a0dd5bfdbd0f9d037e252ef972aca595330538aac4d51
@@ -22158,6 +22169,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfig-paths-webpack-plugin@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "tsconfig-paths-webpack-plugin@npm:4.2.0"
+  dependencies:
+    chalk: ^4.1.0
+    enhanced-resolve: ^5.7.0
+    tapable: ^2.2.1
+    tsconfig-paths: ^4.1.2
+  checksum: b35e4da5fb4ee438267125f369220102a061824c1dd568cd84e9db2368b72581ec7b88db1a5fda180bba65ff7b7597b18561a24f1db9c9a85fdc803bea122aa6
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.14.1":
   version: 3.14.1
   resolution: "tsconfig-paths@npm:3.14.1"
@@ -22170,7 +22193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:^4.2.0":
+"tsconfig-paths@npm:^4.1.2, tsconfig-paths@npm:^4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
   dependencies:


### PR DESCRIPTION
# Description
Adds the [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin) to the base webpack config for automatic paths resolutions

Fixes #2709

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
