### PR TITLE
fix: add recovery for invalid POI sync state on startup

### DIFF
--- a/packages/node-core/src/indexer/poi/poiSync.service.ts
+++ b/packages/node-core/src/indexer/poi/poiSync.service.ts
@@ -14,7 +14,7 @@ import {exitWithError} from '../../process';
 import {hasValue, Queue} from '../../utils';
 import {Metadata, MetadataFactory, MetadataRepo} from '../entities';
 import {PoiFactory, ProofOfIndex, SyncedProofOfIndex} from '../entities/Poi.entity';
-import {PlainPoiModel} from '../storeModelProvider/poi';
+import {ensureProofOfIndexId, PlainPoiModel} from '../storeModelProvider/poi';
 import {ISubqueryProject} from '../types';
 import {PoiBlock} from './PoiBlock';
 
@@ -228,7 +228,7 @@ export class PoiSyncService implements OnApplicationShutdown {
     });
 
     if (result) {
-      return result.toJSON<ProofOfIndex>();
+      return ensureProofOfIndexId(result.toJSON<ProofOfIndex>());
     }
 
     return undefined;


### PR DESCRIPTION
When latestSyncedPoiHeight in metadata points to an invalid POI (created state without hash/parentHash), the node would fail to start. Now it searches backward to find the last valid synced POI and updates the metadata accordingly.

# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data synchronization reliability with enhanced error handling for invalid or missing records; the system now searches backward to recover the last valid state instead of failing immediately, reducing sync interruptions and preserving metadata when possible.

* **Refactor**
  * Exported and adjusted internal ID handling and bulk-update logic to avoid overwriting incomplete proof entries, ensuring only fully-synced values replace existing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->