### PR TITLE
Fix workers queue max size error

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Max queue size error with workers (#2725)
 
 ## [17.2.0] - 2025-03-20
 ### Fixed

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -318,7 +318,8 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS, B> implements IB
         }
 
         // Block fetching has failed, start shutting down things. But we can wait until the ramining fetched blocks can be processed
-        logger.error(`Failed to fetch block, waiting for fetched blocks to be processed before shutting down.`);
+        console.error('ERROR', e);
+        logger.error(`Failed to fetch block, waiting for fetched blocks to be processed before shutting down.`, e);
         if (!this.isShutdown) {
           this.isShutdown = true;
           this.fetchFailureHeight = options.height;

--- a/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/block-dispatcher.ts
@@ -81,6 +81,7 @@ export class BlockDispatcher<B, DS extends BaseDataSource>
   onApplicationShutdown(): void {
     this.isShutdown = true;
     this.processQueue.abort();
+    this.fetchQueue.abort();
   }
 
   enqueueBlocks(heights: (IBlock<B> | number)[], latestBufferHeight: number): void {

--- a/packages/node-core/src/utils/queues/autoQueue.ts
+++ b/packages/node-core/src/utils/queues/autoQueue.ts
@@ -81,10 +81,12 @@ export class AutoQueue<T> implements IQueue {
    * We don't want this function to be async
    * If it is async it will return a promise that throws rather than throwing the function
    */
-  async put(item: Task<T>): Promise<T> {
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  put(item: Task<T>): Promise<T> {
     return this.putMany([item])[0];
   }
 
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
   putMany(tasks: Array<Task<T>>): Promise<T>[] {
     if (this.freeSpace && tasks.length > this.freeSpace) {
       throw new Error(`${this.name} Queue exceeds max size`);

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Max queue size error with workers (#2725)
 
 ## [5.11.0] - 2025-03-20
 ### Fixed


### PR DESCRIPTION
# Description
With recent fixes and changes to the block dispatchers it introduced a bug where the free size wasn't returning the correct value, this would lead to more blocks being enqueued than the queues had space for

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
