### PR TITLE
Fix testing not catching block fetch errors

### DIFF
--- a/packages/node-core/src/indexer/test.runner.spec.ts
+++ b/packages/node-core/src/indexer/test.runner.spec.ts
@@ -179,4 +179,27 @@ describe('TestRunner', () => {
       `\t\tattribute: "timestamp":\n\t\t\texpected: "1970-01-01T00:00:01.000Z"\n\t\t\tactual:   "1970-01-01T00:00:01.001Z"\n`
     );
   });
+
+  it('increments error if a block fails to be fetched', async () => {
+    const expectedEntity = {
+      _name: 'Entity1',
+      id: '1',
+      attr: 'value',
+    };
+    const testMock = {
+      name: 'test1',
+      blockHeight: 1,
+      handler: 'handler1',
+      expectedEntities: [expectedEntity],
+      dependentEntities: [],
+    };
+
+    apiServiceMock.fetchBlocks = jest.fn().mockRejectedValue(new Error('Failed to fetch block'));
+
+    const indexBlock = jest.fn().mockResolvedValue(undefined);
+    const res = await testRunner.runTest(testMock, sandboxMock, indexBlock);
+
+    expect(res.failedTests).toBe(2);
+    expect(res.failedTestSummary?.failedAttributes[0]).toContain('Failed to fetch block');
+  });
 });

--- a/packages/node-core/src/indexer/testing.service.ts
+++ b/packages/node-core/src/indexer/testing.service.ts
@@ -58,12 +58,7 @@ export abstract class TestingService<A, SA, B, DS extends BaseDataSource> {
 
   abstract getTestRunner(): Promise<[close: () => Promise<void>, runner: TestRunner<A, SA, B, DS>]>; // TestRunner will be create with a new app instance
 
-  async indexBlock(
-    block: IBlock<B>,
-    handler: string,
-    indexerManager: IIndexerManager<B, DS>,
-    apiService?: IApi<A, SA, IBlock<B>[]>
-  ): Promise<void> {
+  async indexBlock(block: IBlock<B>, handler: string, indexerManager: IIndexerManager<B, DS>): Promise<void> {
     await indexerManager.indexBlock(block, this.getDsWithHandler(handler));
   }
 


### PR DESCRIPTION
# Description
If block fetching fails during tests then the error would not update the tests results correctly, this is now fixed

Fixes https://github.com/subquery/subql/issues/2711

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
