### PR TITLE
Fix broken link to types-substrate and clarify @subql/types usage in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ This repository contains all the core components of the SubQuery SDK as well as 
 * [`@subql/query`](packages/query) - The GraphQL query service for SubQuery projects, allowing you to interact with your indexed data.
 * [`@subql/common`](packages/common) - Common utilities and types used across SubQuery packages
 * [`@subql/common-substrate`](packages/common-substrate) - Common utilities and types specifically for Substrate-based chains
-* [`@subql/types-substrate`](packages/types-substrate) - Type definitions for Substrate-based chains
-* [`@subql/types`](packages/types) - Type definitions for SubQuery projects, including the project manifest and data models
+* [`@subql/types`](packages/types) - Type definitions for Substrate-based chains and SubQuery projects, including the project manifest and data models
 
 For more detail on the specific network implementations please see their respective repositories:
 


### PR DESCRIPTION
Replaced the broken link to the non-existent @subql/types-substrate package in the README with the correct reference to @subql/types. Also updated the description to clarify that @subql/types provides type definitions for both Substrate-based chains and SubQuery projects, including the project manifest and data models. This resolves the broken link issue and improves documentation clarity.