### PR TITLE
Improve logging of `rewindHeight` when handling un-finalized blocks 

### DIFF
--- a/packages/node-core/src/indexer/unfinalizedBlocks.service.ts
+++ b/packages/node-core/src/indexer/unfinalizedBlocks.service.ts
@@ -15,6 +15,7 @@ import {mainThreadOnly} from '../utils';
 import {ProofOfIndex} from './entities';
 import {PoiBlock} from './poi';
 import {IStoreModelProvider} from './storeModelProvider';
+import util from 'node:util';
 
 const logger = getLogger('UnfinalizedBlocks');
 
@@ -82,8 +83,10 @@ export class UnfinalizedBlocksService<B = any> implements IUnfinalizedBlocksServ
       const rewindHeight = await this.processUnfinalizedBlockHeader();
       if (rewindHeight !== undefined) {
         logger.info(
-          { rewindHeight },
-          'Found un-finalized blocks from previous indexing but unverified, rolling back to last finalized block'
+          `Found un-finalized blocks from previous indexing but unverified, rolling back to last finalized block rewindHeight=${util.inspect(
+            rewindHeight,
+            {depth: 6, colors: false}
+          )}`
         );
         await reindex(rewindHeight);
         logger.info(`Successful rewind to block ${rewindHeight.blockHeight}!`);


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging clarity for internal debugging purposes with enhanced object formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->