### PR TITLE
Fix esbuild not running typescript type checking

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Build command not checking ts types (#2842)
 
 ## [5.14.0] - 2025-07-01
 ### Removed

--- a/packages/types-core/CHANGELOG.md
+++ b/packages/types-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Missing deps for imported deps (#2842)
 
 ## [2.1.0] - 2025-07-01
 ### Removed

--- a/packages/types-core/package.json
+++ b/packages/types-core/package.json
@@ -25,7 +25,8 @@
     "CHANGELOG.md",
     "LICENSE"
   ],
-  "devDependencies": {
-    "package-json-type": "^1.0.3"
+  "dependencies": {
+    "package-json-type": "^1.0.3",
+    "pino": "^6.13.3"
   }
 }

--- a/packages/types-core/src/global.ts
+++ b/packages/types-core/src/global.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import Pino from 'pino';
+import type Pino from 'pino';
 import {Cache, DynamicDatasourceCreator} from './interfaces';
 import {Store} from './store';
 


### PR DESCRIPTION
# Description
When switching to Esbuild from webpack it didn't run any type checking, we now will manually run typescript type checks.

Also fixes missing dependencies from types-core

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
