### PR TITLE
Replace UNPKG w/ jsDelivr in Playground

### DIFF
--- a/packages/query/src/graphql/plugins/PlaygroundPlugin.ts
+++ b/packages/query/src/graphql/plugins/PlaygroundPlugin.ts
@@ -50,11 +50,11 @@ export function playgroundPlugin(options: {url: string; subscriptionUrl?: string
     -->
     <script
       crossorigin
-      src="https://unpkg.com/react@18/umd/react.production.min.js"
+      src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
+      src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"
     ></script>
     <!--
       These two files can be found in the npm module, however you may wish to
@@ -62,21 +62,21 @@ export function playgroundPlugin(options: {url: string; subscriptionUrl?: string
       favored resource bundler.
      -->
     <script
-      src="https://unpkg.com/graphiql/graphiql.min.js"
+      src="https://cdn.jsdelivr.net/npm/graphiql/graphiql.min.js"
       type="application/javascript"
     ></script>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphiql/graphiql.min.css" />
     <!--
       These are imports for the GraphIQL Explorer plugin.
      -->
     <script
-      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
+      src="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer/dist/index.umd.js"
       crossorigin
     ></script>
 
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
+      href="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer/dist/style.css"
     />
   </head>
 


### PR DESCRIPTION
# Description

UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG usage with jsDelivr.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
