### PR TITLE
Fix detecting if a project is multichain for the build command

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix build command for multi-chain projects (#2869)
 
 ## [6.1.0] - 2025-07-24
 ### Changed

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -34,7 +34,7 @@ export async function buildAdapter(
   await buildTsManifest(location, logger.info.bind(logger));
 
   // Check that this is a SubQuery project
-  const projectSearch = path.resolve(directory, './project*.{yaml,yml}');
+  const projectSearch = path.resolve(directory, './{project*.{yaml,yml},subquery-multichain.yaml}');
   const manifests = await glob(projectSearch);
   if (!manifests.length) {
     throw new Error(


### PR DESCRIPTION
# Description
Fixes detecting whether a directory is a SubQuery project for multi-chain projects


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
