### PR TITLE
Hide _global table from query service

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Hide \_global table from being queried (#2799)
 
 ## [2.22.0] - 2025-04-30
 ### Removed

--- a/packages/query/src/graphql/plugins/smartTagsPlugin.ts
+++ b/packages/query/src/graphql/plugins/smartTagsPlugin.ts
@@ -1,15 +1,16 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {MULTI_METADATA_REGEX, METADATA_REGEX} from '@subql/utils';
+import {MULTI_METADATA_REGEX, METADATA_REGEX, MULTI_GLOBAL_REGEX} from '@subql/utils';
 import {PgEntity, PgEntityKind} from '@subql/x-graphile-build-pg';
 import {makePgSmartTagsPlugin} from 'graphile-utils';
 
 export const smartTagsPlugin = makePgSmartTagsPlugin([
   {
-    //Rule 1, omit `_metadata` from node
+    //Rule 1, omit `_metadata`, `_global` from node
     kind: PgEntityKind.CLASS,
-    match: ({name}: PgEntity) => METADATA_REGEX.test(name) || MULTI_METADATA_REGEX.test(name),
+    match: ({name}: PgEntity) =>
+      METADATA_REGEX.test(name) || MULTI_METADATA_REGEX.test(name) || MULTI_GLOBAL_REGEX.test(name),
     tags: {
       omit: true,
     },

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Regex for \_global table (#2799)
 
 ## [2.18.1] - 2025-04-24
 ### Changed

--- a/packages/utils/src/query/metadata.ts
+++ b/packages/utils/src/query/metadata.ts
@@ -4,8 +4,8 @@
 import {blake2AsHex} from '@polkadot/util-crypto';
 
 export const METADATA_REGEX = /^_metadata$/;
-
 export const MULTI_METADATA_REGEX = /^_metadata_[a-zA-Z0-9-]+$/;
+export const MULTI_GLOBAL_REGEX = /^_global$/;
 
 export function getMetadataTableName(chainId: string): string {
   const hash = blake2AsHex(chainId, 64);


### PR DESCRIPTION
# Description
With the introduction of mutlichain rewinds there was a new `_global` table. This should not be exposed via the query service. This PR hides the `_global` table.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
