### PR TITLE
Update publishing workflows to work with npm trusted publishing

### DIFF
--- a/.github/actions/create-prerelease/action.yml
+++ b/.github/actions/create-prerelease/action.yml
@@ -7,10 +7,7 @@ inputs:
   package-path:
     description: 'package path to run action e.g. package/common'
     required: true
-  npm-token:
-    description: 'token to push to npm registry'
-    required: true
-  
+
 runs:
   using: "composite"
   steps:
@@ -19,7 +16,5 @@ runs:
       shell: bash
 
     - working-directory: ${{ inputs.package-path }}
-      run: echo "Changes exist in ${{ inputs.package-path }}" && yarn version prerelease && yarn npm publish --access public --tag dev      
-      env:
-        NPM_TOKEN: ${{ inputs.npm-token }}
+      run: echo "Changes exist in ${{ inputs.package-path }}" && yarn version prerelease && yarn npm publish --access public --tag dev
       shell: bash

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -9,17 +9,12 @@ inputs:
   repo-token:
     description: 'token to create github release'
     required: true
-  npm-token:
-    description: 'token to push to npm registry'
-    required: true
 
 runs:
   using: "composite"
   steps:
     - working-directory: ${{ inputs.package-path }}
       run: echo "Changes exist in ${{ inputs.package-path }}" && yarn npm publish --access public
-      env:
-        NPM_TOKEN: ${{ inputs.npm-token }}
       shell: bash
 
     - working-directory: ${{ github.workspace }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -6,6 +6,10 @@ on:
     paths-ignore:
       - ".github/workflows/**"
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 concurrency:
   group: publish
   cancel-in-progress: false
@@ -87,70 +91,60 @@ jobs:
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/utils
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump types-core & deploy
         if: steps.changed-types-core.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/types-core
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump types & deploy
         if: steps.changed-types.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/types
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump common & deploy
         if: steps.changed-common.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/common
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump common substrate & deploy
         if: steps.changed-common-substrate.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/common-substrate
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump testing & deploy
         if: steps.changed-testing.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/testing
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump node-core & deploy
         if: steps.changed-node-core.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/node-core
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump node & deploy
         if: steps.changed-node.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/node
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump query & deploy
         if: steps.changed-query.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/query
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump cli & deploy
         if: steps.changed-cli.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/cli
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
       - ".github/workflows/**"
   workflow_dispatch:
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 concurrency:
   # Same group as prerelease
   group: publish
@@ -119,7 +123,6 @@ jobs:
         with:
           package-path: packages/utils
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Types-core
         if: steps.changed-types-core.outputs.changed == 'true'
@@ -127,7 +130,6 @@ jobs:
         with:
           package-path: packages/types-core
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Types
         if: steps.changed-types.outputs.changed == 'true'
@@ -135,7 +137,6 @@ jobs:
         with:
           package-path: packages/types
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Common
         if: steps.changed-common.outputs.changed == 'true'
@@ -143,7 +144,6 @@ jobs:
         with:
           package-path: packages/common
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Common Substrate
         if: steps.changed-common-substrate.outputs.changed == 'true'
@@ -151,7 +151,6 @@ jobs:
         with:
           package-path: packages/common-substrate
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Testing
         if: steps.changed-testing.outputs.changed == 'true'
@@ -159,7 +158,6 @@ jobs:
         with:
           package-path: packages/testing
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Node Core
         if: steps.changed-node-core.outputs.changed == 'true'
@@ -167,7 +165,6 @@ jobs:
         with:
           package-path: packages/node-core
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Node
         if: steps.changed-node.outputs.changed == 'true'
@@ -175,7 +172,6 @@ jobs:
         with:
           package-path: packages/node
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Query
         if: steps.changed-query.outputs.changed == 'true'
@@ -183,7 +179,6 @@ jobs:
         with:
           package-path: packages/query
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Cli
         if: steps.changed-cli.outputs.changed == 'true'
@@ -191,4 +186,3 @@ jobs:
         with:
           package-path: packages/cli
           repo-token: ${{ secrets.REPO_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Description
Removes NPM tokens from CI workflows and sets up OIDC publishing for npm

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
