### PR TITLE
Fix Typos in Comments

### DIFF
--- a/packages/node-core/src/indexer/benchmark.service.ts
+++ b/packages/node-core/src/indexer/benchmark.service.ts
@@ -41,7 +41,7 @@ abstract class BaseBenchmarkService {
       intervalName,
       setInterval(
         () => void this.benchMarking(),
-        SAMPLING_TIME_VARIANCE * 1000 // Convert to miliseconds
+        SAMPLING_TIME_VARIANCE * 1000 // Convert to milliseconds
       )
     );
   }

--- a/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
+++ b/packages/node-core/src/indexer/blockDispatcher/base-block-dispatcher.ts
@@ -57,7 +57,7 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS, B> implements IB
 
   protected isShutdown = false;
 
-  /* The height at which a block fetch failure first ocurrs, ensuring that we don't process any blocks after this */
+  /* The height at which a block fetch failure first occurs, ensuring that we don't process any blocks after this */
   protected fetchFailureHeight?: number;
 
   constructor(
@@ -307,7 +307,7 @@ export abstract class BaseBlockDispatcher<Q extends IQueue, DS, B> implements IB
      * */
     processQueue: AutoQueue<void>;
     /**
-     * A function to abort fetching any other blokcs. This is called when there is an error with the fetch task */
+     * A function to abort fetching any other blocks. This is called when there is an error with the fetch task */
     abortFetching: () => Promise<void> | void;
     getHeader: (input: T) => Header;
     height: number;


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `miliseconds` → `milliseconds`
  - `ocurrs` → `occurs`
  - `blokcs` → `blocks`

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.