### PR TITLE
Fix index check on the store, improve source of truth for current models

### DIFF
--- a/packages/common-substrate/CHANGELOG.md
+++ b/packages/common-substrate/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Lock down class-transformer and class-validator versions (#2871)
 
 ## [4.5.1] - 2025-07-17
 ### Changed

--- a/packages/common-substrate/package.json
+++ b/packages/common-substrate/package.json
@@ -18,8 +18,8 @@
     "@subql/types": "workspace:~"
   },
   "peerDependencies": {
-    "class-transformer": "*",
-    "class-validator": "*"
+    "class-transformer": "^0.5.1",
+    "class-validator": "0.14.1"
   },
   "files": [
     "/dist",

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.ts
@@ -172,14 +172,6 @@ export class SchemaMigrationService {
 
       const modelChanges = await migrationAction.run(transaction);
 
-      // Update any relevant application state so the right models are used
-      // NOTES for working on this in the future:
-      // - ModleProvider has the sequelize models, but they seem to get created again from name alone
-      // - Store service, needs the graphqlSchema to define store operations fro POI
-      // Possible suggested solution:
-      // - Update the model provider to take the same sequelize model instances rather than creating new ones
-      // - Update store operations to build from the sequelize models rather than the graphqlSchema
-      // - Use the model provider as a source of truth for models
       this.storeService.updateModels(modelChanges, getAllEntitiesRelations(nextSchema));
 
       await cacheProviderFlushData(this.storeService.modelProvider, true);

--- a/packages/node-core/src/db/migration-service/SchemaMigration.service.ts
+++ b/packages/node-core/src/db/migration-service/SchemaMigration.service.ts
@@ -173,8 +173,14 @@ export class SchemaMigrationService {
       const modelChanges = await migrationAction.run(transaction);
 
       // Update any relevant application state so the right models are used
-      this.storeService.modelProvider.updateModels(modelChanges);
-      await this.storeService.updateModels(this.dbSchema, getAllEntitiesRelations(nextSchema));
+      // NOTES for working on this in the future:
+      // - ModleProvider has the sequelize models, but they seem to get created again from name alone
+      // - Store service, needs the graphqlSchema to define store operations fro POI
+      // Possible suggested solution:
+      // - Update the model provider to take the same sequelize model instances rather than creating new ones
+      // - Update store operations to build from the sequelize models rather than the graphqlSchema
+      // - Use the model provider as a source of truth for models
+      this.storeService.updateModels(modelChanges, getAllEntitiesRelations(nextSchema));
 
       await cacheProviderFlushData(this.storeService.modelProvider, true);
     } catch (e: any) {

--- a/packages/node-core/src/db/migration-service/index.ts
+++ b/packages/node-core/src/db/migration-service/index.ts
@@ -3,3 +3,4 @@
 
 export * from './migration';
 export * from './SchemaMigration.service';
+export {ModifiedDbModels} from './migration-helpers';

--- a/packages/node-core/src/db/migration-service/migration-helpers.ts
+++ b/packages/node-core/src/db/migration-service/migration-helpers.ts
@@ -9,7 +9,13 @@ import {
   GraphQLModelsType,
   GraphQLRelationsType,
 } from '@subql/utils';
+import {ModelStatic} from '@subql/x-sequelize';
 import {isEqual} from 'lodash';
+
+export type ModifiedDbModels = {
+  modifiedModels: ModelStatic<any>[];
+  removedModels: string[];
+};
 
 export type ModifiedModels = Record<
   string,

--- a/packages/node-core/src/db/migration-service/migration.ts
+++ b/packages/node-core/src/db/migration-service/migration.ts
@@ -26,6 +26,7 @@ import {getLogger} from '../../logger';
 import {EnumType, getColumnOption, modelsTypeToModelAttributes, enumNameToHash} from '../../utils';
 import {formatAttributes, formatColumnName, modelToTableName} from '../sequelizeUtil';
 import * as syncHelper from '../sync-helper';
+import {ModifiedDbModels} from './migration-helpers';
 
 const logger = getLogger('db-manager');
 
@@ -86,7 +87,7 @@ export class Migration {
     return new Migration(sequelize, storeService, schemaName, config, existingForeignKeys, enumTypeMap, indexesResult);
   }
 
-  async run(transaction: Transaction): Promise<{modifiedModels: ModelStatic<any>[]; removedModels: string[]}> {
+  async run(transaction: Transaction): Promise<ModifiedDbModels> {
     if (this.historical) {
       // Comments should be added after
       this.addRelationComments();

--- a/packages/node-core/src/indexer/store.service.spec.ts
+++ b/packages/node-core/src/indexer/store.service.spec.ts
@@ -51,21 +51,40 @@ describe('Store Service', () => {
   });
 
   it('isIndexed support snake case', () => {
-    storeService = new StoreService(null as any, null as any, null as any, null as any);
-    (storeService as any)._modelIndexedFields = [
+    storeService = new StoreService(
+      null as any,
+      null as any,
       {
-        entityName: 'Transfer',
-        fieldName: 'account_from_id',
-        isUnique: false,
-        type: 'btree',
-      },
-      {
-        entityName: 'Transfer',
-        fieldName: 'account_to_id',
-        isUnique: false,
-        type: 'btree',
-      },
-    ];
+        getModel: (entityName: string) => {
+          if (entityName !== 'Transfer') {
+            return {
+              model: {
+                options: {},
+              },
+            };
+          }
+          return {
+            model: {
+              options: {
+                indexes: [
+                  {
+                    fields: ['account_from_id'],
+                    unique: false,
+                    type: 'btree',
+                  },
+                  {
+                    fields: ['account_to_id'],
+                    unique: false,
+                    type: 'btree',
+                  },
+                ],
+              },
+            },
+          };
+        },
+      } as any,
+      null as any
+    );
 
     expect(storeService.isIndexed('Transfer', 'account_fromId')).toEqual(true);
     expect(storeService.isIndexed('Transfer', 'accountToId')).toEqual(true);
@@ -79,28 +98,46 @@ describe('Store Service', () => {
   });
 
   it('isIndexedHistorical support snake case', () => {
-    storeService = new StoreService(null as any, null as any, null as any, null as any);
+    storeService = new StoreService(
+      null as any,
+      null as any,
+      {
+        getModel: (entityName: string) => {
+          if (entityName !== 'Transfer') {
+            return {
+              model: {
+                options: {},
+              },
+            };
+          }
+          return {
+            model: {
+              options: {
+                indexes: [
+                  {
+                    fields: ['account_from_id'],
+                    unique: true,
+                    type: 'btree',
+                  },
+                  {
+                    fields: ['account_to_id'],
+                    unique: true,
+                    type: 'btree',
+                  },
+                  {
+                    fields: ['not_index_id'],
+                    unique: false,
+                    type: 'btree',
+                  },
+                ],
+              },
+            },
+          };
+        },
+      } as any,
+      null as any
+    );
     (storeService as any)._historical = false;
-    (storeService as any)._modelIndexedFields = [
-      {
-        entityName: 'Transfer',
-        fieldName: 'account_from_id',
-        isUnique: true,
-        type: 'btree',
-      },
-      {
-        entityName: 'Transfer',
-        fieldName: 'account_to_id',
-        isUnique: true,
-        type: 'btree',
-      },
-      {
-        entityName: 'Transfer',
-        fieldName: 'not_index_id',
-        isUnique: false,
-        type: 'btree',
-      },
-    ];
 
     expect(storeService.isIndexedHistorical('Transfer', 'account_fromId')).toEqual(true);
     expect(storeService.isIndexedHistorical('Transfer', 'accountToId')).toEqual(true);

--- a/packages/node-core/src/indexer/storeModelProvider/model/model.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/model/model.ts
@@ -11,6 +11,7 @@ import {getFullOptions, operatorsMap} from './utils';
 export type BaseEntity = {id: string; __block_range?: (number | null)[] | Fn};
 
 export interface IModel<T extends BaseEntity> {
+  model: Readonly<ModelStatic<Model<T, T>>>;
   get(id: string, tx?: Transaction): Promise<T | undefined>;
 
   getByFields(filters: FieldsExpression<T>[], options: GetOptions<T>, tx?: Transaction): Promise<T[]>;

--- a/packages/node-core/src/indexer/storeModelProvider/types.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/types.ts
@@ -3,6 +3,7 @@
 
 import {ModelStatic, Transaction} from '@subql/x-sequelize';
 import {LRUCache} from 'lru-cache';
+import {ModifiedDbModels} from '../../db/migration-service';
 import {MetadataRepo, PoiRepo} from '../entities';
 import {HistoricalMode} from '../types';
 import {IMetadata} from './metadata';
@@ -22,7 +23,7 @@ export interface IStoreModelProvider {
 
   applyPendingChanges(height: number, dataSourcesCompleted: boolean, tx?: Transaction): Promise<void>;
 
-  updateModels({modifiedModels, removedModels}: {modifiedModels: ModelStatic<any>[]; removedModels: string[]}): void;
+  updateModels(changes: ModifiedDbModels): void;
 }
 
 export interface ICachedModelControl {


### PR DESCRIPTION
# Description
Fixes indexes not being correctly stored in the store service on initial setup.
It improves upon this by no longer making a DB querie and instead uses the models from the model provider.

Works towards https://github.com/subquery/subql/issues/2269

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
