### PR TITLE
fix: subscription w/ historical data enabled

### DIFF
--- a/packages/query/src/graphql/plugins/PgSubscriptionPlugin.ts
+++ b/packages/query/src/graphql/plugins/PgSubscriptionPlugin.ts
@@ -74,8 +74,10 @@ export const PgSubscriptionPlugin = makeExtendSchemaPlugin((build) => {
               queryBuilder.context.args ??= {};
               if (_block_height) {
                 queryBuilder.context.args.blockHeight = sql.fragment`${sql.value(_block_height.toString())}::bigint`;
+                queryBuilder.where(sql.fragment`${tableAlias}._id = ${sql.value(_entity._id)}`);
+              } else {
+                queryBuilder.where(sql.fragment`${tableAlias}.id = ${sql.value(_entity.id)}`);
               }
-              queryBuilder.where(sql.fragment`${tableAlias}.id = ${sql.value(_entity.id)}`);
               queryBuilder.limit(1);
             }
           );


### PR DESCRIPTION
# Description
A recent change in #2889 introduced a bug where the subscriptions always return the oldest data when historical data are enabled. This fixes the issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
