### PR TITLE
Update to graphql v5 and fix resource loading issues

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Playgroung unable to load because of graphiql dependency (#2832)
 
 ## [2.22.1] - 2025-05-21
 ### Changed

--- a/packages/query/src/graphql/plugins/PlaygroundPlugin.ts
+++ b/packages/query/src/graphql/plugins/PlaygroundPlugin.ts
@@ -12,92 +12,108 @@ export function playgroundPlugin(options: {url: string; subscriptionUrl?: string
         async renderLandingPage() {
           // This content is sourced from https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html
           return {
-            html: `
-            <!--
- *  Copyright (c) 2021 GraphQL Contributors
- *  All rights reserved.
- *
- *  This source code is licensed under the license found in the
- *  LICENSE file in the root directory of this source tree.
--->
-<!doctype html>
-<html lang="en">
-  <head>
-    <title>SubQuery Playground</title>
-    <style>
-      body {
-        height: 100%;
-        margin: 0;
-        width: 100%;
-        overflow: hidden;
-      }
+            html: `<!--
+             *  Copyright (c) 2025 GraphQL Contributors
+             *  All rights reserved.
+             *
+             *  This source code is licensed under the license found in the
+             *  LICENSE file in the root directory of this source tree.
+            -->
+            <!doctype html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>GraphiQL 5 with React 19 and GraphiQL Explorer</title>
+                <style>
+                  body {
+                    margin: 0;
+                  }
 
-      #graphiql {
-        height: 100vh;
-      }
+                  #graphiql {
+                    height: 100dvh;
+                  }
 
-      :global(.graphiql-explorer-root > div:first-child) {
-        /* Remove the 2nd horizontal scroll bar */
-        overflow: hidden !important;
-      }
-    </style>
-    <!--
-      This GraphiQL example depends on Promise and fetch, which are available in
-      modern browsers, but can be "polyfilled" for older browsers.
-      GraphiQL itself depends on React DOM.
-      If you do not want to rely on a CDN, you can host these files locally or
-      include them directly in your favored resource bundler.
-    -->
-    <script
-      crossorigin
-      src="https://unpkg.com/react@18/umd/react.production.min.js"
-    ></script>
-    <script
-      crossorigin
-      src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
-    ></script>
-    <!--
-      These two files can be found in the npm module, however you may wish to
-      copy them directly into your environment, or perhaps include them in your
-      favored resource bundler.
-     -->
-    <script
-      src="https://unpkg.com/graphiql/graphiql.min.js"
-      type="application/javascript"
-    ></script>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
-    <!--
-      These are imports for the GraphIQL Explorer plugin.
-     -->
-    <script
-      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
-      crossorigin
-    ></script>
+                  .loading {
+                    height: 100%;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-size: 4rem;
+                  }
+                </style>
+                <link rel="stylesheet" href="https://esm.sh/graphiql/dist/style.css" />
+                <link
+                  rel="stylesheet"
+                  href="https://esm.sh/@graphiql/plugin-explorer/dist/style.css"
+                />
+                <!-- Note: the ?standalone flag bundles the module along with all of its 'dependencies', excluding peerDependencies', into a single JavaScript file. -->
+                <script type="importmap">
+                  {
+                    "imports": {
+                      "react": "https://esm.sh/react@19.1.0",
+                      "react/jsx-runtime": "https://esm.sh/react@19.1.0/jsx-runtime",
 
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
-    />
-  </head>
+                      "react-dom": "https://esm.sh/react-dom@19.1.0",
+                      "react-dom/client": "https://esm.sh/react-dom@19.1.0/client",
 
-  <body>
-    <div id="graphiql">Loading...</div>
-    <script>
-      const root = ReactDOM.createRoot(document.getElementById('graphiql'));
-      const fetcher = GraphiQL.createFetcher(${JSON.stringify(options)});
-      const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin({
-        showAttribution: true,
-      });
-      root.render(
-        React.createElement(GraphiQL, {
-          fetcher,
-          defaultEditorToolsVisibility: true,
-          plugins: [explorerPlugin],
-        }),
-      );
-    </script>
-  </body>
-</html>`,
+                      "graphiql": "https://esm.sh/graphiql?standalone&external=react,react-dom,@graphiql/react,graphql",
+                      "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer?standalone&external=react,@graphiql/react,graphql",
+                      "@graphiql/react": "https://esm.sh/@graphiql/react?standalone&external=react,react-dom,graphql",
+
+                      "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit?standalone&external=graphql",
+                      "graphql": "https://esm.sh/graphql@16.11.0"
+                    }
+                  }
+                </script>
+                <script type="module">
+                  // Import React and ReactDOM
+                  import React from 'react';
+                  import ReactDOM from 'react-dom/client';
+                  // Import GraphiQL and the Explorer plugin
+                  import { GraphiQL, HISTORY_PLUGIN } from 'graphiql';
+                  import { createGraphiQLFetcher } from '@graphiql/toolkit';
+                  import { explorerPlugin } from '@graphiql/plugin-explorer';
+
+                  import createJSONWorker from 'https://esm.sh/monaco-editor/esm/vs/language/json/json.worker.js?worker';
+                  import createGraphQLWorker from 'https://esm.sh/monaco-graphql/esm/graphql.worker.js?worker';
+                  import createEditorWorker from 'https://esm.sh/monaco-editor/esm/vs/editor/editor.worker.js?worker';
+
+                  globalThis.MonacoEnvironment = {
+                    getWorker(_workerId, label) {
+                      console.info('MonacoEnvironment.getWorker', { label });
+                      switch (label) {
+                        case 'json':
+                          return createJSONWorker();
+                        case 'graphql':
+                          return createGraphQLWorker();
+                      }
+                      return createEditorWorker();
+                    },
+                  };
+
+                  const fetcher = createGraphiQLFetcher(${JSON.stringify(options)});
+                  const plugins = [HISTORY_PLUGIN, explorerPlugin()];
+
+                  function App() {
+                    return React.createElement(GraphiQL, {
+                      fetcher,
+                      plugins,
+                      defaultEditorToolsVisibility: true,
+                    });
+                  }
+
+                  const container = document.getElementById('graphiql');
+                  const root = ReactDOM.createRoot(container);
+                  root.render(React.createElement(App));
+                </script>
+              </head>
+              <body>
+                <div id="graphiql">
+                  <div class="loading">Loading…</div>
+                </div>
+              </body>
+            </html>`,
           };
         },
       };


### PR DESCRIPTION
# Description
Update to the latest graphiql fixing issues with it loading

Fixes issues stemming from https://github.com/graphql/graphiql/issues/4034

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
