### PR TITLE
Add a build manifest cmd

### DIFF
--- a/packages/cli/src/commands/build-manifest.ts
+++ b/packages/cli/src/commands/build-manifest.ts
@@ -1,0 +1,73 @@
+// Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import assert from 'node:assert';
+import {existsSync} from 'node:fs';
+import path from 'node:path';
+import {McpServer, RegisteredTool} from '@modelcontextprotocol/sdk/server/mcp';
+import {Command} from '@oclif/core';
+import {z} from 'zod';
+import {Logger, zodToFlags, mcpLogger, commandLogger, getMCPWorkingDirectory, zodToArgs} from '../adapters/utils';
+import {resolveToAbsolutePath, buildTsManifest} from '../utils';
+
+export const buildManifestInputs = z.object({
+  location: z
+    .string({description: 'The path to the project, this can be a directory or a project manifest file.'})
+    .optional(),
+});
+type BuildManifestInputs = z.infer<typeof buildManifestInputs>;
+
+const buildManifestOutputs = z.void();
+
+export async function buildManifestAdapter(
+  workingDir: string,
+  args: BuildManifestInputs,
+  logger: Logger
+): Promise<z.infer<typeof buildManifestOutputs>> {
+  const location = resolveToAbsolutePath(path.resolve(workingDir, args.location ?? ''));
+  assert(existsSync(location), 'Argument `location` is not a valid directory or file');
+
+  await buildTsManifest(location, logger.info.bind(logger));
+
+  logger.info('TypeScript manifest compiled successfully to project.yaml');
+}
+
+export default class BuildManifest extends Command {
+  static description = 'Build TypeScript manifest file to YAML (generates project.yaml from project.ts)';
+  static flags = zodToFlags(buildManifestInputs.omit({location: true}));
+  static args = zodToArgs(buildManifestInputs.pick({location: true}));
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(BuildManifest);
+    try {
+      await buildManifestAdapter(process.cwd(), {...args, ...flags}, commandLogger(this));
+      this.log('TypeScript manifest built successfully!');
+    } catch (e: any) {
+      this.error(e);
+    }
+  }
+}
+
+export function registerBuildManifestMCPTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
+    BuildManifest.name,
+    {
+      description: BuildManifest.description,
+      inputSchema: buildManifestInputs.shape,
+      // outputSchema: buildManifestOutputs.shape,
+    },
+    async (args) => {
+      const cwd = await getMCPWorkingDirectory(server);
+      await buildManifestAdapter(cwd, args, mcpLogger(server.server));
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `${BuildManifest.name} completed successfully.`,
+          },
+        ],
+      };
+    }
+  );
+}


### PR DESCRIPTION
# Description

Currently, I must execute the full `build` command at runtime because my environment variables (such as start block or RPC endpoints in my project.ts) are only determined at run time. However, the full build process is resource-intensive and time-consuming, requiring significantly more CPU and RAM than just running the SubQuery indexer.

This new `build-manifest` command would enable a more efficient runtime workflow: instead of rebuilding the entire project at runtime, we can now just generate the project.html, dramatically reducing resource consumption and startup time while preserving the ability to inject runtime environment variables.

Usage:
`subql build-manifest ./path/to/project.ts`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
