### PR TITLE
Support injecting with esbuild for pollyfils

### DIFF
--- a/packages/cli/src/controller/build-controller.ts
+++ b/packages/cli/src/controller/build-controller.ts
@@ -141,6 +141,11 @@ export async function runBundle(
     },
   };
 
+  // Injecting polyfills if they exist, this allows setting global variables like TextDecoder/TextEncoder
+  const inject = [path.resolve(projectDir, './src/polyfill.ts'), path.resolve(projectDir, './src/polyfills.ts')].filter(
+    (file) => fs.existsSync(file)
+  );
+
   // Build each entry point separately
   const buildPromises = Object.entries(buildEntries).map(async ([name, entry]) => {
     try {
@@ -156,6 +161,7 @@ export async function runBundle(
         plugins: [yamlPlugin],
         tsconfig: path.join(projectDir, 'tsconfig.json'),
         target: 'node22',
+        inject: inject,
       });
     } catch (error) {
       throw new Error(`Error building ${name}: ${error}`);


### PR DESCRIPTION
# Description
When switching to esbuild it changes the order of imports, that means pollyfilling imports like TextEncoder/TextDecoder no longer work. To support this the build command will look for ./src/polyfill.ts or ./src/pollyfills.ts and include them appropriately in the build output

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
