### PR TITLE
Dictionary queries will now query up to the target height

### DIFF
--- a/packages/node-core/src/indexer/dictionary/dictionary.service.ts
+++ b/packages/node-core/src/indexer/dictionary/dictionary.service.ts
@@ -114,10 +114,10 @@ export abstract class DictionaryService<DS, FB> implements IDictionaryCtrl<DS, F
   async scopedDictionaryEntries(
     startBlockHeight: number,
     scaledBatchSize: number,
-    latestFinalizedHeight: number //api FinalizedHeight
+    chainHeadHeight: number //api FinalizedHeight
   ): Promise<DictionaryResponse<number | IBlock<FB>> | undefined> {
     const skipDictionaryIndex: Set<number> = new Set<number>();
-    return this._scopedDictionaryEntries(startBlockHeight, scaledBatchSize, latestFinalizedHeight, skipDictionaryIndex);
+    return this._scopedDictionaryEntries(startBlockHeight, scaledBatchSize, chainHeadHeight, skipDictionaryIndex);
   }
 
   /**
@@ -126,12 +126,11 @@ export abstract class DictionaryService<DS, FB> implements IDictionaryCtrl<DS, F
   private async _scopedDictionaryEntries(
     startBlockHeight: number,
     scaledBatchSize: number,
-    latestFinalizedHeight: number, //api FinalizedHeight
+    chainHeadHeight: number, //api FinalizedHeight
     skipDictionaryIndex: Set<number> = new Set<number>()
   ): Promise<DictionaryResponse<number | IBlock<FB>> | undefined> {
     // Initialize skipDictionaryIndex as an empty array
     // Attempt to get data from the current dictionary
-    // const result = await this.tryGetDictionaryData(startBlockHeight, scaledBatchSize, latestFinalizedHeight, skipDictionaryIndex);
     const dictionary = this.getDictionary(startBlockHeight, skipDictionaryIndex);
     if (!dictionary) {
       return undefined;
@@ -139,7 +138,7 @@ export abstract class DictionaryService<DS, FB> implements IDictionaryCtrl<DS, F
     try {
       const queryEndBlock = dictionary.getQueryEndBlock(
         startBlockHeight + this.nodeConfig.dictionaryQuerySize,
-        latestFinalizedHeight
+        chainHeadHeight
       );
       return await dictionary.getData(startBlockHeight, queryEndBlock, scaledBatchSize);
     } catch (error: any) {
@@ -148,12 +147,7 @@ export abstract class DictionaryService<DS, FB> implements IDictionaryCtrl<DS, F
         throw new Error(`try get next dictionary but _currentDictionaryIndex is undefined`);
       }
       skipDictionaryIndex.add(this._currentDictionaryIndex);
-      return this._scopedDictionaryEntries(
-        startBlockHeight,
-        scaledBatchSize,
-        latestFinalizedHeight,
-        skipDictionaryIndex
-      );
+      return this._scopedDictionaryEntries(startBlockHeight, scaledBatchSize, chainHeadHeight, skipDictionaryIndex);
     }
   }
 

--- a/packages/node-core/src/indexer/dictionary/v2/dictionaryV2.ts
+++ b/packages/node-core/src/indexer/dictionary/v2/dictionaryV2.ts
@@ -102,8 +102,8 @@ export abstract class DictionaryV2<
     this.setDictionaryStartHeight(this._metadata.start);
   }
 
-  getQueryEndBlock(targetBlockHeight: number, apiFinalizedHeight: number): number {
-    return Math.min(targetBlockHeight, this.metadata.end, apiFinalizedHeight);
+  getQueryEndBlock(targetBlockHeight: number, apiHeadHeight: number): number {
+    return Math.min(targetBlockHeight, this.metadata.end, apiHeadHeight);
   }
 
   protected abstract convertResponseBlocks<RFB>(

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -218,7 +218,7 @@ export class FetchService<DS extends BaseDataSource, B extends IBlockDispatcher<
           const dictionary = await this.dictionaryService.scopedDictionaryEntries(
             startBlockHeight,
             scaledBatchSize,
-            this.latestFinalizedHeight
+            latestHeight
           );
 
           if (startBlockHeight !== getStartBlockHeight()) {


### PR DESCRIPTION
# Description
Solana supports unfinalized blocks from dictionary queries. This PR changes the end height to match that of the target height (unfinalized head if unfinalized blocks is enabled). As well as renaming some arguments to better represent this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
