### PR TITLE
Improvements to ABI generation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,6 +45,7 @@ jobs:
       SUBQL_ACCESS_TOKEN: ${{ secrets.SUBQL_ACCESS_TOKEN }}
       SUBQL_ACCESS_TOKEN_TEST: ${{ secrets.SUBQL_ACCESS_TOKEN_TEST }}
       SUBQL_ORG_TEST: ${{ secrets.SUBQL_ORG_TEST }}
+      ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `oclif` dependency (#2817)
 - Update command descriptions (#2817)
-- Alias `codegen:generate` to `abi-import` (#2817)
+- Alias `codegen:generate` to `import-abi` (#2817)
 
 ### Added
 - The `codegen:generate` command can now attempt to pull ABIs from etherscan (#2817)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `oclif` dependency (#2817)
+- Update command descriptions (#2817)
+- Alias `codegen:generate` to `abi-import` (#2817)
+
+### Added
+- The `codegen:generate` command can now attempt to pull ABIs from etherscan (#2817)
 
 ## [5.11.0] - 2025-06-05
 ### Changed

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -26,5 +26,3 @@ if (notifier.update) {
   const oclif = await import('@oclif/core');
   await oclif.execute({development: false, dir: __dirname});
 })();
-// const oclif = require('@oclif/core');
-// oclif.run().then(oclif.flush).catch(oclif.Errors.handle);

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -5,10 +5,10 @@ const updateNotifier = require('update-notifier');
 const chalk = require('chalk');
 const semver = require('semver');
 
-const notifier = updateNotifier({ pkg: pjson, updateCheckInterval: 0 });
+const notifier = updateNotifier({pkg: pjson, updateCheckInterval: 0});
 
 if (notifier.update) {
-  const { current, latest, name } = notifier.update;
+  const {current, latest, name} = notifier.update;
 
   if (semver.lt(current, latest)) {
     const message = `
@@ -21,5 +21,10 @@ if (notifier.update) {
   }
 }
 
-const oclif = require('@oclif/core');
-oclif.run().then(oclif.flush).catch(oclif.Errors.handle);
+// eslint-disable-next-line unicorn/prefer-top-level-await
+(async () => {
+  const oclif = await import('@oclif/core');
+  await oclif.execute({development: false, dir: __dirname});
+})();
+// const oclif = require('@oclif/core');
+// oclif.run().then(oclif.flush).catch(oclif.Errors.handle);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -80,12 +80,7 @@
   "oclif": {
     "commands": "./lib/commands",
     "bin": "subql",
-    "repositoryPrefix": "<%- repo %>/blob/cli/<%- version %>/packages/cli/<%- commandPath.replace('lib/', 'src/').replace(/\\.js$/, '.ts') %>",
-    "topics": {
-      "codegen:generate": {
-        "description": "Generate handlers and datasources from and ethereum abi"
-      }
-    }
+    "repositoryPrefix": "<%- repo %>/blob/cli/<%- version %>/packages/cli/<%- commandPath.replace('lib/', 'src/').replace(/\\.js$/, '.ts') %>"
   },
   "scripts": {
     "build": "rm -rf lib && tsc -b && cp -r src/template lib/",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@subql/cli",
-  "description": "cli for subquery",
+  "description": "CLI for SubQuery",
   "version": "5.11.0",
-  "author": "Ian He",
+  "author": "SubQuery Pte Ltd.",
   "bin": {
     "subql": "./bin/run"
   },
   "bugs": "https://github.com/subquery/subql/issues",
   "dependencies": {
     "@inquirer/prompts": "^5.3.6",
-    "@oclif/core": "^2.16.0",
+    "@oclif/core": "^4.3.3",
     "@subql/common": "workspace:*",
     "@subql/utils": "workspace:*",
     "chalk": "^4",
@@ -80,7 +80,12 @@
   "oclif": {
     "commands": "./lib/commands",
     "bin": "subql",
-    "repositoryPrefix": "<%- repo %>/blob/cli/<%- version %>/packages/cli/<%- commandPath.replace('lib/', 'src/').replace(/\\.js$/, '.ts') %>"
+    "repositoryPrefix": "<%- repo %>/blob/cli/<%- version %>/packages/cli/<%- commandPath.replace('lib/', 'src/').replace(/\\.js$/, '.ts') %>",
+    "topics": {
+      "codegen:generate": {
+        "description": "Generate handlers and datasources from and ethereum abi"
+      }
+    }
   },
   "scripts": {
     "build": "rm -rf lib && tsc -b && cp -r src/template lib/",

--- a/packages/cli/src/commands/codegen/generate.ts
+++ b/packages/cli/src/commands/codegen/generate.ts
@@ -119,8 +119,6 @@ export default class Generate extends Command {
       //
       throw new Error('For multichain projects a specific manifest must be provided');
     }
-    // TODO ensure we still use TS path
-    // TODO ensure if it is multichain and speific manifest is provided we use that
     const yamlManifest = getManifestPath(root, manifests[0]);
     const manifest = tsManifest ?? yamlManifest;
 

--- a/packages/cli/src/commands/codegen/generate.ts
+++ b/packages/cli/src/commands/codegen/generate.ts
@@ -48,7 +48,7 @@ export interface UserInput {
 
 export default class Generate extends Command {
   static description =
-    'Generate project handlers and mapping functions based on an Ethreum ABI. If address is provided, it will attempt to fetch the ABI and start block from the Etherscan.';
+    'Generate project handlers and mapping functions based on an Ethereum ABI. If address is provided, it will attempt to fetch the ABI and start block from the Etherscan.';
 
   static flags = {
     file: Flags.string({char: 'f', description: 'Project folder or manifest file'}),
@@ -130,7 +130,7 @@ export default class Generate extends Command {
 
     if (!abiPath) {
       if (!address) {
-        this.error('Please provide the ABI file path using --abiPath flag, or address to fetch the ABI from Ethersacn');
+        this.error('Please provide the ABI file path using --abiPath flag, or address to fetch the ABI from Etherscan');
       }
       const spinner = ora('Finding ABI from Etherscan').start();
       try {

--- a/packages/cli/src/commands/codegen/index.ts
+++ b/packages/cli/src/commands/codegen/index.ts
@@ -7,12 +7,13 @@ import {codegen} from '../../controller/codegen-controller';
 import {resolveToAbsolutePath, buildManifestFromLocation, getTsManifest} from '../../utils';
 
 export default class Codegen extends Command {
-  static description = 'Generate schemas for graph node';
+  static description = 'Generate entity types from the graphql schema';
 
   static flags = {
     location: Flags.string({
       char: 'l',
-      description: '[deprecated] local folder to run codegen in. please use file flag instead',
+      description: 'local folder to run codegen in. please use file flag instead',
+      deprecated: true,
     }),
     file: Flags.string({char: 'f', description: 'specify manifest file path (will overwrite -l if both used)'}),
   };

--- a/packages/cli/src/commands/codegen/index.ts
+++ b/packages/cli/src/commands/codegen/index.ts
@@ -7,7 +7,7 @@ import {codegen} from '../../controller/codegen-controller';
 import {resolveToAbsolutePath, buildManifestFromLocation, getTsManifest} from '../../utils';
 
 export default class Codegen extends Command {
-  static description = 'Generate entity types from the graphql schema';
+  static description = 'Generate entity types from the GraphQL schema';
 
   static flags = {
     location: Flags.string({

--- a/packages/cli/src/commands/deployment/delete.ts
+++ b/packages/cli/src/commands/deployment/delete.ts
@@ -7,7 +7,7 @@ import {deleteDeployment} from '../../controller/deploy-controller';
 import {checkToken, valueOrPrompt} from '../../utils';
 
 export default class Delete extends Command {
-  static description = 'Delete Deployment';
+  static description = 'Delete a deployment from the OnFinality managed services';
 
   static flags = {
     org: Flags.string({description: 'Enter organization name'}),

--- a/packages/cli/src/commands/deployment/deploy.ts
+++ b/packages/cli/src/commands/deployment/deploy.ts
@@ -19,7 +19,7 @@ import {V3DeploymentIndexerType} from '../../types';
 import {addV, checkToken, valueOrPrompt} from '../../utils';
 
 export default class Deploy extends Command {
-  static description = 'Deployment to hosted service';
+  static description = 'Deployment a project to the OnFinality managed services';
 
   static flags = {
     ...DefaultDeployFlags,
@@ -111,7 +111,7 @@ export default class Deploy extends Command {
 export async function promptImageVersion(
   runner: string,
   version: string,
-  useDefaults: boolean,
+  useDefaults: boolean | undefined,
   authToken: string,
   message: string
 ): Promise<string> {

--- a/packages/cli/src/commands/deployment/deploy.ts
+++ b/packages/cli/src/commands/deployment/deploy.ts
@@ -19,7 +19,7 @@ import {V3DeploymentIndexerType} from '../../types';
 import {addV, checkToken, valueOrPrompt} from '../../utils';
 
 export default class Deploy extends Command {
-  static description = 'Deployment a project to the OnFinality managed services';
+  static description = 'Deploy a project to the OnFinality managed services';
 
   static flags = {
     ...DefaultDeployFlags,

--- a/packages/cli/src/commands/deployment/index.ts
+++ b/packages/cli/src/commands/deployment/index.ts
@@ -10,7 +10,7 @@ import Promote from './promote';
 type DeploymentOption = 'promote' | 'delete' | 'deploy';
 
 export default class Deployment extends Command {
-  static description = 'Deploy to hosted service';
+  static description = 'Deploy to OnFinality managed services';
   static flags = {
     options: Flags.string({
       options: ['deploy', 'promote', 'delete'],

--- a/packages/cli/src/commands/deployment/promote.ts
+++ b/packages/cli/src/commands/deployment/promote.ts
@@ -7,7 +7,7 @@ import {promoteDeployment} from '../../controller/deploy-controller';
 import {checkToken, valueOrPrompt} from '../../utils';
 
 export default class Promote extends Command {
-  static description = 'Promote Deployment';
+  static description = 'Promote a deployment on the OnFinality managed services from a Stage environment to Production';
 
   static flags = {
     org: Flags.string({description: 'Enter organization name'}),

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -37,7 +37,7 @@ function filterInput<T>(arr: T[]) {
 type InitFlags = Interfaces.InferredFlags<typeof Init.flags>;
 
 export default class Init extends Command {
-  static description = 'Initialize a scaffold subquery project';
+  static description = 'Initialize a SubQuery project from a template';
 
   static flags = {
     force: Flags.boolean({

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -142,14 +142,17 @@ export default class Init extends Command {
     assert(selectedProject, 'No project selected');
     const projectPath: string = await cloneProjectTemplate(location, project.name, selectedProject);
     const {isMultiChainProject} = await this.setupProject(project, projectPath, flags);
-    if (isMultiChainProject) return;
+    if (isMultiChainProject) {
+      this.log('Multi-chain project successfully created!');
+      return;
+    }
 
     if (await validateEthereumProjectManifest(projectPath)) {
       if (flags.abiPath) {
         await this.createProjectScaffold(projectPath, flags.abiPath);
       } else if (!flags.force) {
         const loadAbi = await confirm({
-          message: 'Do you want to generate scaffolding from an existing contract abi?',
+          message: 'Do you want to generate datasources and handlers from an existing contract ABI?',
           default: false,
         });
 
@@ -158,6 +161,8 @@ export default class Init extends Command {
         }
       }
     }
+
+    this.log('Project successfully created!');
   }
 
   async setupProject(
@@ -235,6 +240,12 @@ export default class Init extends Command {
         message: 'Path to ABI',
       }));
 
+    // If user doesn't enter anything skip the generation
+    if (!abiFilePath) {
+      this.log('ABI not provided. You can add ABIs at a later stage with the `import-abi` command.');
+      return;
+    }
+
     const contractAddress = await input({
       message: 'Please provide a contract address (optional)',
     });
@@ -246,7 +257,7 @@ export default class Init extends Command {
 
     const cleanedContractAddress = contractAddress.replace(/[`'"]/g, '');
 
-    this.log(`Generating scaffold handlers and manifest from ${abiFilePath}`);
+    this.log(`Generating handlers and manifest from ${abiFilePath}`);
     await Generate.run([
       '-f',
       projectPath,

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -29,11 +29,11 @@ import {
 import {migrateMapping} from '../controller/migrate/mapping/migrate-mapping.controller';
 
 export default class Migrate extends Command {
-  static description = 'Schema subgraph project to subquery project';
+  static description = 'Migrate a Subgraph project to a SubQuery project, including the manifest and schema.';
 
   static flags = {
-    gitSubDirectory: Flags.string({char: 'd', description: 'specify git subdirectory path'}),
-    file: Flags.string({char: 'f', description: 'specify subgraph git/directory path'}),
+    gitSubDirectory: Flags.string({char: 'd', description: 'Specify git subdirectory path'}),
+    file: Flags.string({char: 'f', description: 'Specify subgraph git/directory path'}),
     output: Flags.string({char: 'o', description: 'Output subquery project path', required: false}),
   };
 

--- a/packages/cli/src/commands/project/create-project.ts
+++ b/packages/cli/src/commands/project/create-project.ts
@@ -8,7 +8,7 @@ import {createProject} from '../../controller/project-controller';
 import {checkToken, valueOrPrompt} from '../../utils';
 
 export default class Create_project extends Command {
-  static description = 'Create Project on Hosted Service';
+  static description = 'Create a project on OnFinality managed services';
 
   static flags = {
     org: Flags.string({description: 'Enter organization name'}),

--- a/packages/cli/src/commands/project/delete-project.ts
+++ b/packages/cli/src/commands/project/delete-project.ts
@@ -7,7 +7,7 @@ import {deleteProject} from '../../controller/project-controller';
 import {checkToken, valueOrPrompt} from '../../utils';
 
 export default class Delete_project extends Command {
-  static description = 'Delete Project on Hosted Service';
+  static description = 'Delete a project on OnFinality managed services';
 
   static flags = {
     org: Flags.string({description: 'Enter organization name'}),

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -9,7 +9,7 @@ import Delete_project from './delete-project';
 type projectOptions = 'create' | 'delete';
 
 export default class Project extends Command {
-  static description = 'Create/Delete project';
+  static description = 'Create/Delete projects on the OnFinality managed services';
   static flags = {
     options: Flags.string({
       options: ['create', 'delete'],

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -10,7 +10,7 @@ import {getOptionalToken, resolveToAbsolutePath} from '../utils';
 import Build from './build';
 
 export default class Publish extends Command {
-  static description = 'Upload this SubQuery project to IPFS';
+  static description = 'Upload this SubQuery project to IPFS for distribution';
 
   static flags = {
     location: Flags.string({char: 'f', description: 'from project folder or specify manifest file'}),

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -8,8 +8,8 @@ import {DeploymentType} from './types';
 //DEPLOYMENT
 export const DEFAULT_DEPLOYMENT_TYPE = 'primary' satisfies DeploymentType;
 //PROJECT
-export const ROOT_API_URL_PROD = 'https://api.subquery.network';
-export const BASE_PROJECT_URL = 'https://managedservice.subquery.network';
+export const ROOT_API_URL_PROD = 'https://index-api.onfinality.io';
+export const BASE_PROJECT_URL = 'https://indexing.onfinality.io';
 
 export const BASE_TEMPLATE_URl = 'https://templates.subquery.network';
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -9,7 +9,6 @@ import {DeploymentType} from './types';
 export const DEFAULT_DEPLOYMENT_TYPE = 'primary' satisfies DeploymentType;
 //PROJECT
 export const ROOT_API_URL_PROD = 'https://api.subquery.network';
-
 export const BASE_PROJECT_URL = 'https://managedservice.subquery.network';
 
 export const BASE_TEMPLATE_URl = 'https://templates.subquery.network';

--- a/packages/cli/src/controller/generate-controller.ts
+++ b/packages/cli/src/controller/generate-controller.ts
@@ -48,6 +48,9 @@ export function removeKeyword(inputString: string): string {
   return inputString.replace(/^(event|function) /, '');
 }
 
+/**
+ * Copies the provided ABI file to the default ABI directory in the project root.
+ */
 export async function prepareAbiDirectory(abiPath: string, rootPath: string): Promise<void> {
   const abiDirPath = path.join(rootPath, DEFAULT_ABI_DIR);
 
@@ -63,13 +66,29 @@ export async function prepareAbiDirectory(abiPath: string, rootPath: string): Pr
   const ensuredAbiPath = resolveToAbsolutePath(abiPath);
 
   try {
-    const abiFileContent = await fs.promises.readFile(ensuredAbiPath, 'utf8');
-    await fs.promises.writeFile(path.join(abiDirPath, path.basename(ensuredAbiPath)), abiFileContent);
+    await fs.promises.copyFile(ensuredAbiPath, path.join(abiDirPath, path.basename(ensuredAbiPath)));
   } catch (e: any) {
     if (e.code === 'ENOENT') {
       throw new Error(`Unable to find abi at: ${abiPath}`);
     }
+    throw new Error(`Unable to copy abi file: ${e.message}`);
   }
+}
+
+/**
+ * Saves the provided ABI to a file in the default ABI directory.
+ * @param abi - The ABI to save.
+ * @param addressOrName - The name or address to use as the filename.
+ * @param rootPath - The root path of the project.
+ * @returns The path to the saved ABI file.
+ */
+export async function saveAbiToFile(abi: unknown, addressOrName: string, rootPath: string): Promise<string> {
+  const abiDirPath = path.join(rootPath, DEFAULT_ABI_DIR);
+  const filePath = path.join(abiDirPath, `${addressOrName}.abi.json`);
+
+  await fs.promises.writeFile(filePath, JSON.stringify(abi, null, 2));
+
+  return filePath;
 }
 
 export function constructMethod<T extends ConstructorFragment | Fragment>(

--- a/packages/cli/src/controller/migrate/abis/migrate-abis.controller.ts
+++ b/packages/cli/src/controller/migrate/abis/migrate-abis.controller.ts
@@ -14,10 +14,10 @@ function extractAllAbiFiles(dataSources: SubgraphDataSource[]): string[] {
 async function copyAbiFilesToTargetPathAsync(abiFiles: string[], targetPath: string): Promise<void> {
   try {
     await Promise.all(
-      abiFiles.map((file) => {
+      abiFiles.map(async (file) => {
         const fileName = path.basename(file);
         const targetFilePath = path.join(targetPath, fileName);
-        fs.promises.copyFile(file, targetFilePath);
+        await fs.promises.copyFile(file, targetFilePath);
       })
     );
     console.log(

--- a/packages/cli/src/controller/migrate/manifest/migrate-manifest.controller.ts
+++ b/packages/cli/src/controller/migrate/manifest/migrate-manifest.controller.ts
@@ -99,7 +99,11 @@ export async function renderManifest(projectPath: string, project: CommonSubquer
  * @param inputPath file path to subgraph.yaml
  * @param outputPath file path to project.ts
  */
-export async function migrateManifest(chainInfo: ChainInfo, subgraphManifest: SubgraphProject, outputPath: string) {
+export async function migrateManifest(
+  chainInfo: ChainInfo,
+  subgraphManifest: SubgraphProject,
+  outputPath: string
+): Promise<void> {
   await prepareDirPath(outputPath, false);
   await renderManifest(outputPath, graphManifestToSubqlManifest(chainInfo, subgraphManifest));
 }

--- a/packages/cli/src/controller/migrate/migrate-controller.ts
+++ b/packages/cli/src/controller/migrate/migrate-controller.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 import {NETWORK_FAMILY} from '@subql/common';

--- a/packages/cli/src/controller/project-controller.ts
+++ b/packages/cli/src/controller/project-controller.ts
@@ -8,7 +8,7 @@ import {errorHandle} from '../utils';
 interface CreateProjectResponse {
   key: string;
 }
-export const suffixFormat = (value: string) => {
+export const suffixFormat = (value: string): string => {
   return value
     .replace(/(^\s*)|(\s*$)/g, '')
     .replace(/\s+/g, '-')

--- a/packages/cli/src/modulars/utils.ts
+++ b/packages/cli/src/modulars/utils.ts
@@ -1,4 +1,0 @@
-// Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
-// SPDX-License-Identifier: GPL-3.0
-
-import {NETWORK_FAMILY, runnerMapping} from '@subql/common';

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -163,7 +163,7 @@ export interface ProjectDeploymentInterface {
   ipfsCID: string;
   queryVersion: string;
   authToken: string;
-  log: any;
+  log: (message?: string, ...args: unknown[]) => void;
 }
 
 export interface DeploymentFlagsInterface {
@@ -175,23 +175,23 @@ export interface DeploymentFlagsInterface {
   queryVersion?: string;
   dict?: string;
   endpoint?: string;
-  indexerUnsafe: boolean;
+  indexerUnsafe?: boolean;
   indexerBatchSize?: number;
-  indexerSubscription: boolean;
-  disableHistorical: boolean;
-  indexerUnfinalized: boolean;
+  indexerSubscription?: boolean;
+  disableHistorical?: boolean;
+  indexerUnfinalized?: boolean;
   indexerStoreCacheThreshold?: number;
-  disableIndexerStoreCacheAsync: boolean;
+  disableIndexerStoreCacheAsync?: boolean;
   indexerWorkers?: number;
   ipfsCID?: string;
   location?: string;
-  queryUnsafe: boolean;
-  querySubscription: boolean;
+  queryUnsafe?: boolean;
+  querySubscription?: boolean;
   queryTimeout?: number;
   queryMaxConnection?: number;
-  queryAggregate: boolean;
+  queryAggregate?: boolean;
   queryLimit?: number;
-  useDefaults: boolean;
+  useDefaults?: boolean;
 }
 
 export interface GenerateDeploymentChainInterface {

--- a/packages/cli/src/utils/__snapshots__/etherscan.spec.ts.snap
+++ b/packages/cli/src/utils/__snapshots__/etherscan.spec.ts.snap
@@ -1,0 +1,210 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`etherscan api ABI fetching can fetch the ABI 1`] = `
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address",
+      },
+      {
+        "internalType": "address",
+        "name": "prizePoolAddress",
+        "type": "address",
+      },
+      {
+        "internalType": "uint256",
+        "name": "poolFeePerc_",
+        "type": "uint256",
+      },
+      {
+        "internalType": "address",
+        "name": "shieldAddress",
+        "type": "address",
+      },
+      {
+        "internalType": "uint256",
+        "name": "shieldFeePerc_",
+        "type": "uint256",
+      },
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor",
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address",
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "hashedPrompt",
+        "type": "bytes32",
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256",
+      },
+    ],
+    "name": "BuyIn",
+    "type": "event",
+  },
+  {
+    "stateMutability": "payable",
+    "type": "fallback",
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "hashedPrompt",
+        "type": "bytes32",
+      },
+    ],
+    "name": "buyIn",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function",
+  },
+  {
+    "inputs": [],
+    "name": "operator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address",
+      },
+    ],
+    "stateMutability": "view",
+    "type": "function",
+  },
+  {
+    "inputs": [],
+    "name": "poolFeePerc",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256",
+      },
+    ],
+    "stateMutability": "view",
+    "type": "function",
+  },
+  {
+    "inputs": [],
+    "name": "prizePool",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address",
+      },
+    ],
+    "stateMutability": "view",
+    "type": "function",
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "prizePoolAddress",
+        "type": "address",
+      },
+      {
+        "internalType": "address",
+        "name": "shieldAddress",
+        "type": "address",
+      },
+    ],
+    "name": "setAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function",
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "poolFeePerc_",
+        "type": "uint256",
+      },
+      {
+        "internalType": "uint256",
+        "name": "shieldFeePerc_",
+        "type": "uint256",
+      },
+    ],
+    "name": "setFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function",
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator_",
+        "type": "address",
+      },
+    ],
+    "name": "setOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function",
+  },
+  {
+    "inputs": [],
+    "name": "shield",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address",
+      },
+    ],
+    "stateMutability": "view",
+    "type": "function",
+  },
+  {
+    "inputs": [],
+    "name": "shieldFeePerc",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256",
+      },
+    ],
+    "stateMutability": "view",
+    "type": "function",
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [
+      {
+        "internalType": "contract Token",
+        "name": "",
+        "type": "address",
+      },
+    ],
+    "stateMutability": "view",
+    "type": "function",
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive",
+  },
+]
+`;

--- a/packages/cli/src/utils/etherscan.spec.ts
+++ b/packages/cli/src/utils/etherscan.spec.ts
@@ -1,0 +1,44 @@
+// Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {fetchContractDeployHeight, tryFetchAbiFromExplorer} from './etherscan';
+
+describe('etherscan api', () => {
+  describe('ABI fetching', () => {
+    it('can fetch the ABI', async () => {
+      const abi = await tryFetchAbiFromExplorer('0x53A270147832Fc4eb962584911F5D55e86b1BA3F', '8453' /* Base */);
+      expect(abi).toMatchSnapshot();
+    });
+
+    it('returns undefined if an ABI has not been uploaded', async () => {
+      const abi = await tryFetchAbiFromExplorer('0x4eE879f39Cce3C4CA80E2ee90F9Df5aFEEaeb220', '1' /* Ethereum */);
+      expect(abi).toBeUndefined();
+    });
+
+    it('throws if a contract is non-existant', async () => {
+      const abi = await tryFetchAbiFromExplorer('0x53A270147832Fc4eb962584911F5D55e86b1BA3F', '1' /* Ethereum */);
+      expect(abi).toBeUndefined();
+    });
+
+    it('throws for a network that is not supported', async () => {
+      await expect(
+        tryFetchAbiFromExplorer('0x53A270147832Fc4eb962584911F5D55e86b1BA3F', '1329' /* Moonbeam */)
+      ).rejects.toThrow(
+        'Etherscan API error: Missing or unsupported chainid parameter (required for v2 api), please see https://api.etherscan.io/v2/chainlist for the list of supported chainids'
+      );
+    });
+  });
+
+  describe('Deployment information', () => {
+    it('can get the deploy height of a contract', async () => {
+      const height = await fetchContractDeployHeight('0x53A270147832Fc4eb962584911F5D55e86b1BA3F', '8453' /* Base */);
+
+      expect(height).toBe(22771721);
+    });
+
+    it('returns undefined when getting the deploy height for a non-existant contract', async () => {
+      const height = await fetchContractDeployHeight('0x53A270147832Fc4eb962584911F5D55e86b1BA3F', '1' /* Ethereum */);
+      expect(height).toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/utils/etherscan.ts
+++ b/packages/cli/src/utils/etherscan.ts
@@ -1,0 +1,80 @@
+// Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+async function runRequest<T>(chainId: string | number, params: Record<string, string>): Promise<T | undefined> {
+  const url = `https://api.etherscan.io/v2/api?${new URLSearchParams({
+    ...params,
+    chainid: String(chainId),
+    apiKey: process.env.ETHERSCAN_API_KEY || '',
+  }).toString()}`;
+
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch from Etherscan API: ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as {status: '0' | '1'; message: string; result: T};
+
+  if (data.status === '0') {
+    if (data.result === 'Missing/Invalid API Key') {
+      throw new Error('Missing or invalid Etherscan API key. Please set ETHERSCAN_API_KEY environment variable.');
+    }
+    if (data.message === 'No data found') {
+      return undefined;
+    }
+    throw new Error(`Etherscan API error: ${data.result}`);
+  }
+
+  return data.result;
+}
+
+/**
+ * Fetches the ABI from Etherscan.
+ * @param address - The contract address to fetch the ABI for.
+ * @param chainId - The chain ID of the Ethereum network.
+ * @returns The ABI as a JSON object or undefined if the fetch fails.
+ */
+export async function tryFetchAbiFromExplorer(address: string, chainId: number | string): Promise<unknown | undefined> {
+  try {
+    const result = await runRequest<string>(chainId, {
+      module: 'contract',
+      action: 'getabi',
+      address,
+    });
+
+    if (!result) {
+      return undefined;
+    }
+
+    return JSON.parse(result);
+  } catch (e) {
+    if (e instanceof Error && e.message.includes('Contract source code not verified')) {
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+/**
+ * Fetches the deployment height of a contract from Etherscan.
+ * @param address - The contract address to fetch the deployment height for.
+ * @param chainId - The chain ID of the Ethereum network.
+ * @returns The block number where the contract was deployed, or undefined if not found.
+ */
+export async function fetchContractDeployHeight(
+  address: string,
+  chainId: number | string
+): Promise<number | undefined> {
+  const result = await runRequest<{blockNumber: string}[]>(chainId, {
+    module: 'contract',
+    action: 'getcontractcreation',
+    contractaddresses: address,
+  });
+
+  if (!result) {
+    return undefined;
+  }
+
+  return parseInt(result[0].blockNumber, 10);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5855,39 +5855,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oclif/core@npm:^2.16.0":
-  version: 2.16.0
-  resolution: "@oclif/core@npm:2.16.0"
+"@oclif/core@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "@oclif/core@npm:4.3.3"
   dependencies:
-    "@types/cli-progress": ^3.11.0
     ansi-escapes: ^4.3.2
-    ansi-styles: ^4.3.0
-    cardinal: ^2.1.1
-    chalk: ^4.1.2
+    ansis: ^3.17.0
     clean-stack: ^3.0.1
-    cli-progress: ^3.12.0
-    debug: ^4.3.4
-    ejs: ^3.1.8
+    cli-spinners: ^2.9.2
+    debug: ^4.4.0
+    ejs: ^3.1.10
     get-package-type: ^0.1.0
-    globby: ^11.1.0
-    hyperlinker: ^1.0.0
     indent-string: ^4.0.0
     is-wsl: ^2.2.0
-    js-yaml: ^3.14.1
-    natural-orderby: ^2.0.3
-    object-treeify: ^1.1.33
-    password-prompt: ^1.1.2
-    slice-ansi: ^4.0.0
+    lilconfig: ^3.1.3
+    minimatch: ^9.0.5
+    semver: ^7.6.3
     string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-    supports-color: ^8.1.1
-    supports-hyperlinks: ^2.2.0
-    ts-node: ^10.9.1
-    tslib: ^2.5.0
+    supports-color: ^8
+    tinyglobby: ^0.2.14
     widest-line: ^3.1.0
     wordwrap: ^1.0.0
     wrap-ansi: ^7.0.0
-  checksum: 40341a41200354a30492f32997cd3634ff7987ec645223746a5e22f26f7f4aed818fe4d4e0925f31946cbed68dac93ec310807c40d02160b9232915f980b7fb6
+  checksum: 49ae0d86d97d2ce61db276c4d4632e98c481376d7fe6913b9ac61103add9fc8f7ac7cef6e96e3e9c88af29d798eef7dfaac5a0c951f121c598bbdda55ed7f8f6
   languageName: node
   linkType: hard
 
@@ -7715,7 +7705,7 @@ __metadata:
   resolution: "@subql/cli@workspace:packages/cli"
   dependencies:
     "@inquirer/prompts": ^5.3.6
-    "@oclif/core": ^2.16.0
+    "@oclif/core": ^4.3.3
     "@subql/common": "workspace:*"
     "@subql/common-algorand": ^4.3.1
     "@subql/common-concordium": ^4.0.1
@@ -10119,6 +10109,13 @@ __metadata:
   version: 0.3.2
   resolution: "ansicolors@npm:0.3.2"
   checksum: e84fae7ebc27ac96d9dbb57f35f078cd6dde1b7046b0f03f73dcefc9fbb1f2e82e3685d083466aded8faf038f9fa9ebb408d215282bcd7aaa301d5ac3c486815
+  languageName: node
+  linkType: hard
+
+"ansis@npm:^3.17.0":
+  version: 3.17.0
+  resolution: "ansis@npm:3.17.0"
+  checksum: 6fd6bc4d1187b894d9706f4c141c81b788e90766426617385486dae38f8b2f5a1726d8cc754939e44265f92a9db4647d5136cb1425435c39ac42b35e3acf4f3d
   languageName: node
   linkType: hard
 
@@ -12565,6 +12562,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.4.0":
+  version: 4.4.1
+  resolution: "debug@npm:4.4.1"
+  dependencies:
+    ms: ^2.1.3
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: a43826a01cda685ee4cec00fb2d3322eaa90ccadbef60d9287debc2a886be3e835d9199c80070ede75a409ee57828c4c6cd80e4b154f2843f0dc95a570dc0729
+  languageName: node
+  linkType: hard
+
 "debuglog@npm:^1.0.1":
   version: 1.0.1
   resolution: "debuglog@npm:1.0.1"
@@ -14121,6 +14130,18 @@ __metadata:
   dependencies:
     bser: 2.1.1
   checksum: 8510230778ab3a51c27dffb1b76ef2c24fab672a42742d3c0a45c2e9d1e5f20210b1fbca33486088da4a9a3958bde96b5aec0a63aac9894b4e9df65c88b2cbd6
+  languageName: node
+  linkType: hard
+
+"fdir@npm:^6.4.4":
+  version: 6.4.5
+  resolution: "fdir@npm:6.4.5"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 14efd2d6617a6f9fb314916ccff64e00bdb96216f26542ec9dfa532ed60a7ebb45463f7009aa215c14071566bf43caeb8ba268ccb52a11e6b51e4aaa8cb58d81
   languageName: node
   linkType: hard
 
@@ -17477,6 +17498,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lilconfig@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "lilconfig@npm:3.1.3"
+  checksum: 644eb10830350f9cdc88610f71a921f510574ed02424b57b0b3abb66ea725d7a082559552524a842f4e0272c196b88dfe1ff7d35ffcc6f45736777185cd67c9a
+  languageName: node
+  linkType: hard
+
 "lilconfig@npm:~3.1.1":
   version: 3.1.2
   resolution: "lilconfig@npm:3.1.2"
@@ -18300,7 +18328,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -20104,7 +20132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:4.0.2":
+"picomatch@npm:4.0.2, picomatch@npm:^4.0.2":
   version: 4.0.2
   resolution: "picomatch@npm:4.0.2"
   checksum: a7a5188c954f82c6585720e9143297ccd0e35ad8072231608086ca950bee672d51b0ef676254af0788205e59bd4e4deb4e7708769226bed725bf13370a7d1464
@@ -22639,7 +22667,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0, supports-color@npm:^8.1.0, supports-color@npm:^8.1.1":
+"supports-color@npm:^8, supports-color@npm:^8.0.0, supports-color@npm:^8.1.0, supports-color@npm:^8.1.1":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -22892,6 +22920,16 @@ __metadata:
     es5-ext: ~0.10.46
     next-tick: 1
   checksum: ef3f27a0702a88d885bcbb0317c3e3ecd094ce644da52e7f7d362394a125d9e3578292a8f8966071a980d8abbc3395725333b1856f3ae93835b46589f700d938
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.14":
+  version: 0.2.14
+  resolution: "tinyglobby@npm:0.2.14"
+  dependencies:
+    fdir: ^6.4.4
+    picomatch: ^4.0.2
+  checksum: 261e986e3f2062dec3a582303bad2ce31b4634b9348648b46828c000d464b012cf474e38f503312367d4117c3f2f18611992738fca684040758bba44c24de522
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
Various updates to the CLI with usability improvements and better usage with LLMs

### Changes
* Update oclif to the latest version
* Update the descriptions of subcommands, including renaming hosted service to OnFinality managed services
* Update the `codegen:generate` command to use Etherscan API to attempt to fetch ABIs and the deployment height of contracts. This requires setting the `ETHERSCAN_API_KEY` env var
* Update the `codegen:generate` command to have an alias `import-abi` so that its visible from the top level `--help`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update https://github.com/subquery/documentation/pull/657

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/657
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
