### PR TITLE
fix(node-core): sql injection in dynamic datasource appending via unescaped json serialization

### DIFF
--- a/packages/node-core/src/indexer/storeModelProvider/metadata/utils.ts
+++ b/packages/node-core/src/indexer/storeModelProvider/metadata/utils.ts
@@ -25,9 +25,7 @@ export function APPEND_DS_QUERY(schemaTable: SchemaTable, items: DatasourceParam
   const VALUE = '"value"';
 
   const makeSet = (item: DatasourceParams, value: string, index = 1): string =>
-    `jsonb_set(${value}, array[(jsonb_array_length(${VALUE}) + ${index})::text], '${JSON.stringify(
-      item
-    )}'::jsonb, true)`;
+    `jsonb_set(${value}, array[(jsonb_array_length(${VALUE}) + ${index})::text], '${JSON.stringify(item).replace(/'/g, "''")}'::jsonb, true)`;
 
   return `
       UPDATE ${schemaTable}


### PR DESCRIPTION
## 🔒 Security Fix

### Problem
The `APPEND_DS_QUERY` function constructs a raw SQL query by directly interpolating `JSON.stringify(item)` into a single-quoted SQL string literal (`'${JSON.stringify(item)}'::jsonb`). Because `JSON.stringify` does not escape single quotes, any single quote within the `item` payload (which represents dynamic datasource parameters, often derived from untrusted on-chain events) will break out of the SQL string literal. This allows an attacker to inject arbitrary SQL commands into the indexer's database by emitting crafted events on-chain.

**Severity**: `high`
**File**: `packages/node-core/src/indexer/storeModelProvider/metadata/utils.ts`

### Solution
Escape single quotes in the serialized JSON string by replacing them with double single quotes (`''`) before interpolation:

### Changes
- `packages/node-core/src/indexer/storeModelProvider/metadata/utils.ts` (modified)

# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #3030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data serialization to properly escape single quotes when storing data, preventing query-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->