### PR TITLE
Fix dictionary v2 being used with empty queries

### DIFF
--- a/packages/node-core/CHANGELOG.md
+++ b/packages/node-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Dictionary v2 being used with empty filter conditions (#2909)
 
 ## [18.3.2] - 2025-08-29
 ### Changed

--- a/packages/node-core/src/indexer/dictionary/coreDictionary.ts
+++ b/packages/node-core/src/indexer/dictionary/coreDictionary.ts
@@ -10,7 +10,7 @@ import {FieldSelector} from './v2';
 export abstract class CoreDictionary<DS, FB, M /* Metadata */, E /* DictionaryQueryEntry */>
   implements IDictionary<DS, FB>
 {
-  protected queriesMap?: BlockHeightMap<E>;
+  protected queriesMap?: BlockHeightMap<E | undefined>;
   protected _startHeight = 1;
   protected _metadata?: M;
   metadataValid: boolean | undefined;
@@ -28,7 +28,7 @@ export abstract class CoreDictionary<DS, FB, M /* Metadata */, E /* DictionaryQu
   ): Promise<DictionaryResponse<IBlock | number> | undefined>;
   protected abstract init(): Promise<void>;
   protected abstract dictionaryValidation(metaData?: M, startBlockHeight?: number): boolean;
-  protected abstract buildDictionaryQueryEntries(dataSources: DS[]): E;
+  protected abstract buildDictionaryQueryEntries(dataSources: DS[]): E | undefined;
   abstract queryMapValidByHeight(height: number): boolean;
   abstract getQueryEndBlock(targetBlockHeight: number, apiFinalizedHeight: number): number;
 

--- a/packages/node-core/src/indexer/dictionary/dictionary.fixtures.ts
+++ b/packages/node-core/src/indexer/dictionary/dictionary.fixtures.ts
@@ -8,7 +8,7 @@ import {BlockHeightMap} from '../../utils';
 import {IBlock} from '../types';
 import {DictionaryResponse} from './types';
 import {DictionaryV1} from './v1';
-import {DictionaryV2, DictionaryV2QueryEntry, RawDictionaryResponseData} from './v2';
+import {DictionaryV2, DictionaryV2Metadata, DictionaryV2QueryEntry, RawDictionaryResponseData} from './v2';
 
 // export use in dictionary service test
 export class TestDictionaryV1 extends DictionaryV1<any> {
@@ -132,8 +132,17 @@ export interface TestFB {
 }
 
 export class TestDictionaryV2 extends DictionaryV2<TestFB, any, any> {
+  get testMetadata(): DictionaryV2Metadata | undefined {
+    return this._metadata;
+  }
+
+  setMockedApi(mocked: {post: () => Promise<any> | any}): void {
+    this.dictionaryApi = mocked as any;
+  }
+
   buildDictionaryQueryEntries(dataSources: any[]): DictionaryV2QueryEntry {
-    return {};
+    // Random non-empty object to satisfy running a query
+    return {property: ['value']};
   }
 
   convertResponseBlocks<RFB>(result: RawDictionaryResponseData<RFB>): DictionaryResponse<IBlock<TestFB>> | undefined {

--- a/packages/node-core/src/indexer/dictionary/dictionary.fixtures.ts
+++ b/packages/node-core/src/indexer/dictionary/dictionary.fixtures.ts
@@ -141,7 +141,7 @@ export class TestDictionaryV2 extends DictionaryV2<TestFB, any, any> {
   }
 
   buildDictionaryQueryEntries(dataSources: any[]): DictionaryV2QueryEntry {
-    // Random non-empty object to satisfy running a query
+    // Test fixture object with non-empty conditions to satisfy running a query
     return {property: ['value']};
   }
 

--- a/packages/node-core/src/indexer/dictionary/v1/dictionaryV1.ts
+++ b/packages/node-core/src/indexer/dictionary/v1/dictionaryV1.ts
@@ -48,8 +48,6 @@ export abstract class DictionaryV1<DS> extends CoreDictionary<
     });
   }
 
-  abstract buildDictionaryQueryEntries(dataSources: DS[]): DictionaryV1QueryEntry[];
-
   protected async init(): Promise<void> {
     const {query} = this.metadataQuery();
     try {

--- a/packages/node-core/src/indexer/dictionary/v2/dictionaryV2.ts
+++ b/packages/node-core/src/indexer/dictionary/v2/dictionaryV2.ts
@@ -117,7 +117,7 @@ export abstract class DictionaryV2<
     fieldSelector: FieldSelector
   ): Promise<DictionaryResponse<IBlock<FB> | number> | undefined> {
     const {conditions, queryEndBlock} = this.getQueryConditions(startBlock, endBlock);
-    if (!conditions) {
+    if (!conditions || Object.keys(conditions).length === 0) {
       return undefined;
     }
     const requestData = {

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Dictionary v2 being used with empty filter conditions (#2909)
 
 ## [6.3.3] - 2025-07-30
 ### Fixed

--- a/packages/node/src/indexer/dictionary/v1/substrateDictionaryV1.ts
+++ b/packages/node/src/indexer/dictionary/v1/substrateDictionaryV1.ts
@@ -179,9 +179,7 @@ export function buildDictionaryV1QueryEntries(
   return uniqBy(
     queryEntries,
     (item) =>
-      `${item.entity}|${JSON.stringify(
-        sortBy(item.conditions, (c) => c.field),
-      )}`,
+      `${item.entity}|${JSON.stringify(sortBy(item.conditions, (c) => c.field))}`,
   );
 }
 


### PR DESCRIPTION
# Description
Fixes a case where a v2 dictionary would be used if the filter is empty. Also adds clarification to the types allowing for undefined to be returned for the query conditions.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
