### PR TITLE
chore: remove unused import in remove-deployment-boost command

### DIFF
--- a/packages/cli/src/commands/network/remove-deployment-boost.ts
+++ b/packages/cli/src/commands/network/remove-deployment-boost.ts
@@ -4,7 +4,6 @@
 import {parseEther} from '@ethersproject/units';
 import {McpServer, RegisteredTool} from '@modelcontextprotocol/sdk/server/mcp';
 import {Command} from '@oclif/core';
-import {DeploymentBoosterAddedEvent} from '@subql/contract-sdk/typechain/contracts/RewardsBooster';
 import {z} from 'zod';
 import {
   commandLogger,


### PR DESCRIPTION
Removes an unused import left in the CLI network command.
No behavior changes — just small cleanup to keep the codebase tidy and avoid lint noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup and maintenance improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->