### PR TITLE
Improve the sandbox require error

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix decoding sourcemaps with stack traces
 
+### Changed
+- Improve error stack with sandbox require limitations (#2864)
+
 ## [18.2.1] - 2025-07-17
 ### Changed
 - Workspace dependencies now match to patch versions rather than exact (#2855)

--- a/packages/node-core/src/indexer/sandbox.ts
+++ b/packages/node-core/src/indexer/sandbox.ts
@@ -86,10 +86,16 @@ export class Sandbox extends NodeVM {
     } catch (e) {
       const msgPart = 'Cannot find module ';
       if (e instanceof VMError && e.message.includes(msgPart)) {
-        throw new Error(
-          `Unable to resolve module ${e.message.replace(msgPart, '')}. To resolve this you can either:\n\tNarrow your import. e.g Instead of "import { BigNumber } from 'ethers'" you can use "import {BigNumber} from '@ethersproject/bignumber';"\n\tEnable the --unsafe flag.`,
+        const err = new Error(
+          `Unable to resolve module ${e.message.replace(
+            msgPart,
+            ''
+          )}. To resolve this you can either:\n\tNarrow your import. e.g Instead of "import { BigNumber } from 'ethers'" you can use "import {BigNumber} from '@ethersproject/bignumber';"\n\tEnable the --unsafe flag.`,
           {cause: e}
         );
+        // Copy the stack so that the logged error is more useful
+        err.stack = e.stack;
+        throw err;
       }
       throw e;
     }


### PR DESCRIPTION
# Description
If there is a require issue because of sandbox limitations, a new error would be thrown. Now we copy the stack from the initial error so we can more easily debug where the require is coming from

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
