### PR TITLE
Update cli build.ts glob call to make it win compatible

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -35,7 +35,7 @@ export async function buildAdapter(
 
   // Check that this is a SubQuery project
   const projectSearch = path.resolve(directory, './{project*.{yaml,yml},subquery-multichain.yaml}');
-  const manifests = await glob(projectSearch);
+  const manifests = await glob(projectSearch, {windowsPathsNoEscape: true});
   if (!manifests.length) {
     throw new Error(
       'This is not a SubQuery project, please make sure you run this in the root of your project directory.'


### PR DESCRIPTION
# Description
When running a SubQuery project build on Windows using the subql build command, the glob pattern used to detect project manifest files fails due to how glob interprets backslashes (\).
Set the flag windowsPathsNoEscape to true for preventing path resolution issues on windows

Fixes #2873

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
