### PR TITLE
fix: dead links to source files of commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -71,7 +71,7 @@ DESCRIPTION
   Build this SubQuery project code
 ```
 
-_See code: [lib/commands/build/index.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/build/index.js)_
+_See code: [lib/commands/build/index.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/build/index.ts)_
 
 ## `subql codegen`
 
@@ -89,7 +89,7 @@ DESCRIPTION
   Generate schemas for graph node
 ```
 
-_See code: [lib/commands/codegen/index.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/codegen/index.js)_
+_See code: [lib/commands/codegen/index.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/codegen/index.ts)_
 
 ## `subql codegen:generate`
 
@@ -112,7 +112,7 @@ DESCRIPTION
   Generate Project.yaml and mapping functions based on provided ABI
 ```
 
-_See code: [lib/commands/codegen/generate.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/codegen/generate.js)_
+_See code: [lib/commands/codegen/generate.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/codegen/generate.ts)_
 
 ## `subql deployment`
 
@@ -161,7 +161,7 @@ DESCRIPTION
   Deploy to hosted service
 ```
 
-_See code: [lib/commands/deployment/index.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/deployment/index.js)_
+_See code: [lib/commands/deployment/index.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/deployment/index.ts)_
 
 ## `subql deployment:delete`
 
@@ -180,7 +180,7 @@ DESCRIPTION
   Delete Deployment
 ```
 
-_See code: [lib/commands/deployment/delete.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/deployment/delete.js)_
+_See code: [lib/commands/deployment/delete.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/deployment/delete.ts)_
 
 ## `subql deployment:deploy`
 
@@ -225,7 +225,7 @@ DESCRIPTION
   Deployment to hosted service
 ```
 
-_See code: [lib/commands/deployment/deploy.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/deployment/deploy.js)_
+_See code: [lib/commands/deployment/deploy.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/deployment/deploy.ts)_
 
 ## `subql deployment:promote`
 
@@ -244,7 +244,7 @@ DESCRIPTION
   Promote Deployment
 ```
 
-_See code: [lib/commands/deployment/promote.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/deployment/promote.js)_
+_See code: [lib/commands/deployment/promote.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/deployment/promote.ts)_
 
 ## `subql init [PROJECTNAME]`
 
@@ -268,7 +268,7 @@ DESCRIPTION
   Initialize a scaffold subquery project
 ```
 
-_See code: [lib/commands/init.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/init.js)_
+_See code: [lib/commands/init.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/init.ts)_
 
 ## `subql migrate`
 
@@ -287,7 +287,7 @@ DESCRIPTION
   Schema subgraph project to subquery project
 ```
 
-_See code: [lib/commands/migrate.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/migrate.js)_
+_See code: [lib/commands/migrate.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/migrate.ts)_
 
 ## `subql multi-chain:add`
 
@@ -306,7 +306,7 @@ DESCRIPTION
   Add new chain manifest to multi-chain configuration
 ```
 
-_See code: [lib/commands/multi-chain/add.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/multi-chain/add.js)_
+_See code: [lib/commands/multi-chain/add.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/multi-chain/add.ts)_
 
 ## `subql multi-chain:deploy`
 
@@ -352,7 +352,7 @@ DESCRIPTION
   Multi-chain deployment to hosted service
 ```
 
-_See code: [lib/commands/multi-chain/deploy.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/multi-chain/deploy.js)_
+_See code: [lib/commands/multi-chain/deploy.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/multi-chain/deploy.ts)_
 
 ## `subql project`
 
@@ -377,7 +377,7 @@ DESCRIPTION
   Create/Delete project
 ```
 
-_See code: [lib/commands/project/index.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/project/index.js)_
+_See code: [lib/commands/project/index.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/project/index.ts)_
 
 ## `subql project:create-project`
 
@@ -401,7 +401,7 @@ DESCRIPTION
   Create Project on Hosted Service
 ```
 
-_See code: [lib/commands/project/create-project.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/project/create-project.js)_
+_See code: [lib/commands/project/create-project.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/project/create-project.ts)_
 
 ## `subql project:delete-project`
 
@@ -419,7 +419,7 @@ DESCRIPTION
   Delete Project on Hosted Service
 ```
 
-_See code: [lib/commands/project/delete-project.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/project/delete-project.js)_
+_See code: [lib/commands/project/delete-project.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/project/delete-project.ts)_
 
 ## `subql publish`
 
@@ -438,6 +438,6 @@ DESCRIPTION
   Upload this SubQuery project to IPFS
 ```
 
-_See code: [lib/commands/publish.js](https://github.com/packages/cli/blob/v5.9.1-0/lib/commands/publish.js)_
+_See code: [lib/commands/publish.js](https://github.com/subquery/subql/blob/main/packages/cli/src/commands/publish.ts)_
 
 <!-- commandsstop -->


### PR DESCRIPTION
# Description
changed links to source files of every command in `packages/cli/README.md` so now it works properly. 
Fixes # (issue)

## Type of change

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
