### PR TITLE
docs(chore): Fix spelling and wording in comments, logs, and messages

### DIFF
--- a/packages/cli/src/controller/build-controller.ts
+++ b/packages/cli/src/controller/build-controller.ts
@@ -18,7 +18,7 @@ import {Logger} from '../adapters/utils';
  * These are the reasons for using webpack:
  * * Good tree shaking including of dependencies. e.g imports to 'ethers' will result in tree shaking of unused code like Providers, this is to avoid importing 'unsafe' node imports like 'http'.
  * * Correctly hoists polyfills. So if something like `global.TextDecoder = SomeOtherTextDecoder` will be set before any other code is run. esbuild does not do this.
- * * There is some issues with pnpm resolving the @subql/types-* and @subql/types-core global entities correctly. This was the reason for swithcing to esbuild
+ * * There is some issues with pnpm resolving the @subql/types-* and @subql/types-core global entities correctly. This was the reason for switching to esbuild
  */
 
 const getBaseConfig = (

--- a/packages/common/src/project/readers/reader.ts
+++ b/packages/common/src/project/readers/reader.ts
@@ -28,7 +28,7 @@ export class ReaderFactory {
     if (fs.existsSync(location)) {
       const project = getProjectRootAndManifest(location);
       if (project.manifests.length > 1) {
-        throw new Error(`Mulitple manifests found, expected only one`);
+        throw new Error(`Multiple manifests found, expected only one`);
       }
       return new LocalReader(project.root, path.join(project.root, project.manifests[0]));
     }

--- a/packages/node-core/src/blockchain.service.ts
+++ b/packages/node-core/src/blockchain.service.ts
@@ -44,7 +44,7 @@ export interface IBlockchainService<
 
   // Fetch service
   /**
-   * The finalized header. If the chain doesn't have concrete finalization this could be a probablilistic finalization
+   * The finalized header. If the chain doesn't have concrete finalization this could be a probabilistic finalization
    * */
   getFinalizedHeader(): Promise<Header>;
   /**

--- a/packages/node-core/src/configure/configure.module.ts
+++ b/packages/node-core/src/configure/configure.module.ts
@@ -137,7 +137,7 @@ export async function registerApp<P extends ISubqueryProject>(
   ) => Promise<P>,
   showHelp: () => void,
   pjson: any,
-  nameMapping?: Record<string, string> // Curently only used by cosmos
+  nameMapping?: Record<string, string> // Currently only used by cosmos
 ): Promise<{nodeConfig: NodeConfig; project: P & IProjectUpgradeService<P>}> {
   let config: NodeConfig;
   let rawManifest: unknown;

--- a/packages/node-core/src/db/sync-helper.ts
+++ b/packages/node-core/src/db/sync-helper.ts
@@ -404,7 +404,7 @@ export const sqlIterator = (tableName: string, sql: string, batch: number = DEFA
   `;
 };
 
-// Only used with historical to add indexes to ID fields for gettign entitities by ID
+// Only used with historical to add indexes to ID fields for getting entities by ID
 export function addHistoricalIdIndex(model: GraphQLModelsType, indexes: IndexesOptions[]): void {
   const idFieldName = model.fields.find((field) => field.type === 'ID')?.name;
   if (idFieldName && !indexes.find((idx) => idx.fields?.includes(idFieldName))) {

--- a/packages/node-core/src/indexer/fetch.service.ts
+++ b/packages/node-core/src/indexer/fetch.service.ts
@@ -288,7 +288,7 @@ export class FetchService<DS extends BaseDataSource, B extends IBlockDispatcher<
   }
 
   private useModuloHandlersOnly(relevantDS: DS[]): boolean {
-    // If there are modulos hanlders only, then number of moduloNumbers should be match number of with handlers
+    // If there are modulos handlers only, then number of moduloNumbers should be match number of with handlers
     const moduloNumbers = this.getModulos(relevantDS);
     const handlers = [...relevantDS.map((ds) => ds.mapping.handlers)].flat();
     return !!handlers.length && moduloNumbers.length === handlers.length;

--- a/packages/node-core/src/indexer/poi/poi.service.ts
+++ b/packages/node-core/src/indexer/poi/poi.service.ts
@@ -156,7 +156,7 @@ export class PoiService implements OnApplicationShutdown {
         await tx.commit();
         logger.info('Migrating POI completed.');
         if (checkResult?.mmr_exists) {
-          logger.info(`If file based mmr were used previously, it can be clean up mannually`);
+          logger.info(`If file based mmr were used previously, it can be clean up manually`);
         }
       }
     } catch (e) {

--- a/packages/node-core/src/indexer/project.service.ts
+++ b/packages/node-core/src/indexer/project.service.ts
@@ -157,7 +157,7 @@ export class ProjectService<
       // Flush any pending operations to set up DB
       await cacheProviderFlushData(this.storeService.modelProvider, true);
     } else {
-      assert(startHeight, 'ProjectService must be initalized with a start height in workers');
+      assert(startHeight, 'ProjectService must be initialized with a start height in workers');
       this.projectUpgradeService.initWorker(startHeight, this.handleProjectChange.bind(this));
 
       // Called to allow handling the first project

--- a/packages/node-core/src/indexer/store/store.ts
+++ b/packages/node-core/src/indexer/store/store.ts
@@ -22,7 +22,7 @@ type Context = {
 };
 
 export class Store implements IStore {
-  /* These need to explicily be private using JS style private properties in order to not leak these in the sandbox */
+  /* These need to explicitly be private using JS style private properties in order to not leak these in the sandbox */
   #config: NodeConfig;
   #modelProvider: IStoreModelProvider;
   #context: Context;

--- a/packages/node-core/src/indexer/storeModelProvider/model/model.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/model/model.ts
@@ -107,7 +107,7 @@ export class PlainModel<T extends BaseEntity = BaseEntity> implements IModel<T> 
 
       await Promise.all(this.exporters.map((exporter) => exporter.export(exportData)));
 
-      // Without a transaciton, commit that data instantly
+      // Without a transaction, commit that data instantly
       if (!tx) {
         await Promise.all(this.exporters.map((exporter) => exporter.commit()));
       }

--- a/packages/node-core/src/indexer/worker/worker.store.service.ts
+++ b/packages/node-core/src/indexer/worker/worker.store.service.ts
@@ -39,7 +39,7 @@ export const hostStoreKeys: (keyof HostStore)[] = [
 ];
 
 // Entities have to be converted to plain objects so they can be serialized.
-// We don't need the funcitons to be included
+// We don't need the functions to be included
 export const hostStoreToStore = (host: HostStore): Store => {
   return {
     get: unwrapProxyArgs(host.storeGet),

--- a/packages/node-core/src/process.ts
+++ b/packages/node-core/src/process.ts
@@ -17,7 +17,7 @@ export function exitWithError(error: Error | string, logger?: Pino.Logger, code 
   process.exit(code);
 }
 
-// Function argument is to allow for lazy evauluation only if monitor service is enabled
+// Function argument is to allow for lazy evaluation only if monitor service is enabled
 export function monitorWrite(blockData: string | (() => string)): void {
   monitorService?.write(blockData);
 }

--- a/packages/node-core/src/yargs.ts
+++ b/packages/node-core/src/yargs.ts
@@ -280,7 +280,7 @@ export function yargsBuilder<
             })
             .hide('root'), // root is hidden because its for internal use
         handler: () => {
-          // boostrap trigger in main.ts
+          // bootstrap trigger in main.ts
         },
       })
       // Default options, shared with all command


### PR DESCRIPTION


- Corrects multiple typos and grammar across the repo (e.g., “probabilistic”, “initialized”, “explicitly”, “handlers”, “functions”, “transaction”, “evaluation”, “manually”, “getting”).
- Clarifies wording in comments and error/info messages.


