### PR TITLE
Fix typos and grammar

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -43,7 +43,7 @@ or harmful.
 Project maintainers have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions that are
 not aligned to this Code of Conduct, or to ban temporarily or permanently any 
-contributor for other behaviors that is deemed inappropriate, threatening, offensive, or harmful.
+contributor for other behaviors that are deemed inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
@@ -56,7 +56,7 @@ representative at an online or offline event.
 
 ## Reporting Code of Conduct Issues
 
-SubQuery encourage all communities to resolve issues on their own whenever possible. 
+SubQuery encourages all communities to resolve issues on their own whenever possible. 
 This builds a broader and deeper understanding and ultimately a healthier interaction. 
 In the event that an issue cannot be resolved locally, please feel free to report your concerns by 
 contacting support@subquery.network. 

--- a/scripts/update_versions.sh
+++ b/scripts/update_versions.sh
@@ -40,7 +40,7 @@ prepare_package_release() {
     exit 1
   fi
 
-  # Movde into the directory in the path
+  # Move into the directory in the path
   cd "$dir"
 
   # Get the version from package.json


### PR DESCRIPTION
In CODE_OF_CONDUCT.md:

Changed is deemed to are deemed — the subject "behaviors" is plural, so the verb must agree in number.

Changed SubQuery encourage to SubQuery encourages — "SubQuery" is singular, so the verb should be in third-person singular form.

In scripts/update_versions.sh:

Fixed a typo: Movde → Move.